### PR TITLE
Fixes for mingw-w64

### DIFF
--- a/MagickCore/locale.c
+++ b/MagickCore/locale.c
@@ -130,7 +130,7 @@ static locale_t AcquireCLocale(void)
 #if defined(MAGICKCORE_HAVE_NEWLOCALE)
   if (c_locale == (locale_t) NULL)
     c_locale=newlocale(LC_ALL_MASK,"C",(locale_t) 0);
-#elif defined(MAGICKCORE_WINDOWS_SUPPORT)
+#elif defined(MAGICKCORE_WINDOWS_SUPPORT) && !defined(__MINGW32__)
   if (c_locale == (locale_t) NULL)
     c_locale=_create_locale(LC_ALL,"C");
 #endif
@@ -260,7 +260,7 @@ static void DestroyCLocale(void)
 #if defined(MAGICKCORE_HAVE_NEWLOCALE)
   if (c_locale != (locale_t) NULL)
     freelocale(c_locale);
-#elif defined(MAGICKCORE_WINDOWS_SUPPORT)
+#elif defined(MAGICKCORE_WINDOWS_SUPPORT) && !defined(__MINGW32__)
   if (c_locale != (locale_t) NULL)
     _free_locale(c_locale);
 #endif

--- a/MagickCore/thread_.h
+++ b/MagickCore/thread_.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-#if defined(MAGICKCORE_WINDOWS_SUPPORT)
+#if defined(MAGICKCORE_WINDOWS_SUPPORT) && !defined(__MINGW32__)
 #include <intsafe.h>
 #endif
 


### PR DESCRIPTION
These are fixes needed to build on `mingw-w64` platform. The CRT does not expose `_create_locale` and `__free_locale` and also the `#include <intsafe.h>` header is not available and not needed.