### PR TITLE
fix url missing hyphen

### DIFF
--- a/www/binary-releases.html
+++ b/www/binary-releases.html
@@ -84,8 +84,8 @@
 
   <tr>
       <td>ImageMagick-libs7.0.3-8.x86_64.rpm</td>
-      <td><a href= "https://www.imagemagick.org/download/linux/CentOS/x86_64/ImageMagick-libs7.0.3-8.x86_64.rpm">download</a></td>
-    <td><a href="ftp://ftp.imagemagick.org/pub/ImageMagick/linux/CentOS/x86_64/ImageMagick-libs7.0.3-8.x86_64.rpm">download</a></td>
+      <td><a href= "https://www.imagemagick.org/download/linux/CentOS/x86_64/ImageMagick-libs-7.0.3-8.x86_64.rpm">download</a></td>
+    <td><a href="ftp://ftp.imagemagick.org/pub/ImageMagick/linux/CentOS/x86_64/ImageMagick-libs-7.0.3-8.x86_64.rpm">download</a></td>
     <td>Redhat / CentOS 7.1 x86_64 RPM</td>
   </tr>
 
@@ -123,7 +123,7 @@
 <p>ImageMagick RPM's are self-installing.  Simply type the following command and you're ready to start using ImageMagick:</p>
 
 <pre><span class="crtprompt"> </span><span class='crtin'>rpm -Uvh ImageMagick-7.0.3-8.x86_64.rpm</span></pre><p>You'll need the libraries as well:</p>
-<pre><span class="crtprompt"> </span><span class='crtin'>rpm -Uvh ImageMagick-libs7.0.3-8.x86_64.rpm</span></pre>
+<pre><span class="crtprompt"> </span><span class='crtin'>rpm -Uvh ImageMagick-libs-7.0.3-8.x86_64.rpm</span></pre>
 <p>For other systems, create (or choose) a directory to install the package into and change to that directory, for example:</p>
 
 <pre>


### PR DESCRIPTION
the download links on the binary releases page points to urls that are 404s because they miss the hyphen after libs.