### PR TITLE
Correct install location of the Magick++ headers.

### DIFF
--- a/Magick++/Makefile.am
+++ b/Magick++/Makefile.am
@@ -120,7 +120,7 @@ magickpptopinc_HEADERS = $(MAGICKPP_TOP_INCHEADERS)
 MAGICKPP_TOP_INCHEADERS_OPT = \
   Magick++/lib/Magick++.h
 
-magickppincdir = $(topincludedir)/Magick++
+magickppincdir = $(INCLUDE_PATH)/Magick++
 
 magickppinc_HEADERS = $(MAGICKPP_INCHEADERS)
 


### PR DESCRIPTION
$(topincludedir) is used during build to find the MagickCore headers,
if used the Magick++ headers are installed as include/MagickCore/Magick++.
Use $(INCLUDE_PATH) so it gets installed as include/ImageMagick-7/Magick++.

This will also match what the Magick++.pc file tells us.