### PR TITLE
Add function getHdriEnabled

### DIFF
--- a/wand/magick-property.c
+++ b/wand/magick-property.c
@@ -489,7 +489,36 @@ WandExport GravityType MagickGetGravity(MagickWand *wand)
   type=(GravityType) ParseCommandOption(MagickGravityOptions,MagickFalse,option);
   return(type);
 }
-
+
+/*
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+%                                                                             %
+%                                                                             %
+%   M a g i c k G e t H d r i E n a b le d                                    %
+%                                                                             %
+%                                                                             %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  MagickGetHdriEnabled() returns true if ImageMagick was compiled with HDRI 
+%  enabled.
+%
+%  The format of the MagickGetHdriEnabled method is:
+%
+%      MagickBooleanType MagickGetHdriEnabled(void)
+%
+%
+*/
+WandExport MagickBooleanType MagickGetHdriEnabled(void)
+{
+#ifdef MAGICKCORE_HDRI_SUPPORT
+  return MagickTrue;
+#else 
+  return MagickFalse;
+#endif
+}
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %

--- a/wand/magick-property.h
+++ b/wand/magick-property.h
@@ -81,6 +81,7 @@ extern WandExport MagickBooleanType
   MagickDeleteImageProperty(MagickWand *,const char *),
   MagickDeleteOption(MagickWand *,const char *),
   MagickGetAntialias(const MagickWand *),
+  MagickGetHdriEnabled(void),
   MagickGetPage(const MagickWand *,size_t *,size_t *,ssize_t *,ssize_t *),
   MagickGetResolution(const MagickWand *,double *,double *),
   MagickGetSize(const MagickWand *,size_t *,size_t *),


### PR DESCRIPTION
Add function to allow determining if ImageMagick was compiled with HDRI enabled at run time.

This may seem slightly ridiculous as it is obviously available at compile time - the problem it solves is that people seem to install Imagick with an version of ImageMagick from different places, and it's not guaranteed that Imagick was compiled against IM with the same HDRI setting. Adding the function to get the HDRI setting allows it to be checked at run-time.