### PR TITLE
Rewrite MagickCore-config.1 man page with propper man macro's.

### DIFF
--- a/MagickCore/MagickCore-config.1
+++ b/MagickCore/MagickCore-config.1
@@ -1,69 +1,71 @@
-.ad l
-.nh
-.TH MagickCore-Config 1 "2 May 2002" "ImageMagick"
-.SH NAME
-MagickCore-config \- get information about the installed version of ImageMagick
-.SH SYNOPSIS
-.B MagickCore-config 
-.B [--cflags]
-.B [--cppflags]
-.B [--exec-prefix]
-.B [--ldflags]
-.B [--libs]
-.B [--prefix]
-.B [--version]
-.SH DESCRIPTION
-.B MagickCore-config
-prints the compiler and linker flags required to compile and link programs
-that use the
-.BR ImageMagick
+.Dd July 13, 2015
+.Dt MAGICKCORE-CONFIG 1
+.Os
+.Sh NAME
+.Nm MagickCore-config
+.Nd get information about the installed version of ImageMagick
+.Sh SYNOPSIS
+.Nm MagickCore-config
+.Op Fl -cflags
+.Op Fl -cppflags
+.Op Fl -exec-prefix
+.Op Fl -ldflags
+.Op Fl -libs
+.Op Fl -prefix
+.Op Fl -version
+.Sh DESCRIPTION
+The
+.Nm MagickCore-config
+utility prints the compiler and linker flags required
+to compile and link programs that use the
+.Nm ImageMagick "Core"
 Application Programmer Interface.
-.SH EXAMPLES
-To print the version of the installed distribution of
-.BR ImageMagick ,
-use:
-
-.nf
-  MagickCore-config \-\-version
-.fi
-  
-To compile a program that calls the 
-.BR ImageMagick
-Application Programmer Interface, use:
-
-.nf
-  cc `MagickCore-config \-\-cflags \-\-cppflags \-\-ldflags \-\-libs` program.c
-.fi
-
-.SH OPTIONS
-.TP
-.B \-\-cflags
-Print the compiler flags that were used to compile 
-.BR libMagick .
-.TP
-.B \-\-cppflags
-Print the preprocessor flags that are needed to find the
-.B ImageMagick
+.Pp
+The following options are available:
+.Bl -tag -width Fl
+.It Fl -cppflags , -cflags , -cxxflags
+Print the compiler flags that are needed to find the
+.Xr ImageMagick 1
 C include files and defines to ensure that the ImageMagick data structures match between
 your program and the installed libraries.
-.TP
-.B \-\-exec-prefix
+.It Fl -prefix , -exec-prefix
 Print the directory under which target specific binaries and executables are installed.
-.TP
-.B \-\-ldflags
+.It Fl -ldflags , -libs
 Print the linker flags that are needed to link with the
-.B ImageMagick
+.Xr ImageMagick 1
 library.
-.TP
-.B \-\-libs
-Print the linker flags that are needed to link a program with
-.BR libMagick .
-.TP
-.B \-\-version
+.It Fl -version
 Print the version of the
-.B ImageMagick
+.Xr ImageMagick 1
 distribution to standard output.
-.SH LICENSE
-See http://www.imagemagick.org/script/license.php.
-.SH AUTHORS
-Cristy, ImageMagick Studio LLC
+.It Fl -coder-path
+Print the path where the
+.Xr ImageMagick 1
+coder modules are installed.
+.It Fl -filter-path
+Print the path where the
+.Xr ImageMagick 1
+filter modules are installed.
+.El
+.Sh EXAMPLES
+To print the version of the installed distribution of
+.Nm ImageMagick
+use:
+.Dl MagickCore-config --version
+.sp
+To compile a program that calls the
+.Xr ImageMagick 1
+Application Programmer Interface, use:
+.Dl cc `MagickCore-config --cppflags --ldflags` program.c
+.Sh SEE ALSO
+.Xr ImageMagick 1
+.Sh LICENSE
+.Nm ImageMagick
+is licensed with the Apache license 2.0. See
+http://www.imagemagick.org/script/license.php for more details.
+.Sh AUTHORS
+.An -nosplit
+The
+.Nm ImageMagick
+suite and this manual page where written by
+.An Cristy, ImageMagick Studio LLC <e-mail here?> .


### PR DESCRIPTION
This started by me noticing "holes" in the manual pages. Now FreeBSD uses mandoc to "format" manual pages, which comes from OpenBSD. While mandoc is stricter it didn't give that many warnings on the old manpage, it just showed holes. mandoc also strives to be compatible with other manual page formatters like groff. 

Rewrite the manpage using "proper" man macro's. I also changed a few things like grouping arguments that did the same thing together. I would like some feedback about the new setup so I can take that into account when I update the other manual pages.

Please add a e-mail at the end or just remove the <e-mail here> part before commit.