### PR TITLE
Fix misaligned bits when writing .rfg

### DIFF
--- a/coders/rgf.c
+++ b/coders/rgf.c
@@ -387,7 +387,10 @@ static MagickBooleanType WriteRGFImage(const ImageInfo *image_info,Image *image)
       p++;
     }
     if (bit != 0)
+    {
+      byte >>= 8 - bit;
       (void) WriteBlobByte(image,byte);
+    }
     status=SetImageProgress(image,SaveImageTag,(MagickOffsetType) y,
       image->rows);
     if (status == MagickFalse)


### PR DESCRIPTION
When writing LEGO MINDSTORMS EV3 .rfg file, if the image is not a
multiple of 8 pixels wide, the pixels in the last byte are not aligned
correctly. The pixels need to be shifted the number of bits that are
not used in the last byte.