### PR TITLE
Fix build when fchmod is missing

### DIFF
--- a/MagickCore/random.c
+++ b/MagickCore/random.c
@@ -464,7 +464,9 @@ static StringInfo *GenerateEntropicChaos(RandomInfo *random_info)
     file=mkstemp(path);
     if (file != -1)
       {
+#if defined(MAGICKCORE_HAVE_FCHMOD)
         (void) fchmod(file,0600);
+#endif
 #if defined(__OS2__)
         setmode(file,O_BINARY);
 #endif

--- a/MagickCore/resource.c
+++ b/MagickCore/resource.c
@@ -527,7 +527,9 @@ MagickExport int AcquireUniqueFileResource(char *path)
     file=mkstemp(path);
     if (file != -1)
       {
+#if defined(MAGICKCORE_HAVE_FCHMOD)
         (void) fchmod(file,0600);
+#endif
 #if defined(__OS2__)
         setmode(file,O_BINARY);
 #endif


### PR DESCRIPTION
fchmod doesn't exist on all platforms, and it's already detected by the configure script, so just don't use it if it's not found.