### PR TITLE
First pass at fully escaping all string output in json.c

### DIFF
--- a/coders/json.c
+++ b/coders/json.c
@@ -731,7 +731,8 @@ static MagickBooleanType EncodeImageAttributes(Image *image,FILE *file)
 
         GetPathComponent(image->magick_filename,TailPath,filename);
         escaped_json=EscapeJsonString(filename);
-        (void) FormatLocaleFile(file,"    \"baseName\": \"%s\",\n",escaped_json);
+        (void) FormatLocaleFile(file,"    \"baseName\": \"%s\",\n",
+          escaped_json);
         escaped_json=DestroyString(escaped_json);
       }
   magick_info=GetMagickInfo(image->magick,exception);
@@ -750,8 +751,7 @@ static MagickBooleanType EncodeImageAttributes(Image *image,FILE *file)
       (GetMagickMimeType(magick_info) != (const char *) NULL))
     {
       escaped_json=EscapeJsonString(GetMagickMimeType(magick_info));
-      (void) FormatLocaleFile(file,"    \"mimeType\": \"%s\",\n",
-        escaped_json);
+      (void) FormatLocaleFile(file,"    \"mimeType\": \"%s\",\n",escaped_json);
       escaped_json=DestroyString(escaped_json);
     }
   escaped_json=EscapeJsonString(
@@ -1468,7 +1468,7 @@ static MagickBooleanType EncodeImageAttributes(Image *image,FILE *file)
           {
             char
               *attribute,
-              *escaped_attribute;
+              *escaped_json;
 
             const char
               *tag;
@@ -1553,7 +1553,6 @@ static MagickBooleanType EncodeImageAttributes(Image *image,FILE *file)
               length=(size_t) (GetStringInfoDatum(profile)[i++] << 8);
               length|=GetStringInfoDatum(profile)[i++];
               attribute=(char *) NULL;
-              escaped_attribute=(char *) NULL;
               if (~length >= (MaxTextExtent-1))
                 attribute=(char *) AcquireQuantumMemory(length+MaxTextExtent,
                   sizeof(*attribute));

--- a/magick/string.c
+++ b/magick/string.c
@@ -954,6 +954,119 @@ MagickExport char *EscapeString(const char *source,const char escape)
 %                                                                             %
 %                                                                             %
 %                                                                             %
+%   E s c a p e J s o n S t r i n g                                           %
+%                                                                             %
+%                                                                             %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  EscapeJsonString() allocates memory for a json-escaped version of a
+%  source text string, copies the escaped version of the text to that
+%  memory location while adding backslash characters, and returns the
+%  escaped string.
+%
+%  The format of the EscapeJsonString method is:
+%
+%      char *EscapeJsonString(const char *source,const char escape)
+%
+%  A description of each parameter follows:
+%
+%    o allocate_string:  Method EscapeJsonString returns the escaped string.
+%
+%    o source: A character string.
+%
+*/
+MagickExport char *EscapeJsonString(const char *source)
+{
+  char
+    *destination;
+
+  register char
+    *q;
+
+  register const char
+    *p;
+
+  size_t
+    length;
+
+  assert(source != (const char *) NULL);
+  length=strlen(source);
+  // Find all the chars that need escaping and increase the dest length counter
+  for (p=source; *p != '\0'; p++)
+    {
+      switch (*p)
+        {
+          case '"':
+          case '\b':
+          case '\f':
+          case '\n':
+          case '\r':
+          case '\t':
+          case '\\':
+            if (~length < 1)
+              ThrowFatalException(ResourceLimitFatalError,"UnableToEscapeJsonString");
+            length++;
+            break;
+          default:
+            break;
+        }
+    }
+
+  destination=(char *) NULL;
+  if (~length >= (MaxTextExtent-1))
+    destination=(char *) AcquireQuantumMemory(length+MaxTextExtent,
+      sizeof(*destination));
+  if (destination == (char *) NULL)
+    ThrowFatalException(ResourceLimitFatalError,"UnableToEscapeJsonString");
+  *destination='\0';
+  q=destination;
+  for (p=source; *p != '\0'; p++)
+    {
+      switch (*p)
+        {
+          case '"':
+            *q++='\\';
+            *q++=(*p);
+            break;
+          case '\b':
+            *q++='\\';
+            *q++='b';
+            break;
+          case '\f':
+            *q++='\\';
+            *q++='f';
+            break;
+          case '\n':
+            *q++='\\';
+            *q++='n';
+            break;
+          case '\r':
+            *q++='\\';
+            *q++='r';
+            break;
+          case '\t':
+            *q++='\\';
+            *q++='t';
+            break;
+          case '\\':
+            *q++='\\';
+            *q++='\\';
+            break;
+          default:
+            *q++=(*p);
+            break;
+        }
+  }
+  *q='\0';
+  return(destination);
+}
+
+/*
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+%                                                                             %
+%                                                                             %
 %   F i l e T o S t r i n g                                                   %
 %                                                                             %
 %                                                                             %

--- a/magick/string_.h
+++ b/magick/string_.h
@@ -46,6 +46,7 @@ extern MagickExport char
   *DestroyString(char *),
   **DestroyStringList(char **),
   *EscapeString(const char *,const char),
+  *EscapeJsonString(const char *),
   *FileToString(const char *,const size_t,ExceptionInfo *),
   *GetEnvironmentValue(const char *),
   *StringInfoToHexString(const StringInfo *),


### PR DESCRIPTION
This pull request works though I'm not sure I'd say I'm proud of the form. Like I said in the original bug C is not my forte. If you have suggestions for improvements please let me know.

I took the very defensive approach and simply json escaped any string printed out by json.c I'd guess some subset of those strings are never going to be invalid but it is probably better to be consistent and safe.

I tested a few images with metadata that is invalid in JSON via:
`convert IMAGEFILE -moments -features 1 json:- | jsonlint`

https://github.com/zaach/jsonlint