### PR TITLE
(IM6) Fixed TR/TD placement in MVG docs

### DIFF
--- a/www/magick-vector-graphics.html
+++ b/www/magick-vector-graphics.html
@@ -407,18 +407,18 @@ underline</pre></td>
   </tr>
   <tr>
     <td><a id="ellipse"></a>ellipse <var>center<sub>x</sub></var>,<var>center<sub>y</sub></var>   <var>radius<sub>x</sub></var>,<var>radius<sub>y</sub></var>   <var>arc<sub>start</sub></var>,<var>arc<sub>stop</sub></var></td>
+    <td></td>
+  </tr>
+  <tr>
     <td><a id="fill"></a>fill <var>color</var></td>
-  </tr>
-  <tr>
     <td>Choose from any of these <a href="color.html">colors</a>.</td>
+  </tr>
+  <tr>
     <td><a id="fill-opacity"></a>fill-opacity <var>opacity</var></td>
+    <td>The opacity ranges from 0.0 (fully transparent) to 1.0 (fully opaque) or as a percentage (e.g. 50%).</td>
   </tr>
   <tr>
-    <td>The opacity ranges from 0.0 (fully transparent) to 1.0 (fully opaque) or as a percentage (e.g. 50%).
-</td>
     <td><a id="fill-rule"></a>fill-rule <var>rule</var></td>
-  </tr>
-  <tr>
     <td>Choose from these rule types:
 <pre>evenodd
 nonzero</pre></td>


### PR DESCRIPTION
A misplaced **&lt;td&gt;**  element resulted a series of fill _primitives_ in the _description_column. This Pull Request (1 of 2) reorders everything back in place.