### PR TITLE
Fix bug with missing return

### DIFF
--- a/magick/nt-base.c
+++ b/magick/nt-base.c
@@ -1717,6 +1717,7 @@ MagickPrivate DIR *NTOpenDirectory(const char *path)
   if (length == 0)
     return((DIR *) NULL);
   if (wcsncat(file_specification,directory_separator,MaxTextExtent-wcslen(file_specification)-1) == (wchar_t *) NULL)
+    return((DIR *) NULL);
   entry=(DIR *) AcquireMagickMemory(sizeof(DIR));
   if (entry != (DIR *) NULL)
     {


### PR DESCRIPTION
I found an access exception to occur because there is no return in windows ImageMagick 6.
Could you check this?