### PR TITLE
Fix multiple DDS output issues.

### DIFF
--- a/coders/dds.c
+++ b/coders/dds.c
@@ -2731,9 +2731,9 @@ static void WriteDDSInfo(Image *image, const size_t pixelFormat,
     {
       // Uncompressed DDS requires byte pitch of first image
       if (image->alpha_trait != UndefinedPixelTrait)
-        (void) WriteBlobLSBLong(image,(unsigned int) (image->columns * 32));
+        (void) WriteBlobLSBLong(image,(unsigned int) (image->columns * 4));
       else
-        (void) WriteBlobLSBLong(image,(unsigned int) (image->columns * 24));
+        (void) WriteBlobLSBLong(image,(unsigned int) (image->columns * 3));
     }
 
   (void) WriteBlobLSBLong(image,0x00);


### PR DESCRIPTION
Fixes errors in encoding logic for DXT5 alpha, which caused alpha blockiness and incorrect alphas if a block hit a certain branch of FixRange.

Fixes DDS header to follow the specification. Writes linear size or stride depending on compression. Should prevent output DDS files from crashing GIMP.

Addresses problems in https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=27169&sid=39ea05ff30d1fe5a2ae55ce4d547207a

The original code seems to be converted from libsquish, but suffered some logic errors in conversion. It lacks unit tests comparing the output to libsquish output, which would have caught the alpha problem.