### PR TITLE
Add Manhattan interpolate option for sparse color method (IM-7)

### DIFF
--- a/Magick++/lib/Magick++/Include.h
+++ b/Magick++/lib/Magick++/Include.h
@@ -1022,6 +1022,7 @@ namespace Magick
   using MagickCore::ShepardsColorInterpolate;
   using MagickCore::VoronoiColorInterpolate;
   using MagickCore::InverseColorInterpolate;
+  using MagickCore::ManhattanColorInterpolate;
 
   // Statistic type
   using MagickCore::StatisticType;

--- a/MagickCore/distort.c
+++ b/MagickCore/distort.c
@@ -3161,6 +3161,40 @@ MagickExport Image *SparseColorImage(const Image *image,
               pixel.alpha/=denominator;
             break;
           }
+          case ManhattanColorInterpolate:
+          {
+            size_t
+              k;
+
+            double
+              minimum = MagickMaximumValue;
+
+            /*
+              Just use the closest control point you can find!
+            */
+            for(k=0; k<number_arguments; k+=2+number_colors) {
+              double distance =
+                  fabs((double)i-arguments[ k ])
+                + fabs((double)j-arguments[k+1]);
+              if ( distance < minimum ) {
+                register ssize_t x=(ssize_t) k+2;
+                if ((GetPixelRedTraits(image) & UpdatePixelTrait) != 0)
+                  pixel.red=arguments[x++];
+                if ((GetPixelGreenTraits(image) & UpdatePixelTrait) != 0)
+                  pixel.green=arguments[x++];
+                if ((GetPixelBlueTraits(image) & UpdatePixelTrait) != 0)
+                  pixel.blue=arguments[x++];
+                if (((GetPixelBlackTraits(image) & UpdatePixelTrait) != 0) &&
+                    (image->colorspace == CMYKColorspace))
+                  pixel.black=arguments[x++];
+                if (((GetPixelAlphaTraits(image) & UpdatePixelTrait) != 0) &&
+                    (image->alpha_trait != UndefinedPixelTrait))
+                  pixel.alpha=arguments[x++];
+                minimum = distance;
+              }
+            }
+            break;
+          }
           case VoronoiColorInterpolate:
           default:
           {

--- a/MagickCore/distort.h
+++ b/MagickCore/distort.h
@@ -66,7 +66,8 @@ typedef enum
     Methods unique to SparseColor().
   */
   VoronoiColorInterpolate = SentinelDistortion,
-  InverseColorInterpolate
+  InverseColorInterpolate,
+  ManhattanColorInterpolate
 } SparseColorMethod;
 
 extern MagickExport Image

--- a/MagickCore/option.c
+++ b/MagickCore/option.c
@@ -1646,6 +1646,7 @@ static const OptionInfo
     { "Inverse", InverseColorInterpolate, UndefinedOptionFlag, MagickFalse },
     { "Shepards", ShepardsColorInterpolate, UndefinedOptionFlag, MagickFalse },
     { "Voronoi", VoronoiColorInterpolate, UndefinedOptionFlag, MagickFalse },
+    { "Manhattan", ManhattanColorInterpolate, UndefinedOptionFlag, MagickFalse },
     { (char *) NULL, UndefinedResource, UndefinedOptionFlag, MagickFalse }
   },
   StatisticOptions[] =

--- a/www/command-line-options.html
+++ b/www/command-line-options.html
@@ -6861,6 +6861,9 @@ exposing a photographic film to light during the development process.</p>
     <dt>voronoi</dt>
     <dd>Simply map each pixel to the to nearest color point
         given. The result are polygonal 'cells' of solid color. </dd>
+    <dt>manhatten</dt>
+    <dd>Like voronoi, but resulting polygonal 'cells' are mapped
+        to fixed coordinate system.</dd>
     <dt>shepards</dt>
     <dd>Colors points biased on the ratio of inverse distance
         squared. Generating spots of color in a sea of the average of


### PR DESCRIPTION
Identical to previous PU #36, but on ImageMagick 7 branch.


Similar to [Voronoi diagram](https://en.wikipedia.org/wiki/Voronoi_diagram), the Manhattan distance calculation can be used with the [-sparse-color](http://www.imagemagick.org/script/command-line-options.php#sparse-color) operator.


## Example

Voronoi

    convert -size 100x100 xc: \
         -sparse-color Manhattan \
         '10,40 #F00 80,20 #0F0 59,90 #00F 80,9 #FF0 24 70 #F0F' \
         manhattan_im6.gif

![manhattan_im6](https://cloud.githubusercontent.com/assets/84594/10091020/9d56eea0-62fb-11e5-92ad-df806d326ee9.gif)

As comparied to `-sparse-color Voronoi` with the same points/colors.

![voronoi_im6](https://cloud.githubusercontent.com/assets/84594/10091016/9615759e-62fb-11e5-85c6-61056dd58249.gif)
