### PR TITLE
Write correct pitch and channel bitmasks for uncompressed DDS images.

### DIFF
--- a/coders/dds.c
+++ b/coders/dds.c
@@ -2708,12 +2708,22 @@ static void WriteDDSInfo(Image *image, const size_t pixelFormat,
   (void) WriteBlobLSBLong(image,(unsigned int) image->rows);
   (void) WriteBlobLSBLong(image,(unsigned int) image->columns);
 
-  if (compression == FOURCC_DXT1)
-    (void) WriteBlobLSBLong(image,
-             (unsigned int) (MagickMax(1,(image->columns+3)/4) * 8));
+  if (pixelFormat == DDPF_FOURCC)
+    {
+      if (compression == FOURCC_DXT1)
+        (void) WriteBlobLSBLong(image,
+                 (unsigned int) (MagickMax(1,(image->columns+3)/4) * 8));
+      else
+        (void) WriteBlobLSBLong(image,
+                 (unsigned int) (MagickMax(1,(image->columns+3)/4) * 16));
+    }
   else
-    (void) WriteBlobLSBLong(image,
-             (unsigned int) (MagickMax(1,(image->columns+3)/4) * 16));
+    {
+      if (image->alpha_trait != UndefinedPixelTrait)
+        (void) WriteBlobLSBLong(image,(unsigned int) (image->columns * 32));
+      else
+        (void) WriteBlobLSBLong(image,(unsigned int) (image->columns * 24));
+    }
 
   (void) WriteBlobLSBLong(image,0x00);
   (void) WriteBlobLSBLong(image,(unsigned int) mipmaps+1);
@@ -2744,9 +2754,9 @@ static void WriteDDSInfo(Image *image, const size_t pixelFormat,
       else
         {
           (void) WriteBlobLSBLong(image,24);
+          (void) WriteBlobLSBLong(image,0xff0000);
+          (void) WriteBlobLSBLong(image,0xff00);
           (void) WriteBlobLSBLong(image,0xff);
-          (void) WriteBlobLSBLong(image,0x00);
-          (void) WriteBlobLSBLong(image,0x00);
           (void) WriteBlobLSBLong(image,0x00);
         }
     }


### PR DESCRIPTION
I noticed that images I converted with `convert in -define dds:compressed=none out.dds` didn't have sensible values for pitch and channel bitmasks. This fixes that.