### PR TITLE
Fix typo s/width/height/ in resource.c (ImageMagick-6 branch)

### DIFF
--- a/magick/resource.c
+++ b/magick/resource.c
@@ -1111,7 +1111,7 @@ MagickExport MagickBooleanType ResourceComponentGenesis(void)
         100.0));
       limit=DestroyString(limit);
     }
-  (void) SetMagickResourceLimit(HeightResource,resource_info.width_limit);
+  (void) SetMagickResourceLimit(HeightResource,resource_info.height_limit);
   limit=GetEnvironmentValue("MAGICK_HEIGHT_LIMIT");
   if (limit != (char *) NULL)
     {


### PR DESCRIPTION
Hi there,
I found that `width` is wrongly used instead of `height` in `magick/resource.c`.
Could you check this?