### PR TITLE
Fix text wrapping bug

### DIFF
--- a/MagickCore/annotate.c
+++ b/MagickCore/annotate.c
@@ -634,7 +634,7 @@ MagickExport ssize_t FormatMagickCaption(Image *image,DrawInfo *draw_info,
     if (status == MagickFalse)
       break;
     width=(size_t) floor(metrics->width+draw_info->stroke_width+0.5);
-    if ((width <= image->columns) || (strcmp(text,draw_info->text) == 0))
+    if ((width <= image->columns) || (s == (char *) NULL))
       continue;
     (void) strcpy(text,draw_info->text);
     if ((s != (char *) NULL) && (GetUTFOctets(s) == 1))


### PR DESCRIPTION
The bug was described here: http://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=30376

tl;dr:
```convert -size 400x -pointsize 50 caption:'This does not wrap' out.png```
<img src="http://i.imgur.com/eJmsL1C.png">

If the last letter of the last word is the only thing overflowing, but there is a wrap point somewhere available, then it should be used to wrap.

If I'm not mistaken, the strcmp check was only here to avoid an infinite loop when trying to render a single word in a too small width. If so, the check i used instead does the job.