### PR TITLE
Add complex text support, take two

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required # needed for trusty beta
+dist: trusty   # needed for HarfBuzz
+
 language: c
 
 
@@ -6,9 +9,11 @@ compiler:
   - gcc
 
 before_script:
+  - sudo add-apt-repository -y ppa:as-bahanta/raqm
   - sudo add-apt-repository ppa:dns/gnu -y
   - sudo apt-get update -q
   - sudo apt-get install --only-upgrade autoconf
+  - sudo apt-get install -y libraqm-dev libfreetype6-dev libharfbuzz-dev libfribidi-dev
 
 script:
     - export OMP_NUM_THREADS=1

--- a/MagickCore/draw.c
+++ b/MagickCore/draw.c
@@ -282,6 +282,8 @@ MagickExport DrawInfo *CloneDrawInfo(const ImageInfo *image_info,
     (void) CloneString(&clone_info->text,draw_info->text);
   if (draw_info->font != (char *) NULL)
     (void) CloneString(&clone_info->font,draw_info->font);
+  if (draw_info->font_features != (char *) NULL)
+    (void) CloneString(&clone_info->font_features,draw_info->font_features);
   if (draw_info->metrics != (char *) NULL)
     (void) CloneString(&clone_info->metrics,draw_info->metrics);
   if (draw_info->family != (char *) NULL)
@@ -836,6 +838,8 @@ MagickExport DrawInfo *DestroyDrawInfo(DrawInfo *draw_info)
     draw_info->stroke_pattern=DestroyImage(draw_info->stroke_pattern);
   if (draw_info->font != (char *) NULL)
     draw_info->font=DestroyString(draw_info->font);
+  if (draw_info->font_features != (char *) NULL)
+    draw_info->font_features=DestroyString(draw_info->font_features);
   if (draw_info->metrics != (char *) NULL)
     draw_info->metrics=DestroyString(draw_info->metrics);
   if (draw_info->family != (char *) NULL)
@@ -2058,6 +2062,15 @@ MagickExport MagickBooleanType DrawImage(Image *image,const DrawInfo *draw_info,
                 RelinquishMagickMemory(graphic_context[n]->font);
             break;
           }
+        if (LocaleCompare("font-features",keyword) == 0)
+        {
+            GetMagickToken(q,&q,token);
+            (void) CloneString(&graphic_context[n]->font_features,token);
+            if (LocaleCompare("none",token) == 0)
+                graphic_context[n]->font_features=(char *)
+                  RelinquishMagickMemory(graphic_context[n]->font_features);
+            break;
+        }
         if (LocaleCompare("font-family",keyword) == 0)
           {
             GetMagickToken(q,&q,token);
@@ -4863,6 +4876,9 @@ MagickExport void GetDrawInfo(const ImageInfo *image_info,DrawInfo *draw_info)
   draw_info->stroke_antialias=clone_info->antialias;
   if (clone_info->font != (char *) NULL)
     draw_info->font=AcquireString(clone_info->font);
+  option=GetImageOption(clone_info,"font-features");
+  if (option != (char *) NULL)
+    draw_info->font_features=AcquireString(option);
   if (clone_info->density != (char *) NULL)
     draw_info->density=AcquireString(clone_info->density);
   draw_info->text_antialias=clone_info->antialias;

--- a/MagickCore/draw.h
+++ b/MagickCore/draw.h
@@ -254,7 +254,8 @@ typedef struct _DrawInfo
     *text,
     *font,
     *metrics,
-    *family;
+    *family,
+    *font_features;
 
   size_t
     face;

--- a/MagickCore/option.c
+++ b/MagickCore/option.c
@@ -475,6 +475,8 @@ static const OptionInfo
     { "-flop", 0L, SimpleOperatorFlag, MagickFalse },
     { "+font", 0L, ImageInfoOptionFlag | DrawInfoOptionFlag, MagickFalse },
     { "-font", 1L, ImageInfoOptionFlag | DrawInfoOptionFlag, MagickFalse },
+    { "+font-features", 0L, ImageInfoOptionFlag | DrawInfoOptionFlag, MagickFalse },
+    { "-font-features", 1L, ImageInfoOptionFlag | DrawInfoOptionFlag, MagickFalse },
     { "+foreground", 0L, NonMagickOptionFlag, MagickFalse },
     { "-foreground", 1L, NonMagickOptionFlag, MagickFalse },
     { "+frame", 1L, DeprecateOptionFlag, MagickTrue },

--- a/MagickWand/operation.c
+++ b/MagickWand/operation.c
@@ -885,6 +885,11 @@ WandPrivate void CLISettingOptionInfo(MagickCLI *cli_wand,
           (void) CloneString(&_image_info->font,_draw_info->font);
           break;
         }
+      if (LocaleCompare("font-features",option+1) == 0)
+      {
+          (void) CloneString(&_draw_info->font_features,ArgOption(NULL));
+          break;
+      }
       if (LocaleCompare("format",option+1) == 0)
         {
           /* FUTURE: why the ping test, you could set ping after this! */

--- a/configure.ac
+++ b/configure.ac
@@ -2021,6 +2021,40 @@ AC_SUBST(FREETYPE_LIBS)
 dnl ===========================================================================
 
 #
+# Check for the raqm delegate library.
+#
+AC_ARG_WITH([raqm],
+    [AC_HELP_STRING([--without-raqm],
+                    [disable Raqm support])],
+    [with_raqm=$withval],
+    [with_raqm='yes'])
+
+if test "$with_raqm" != 'yes'; then
+    DISTCHECK_CONFIG_FLAGS="${DISTCHECK_CONFIG_FLAGS} --with-raqm=$with_raqm "
+fi
+
+have_raqm='no'
+RAQM_CFLAGS=""
+RAQM_LIBS=""
+RAQM_PKG=""
+if test "x$with_raqm" = "xyes"; then
+  AC_MSG_RESULT([-------------------------------------------------------------])
+  PKG_CHECK_MODULES(RAQM,[raqm], have_raqm=yes, have_raqm=no)
+  AC_MSG_RESULT([])
+fi
+
+if test "$have_raqm" = 'yes'; then
+  AC_DEFINE(RAQM_DELEGATE,1,Define if you have RAQM library)
+  CFLAGS="$RAQM_CFLAGS $CFLAGS"
+fi
+
+AM_CONDITIONAL(RAQM_DELEGATE, test "$have_raqm" = 'yes')
+AC_SUBST(RAQM_CFLAGS)
+AC_SUBST(RAQM_LIBS)
+
+dnl ===========================================================================
+
+#
 # Check for Ghostscript library or framework.
 #
 # Test for iapi.h & test for gsapi_new_instance in -lgs
@@ -3588,6 +3622,9 @@ fi
 if test "$have_freetype"    = 'yes' ; then
    MAGICK_DELEGATES="$MAGICK_DELEGATES freetype"
 fi
+if test "$have_raqm"    = 'yes' ; then
+   MAGICK_DELEGATES="$MAGICK_DELEGATES raqm"
+fi
 if test "$have_gslib"    = 'yes' ; then
    MAGICK_DELEGATES="$MAGICK_DELEGATES gslib"
 fi
@@ -3706,9 +3743,9 @@ fi
 #
 
 if test "$build_modules" != 'no'; then
-    MAGICK_DEP_LIBS="$USER_LIBS $LCMS_LIBS $FREETYPE_LIBS $LQR_LIBS $FFTW_LIBS $FONTCONFIG_LIBS $XEXT_LIBS $IPC_LIBS $X11_LIBS $XT_LIBS $LZMA_LIBS $BZLIB_LIBS $ZLIB_LIBS $LTDL_LIBS $GDI32_LIBS $MATH_LIBS $GOMP_LIBS $CL_LIBS $UMEM_LIBS $JEMALLOC_LIBS $THREAD_LIBS"
+    MAGICK_DEP_LIBS="$USER_LIBS $LCMS_LIBS $FREETYPE_LIBS $RAQM_LIBS $LQR_LIBS $FFTW_LIBS $FONTCONFIG_LIBS $XEXT_LIBS $IPC_LIBS $X11_LIBS $XT_LIBS $LZMA_LIBS $BZLIB_LIBS $ZLIB_LIBS $LTDL_LIBS $GDI32_LIBS $MATH_LIBS $GOMP_LIBS $CL_LIBS $UMEM_LIBS $JEMALLOC_LIBS $THREAD_LIBS"
 else
-    MAGICK_DEP_LIBS="$USER_LIBS $JBIG_LIBS $LCMS_LIBS $TIFF_LIBS $FREETYPE_LIBS $JPEG_LIBS $GS_LIBS $LQR_LIBS $PNG_LIBS $AUTOTRACE_LIBS $DJVU_LIBS $FFTW_LIBS $FPX_LIBS $FONTCONFIG_LIBS $WEBP_LIBS $WMF_LIBS $DPS_LIBS $XEXT_LIBS $XT_LIBS $IPC_LIBS $X11_LIBS $LZMA_LIBS $BZLIB_LIBS $OPENEXR_LIBS $LIBOPENJP2_LIBS $PANGO_LIBS $RSVG_LIBS $XML_LIBS $GVC_LIBS $ZLIB_LIBS $GDI32_LIBS $MATH_LIBS $GOMP_LIBS $CL_LIBS $UMEM_LIBS $JEMALLOC_LIBS $THREAD_LIBS"
+    MAGICK_DEP_LIBS="$USER_LIBS $JBIG_LIBS $LCMS_LIBS $TIFF_LIBS $FREETYPE_LIBS $RAQM_LIBS $JPEG_LIBS $GS_LIBS $LQR_LIBS $PNG_LIBS $AUTOTRACE_LIBS $DJVU_LIBS $FFTW_LIBS $FPX_LIBS $FONTCONFIG_LIBS $WEBP_LIBS $WMF_LIBS $DPS_LIBS $XEXT_LIBS $XT_LIBS $IPC_LIBS $X11_LIBS $LZMA_LIBS $BZLIB_LIBS $OPENEXR_LIBS $LIBOPENJP2_LIBS $PANGO_LIBS $RSVG_LIBS $XML_LIBS $GVC_LIBS $ZLIB_LIBS $GDI32_LIBS $MATH_LIBS $GOMP_LIBS $CL_LIBS $UMEM_LIBS $JEMALLOC_LIBS $THREAD_LIBS"
 fi
 AC_SUBST(MAGICK_DEP_LIBS)
 
@@ -3845,6 +3882,7 @@ matches your expectations.
   FlashPIX          --with-fpx=$with_fpx		$have_fpx
   FontConfig        --with-fontconfig=$with_fontconfig	$have_fontconfig
   FreeType          --with-freetype=$with_freetype		$have_freetype
+  Raqm              --with-raqm=$with_raqm		$have_raqm
   Ghostscript lib   --with-gslib=$with_gslib		$have_gslib
   Graphviz          --with-gvc=$with_gvc		$have_gvc
   JBIG              --with-jbig=$with_jbig		$have_jbig


### PR DESCRIPTION
This pull request adds support for languages that require complex text layout.

We are using a standalone library 'Raqm', that wraps FriBidi (for bidirectional
text support) and HarfBuzz (for text shaping), and does proper BiDi and script
itemization.

We also add a -font-features option to allow controlling font features used
during text layout.

Raqm support is enabled by default but can be disabled at compiling time.

This is the follow up to https://github.com/ImageMagick/ImageMagick/pull/69,
but uses Raqm as a standalone library and supports setting font features.