### PR TITLE
Stop overwriting index.html with copy from root directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -247,7 +247,6 @@ endif
 
 install-data-html:
 	$(mkinstalldirs) $(DESTDIR)$(pkgdocdir)
-	$(INSTALL_DATA) $(srcdir)/index.html $(DESTDIR)$(pkgdocdir)
 	for dir in $(DOCDIRS) ; do \
 	  $(mkinstalldirs) $(DESTDIR)$(pkgdocdir)/$$dir && \
 	  if test -d $(builddir)/$$dir ; then \
@@ -266,7 +265,6 @@ install-data-html:
 # Uninstall HTML files
 HTML_UNINSTALL_DATA_TARGETS = uninstall-data-html
 uninstall-data-html:
-	rm -f $(DESTDIR)$(pkgdocdir)/index.html
 	for dir in $(DOCDIRS) ; do \
 	  rm -f -r $(DESTDIR)$(pkgdocdir)/$$dir ; \
 	done

--- a/Makefile.in
+++ b/Makefile.in
@@ -11617,7 +11617,6 @@ dist-hook:
 
 install-data-html:
 	$(mkinstalldirs) $(DESTDIR)$(pkgdocdir)
-	$(INSTALL_DATA) $(srcdir)/index.html $(DESTDIR)$(pkgdocdir)
 	for dir in $(DOCDIRS) ; do \
 	  $(mkinstalldirs) $(DESTDIR)$(pkgdocdir)/$$dir && \
 	  if test -d $(builddir)/$$dir ; then \
@@ -11633,7 +11632,6 @@ install-data-html:
 	  fi; \
 	done
 uninstall-data-html:
-	rm -f $(DESTDIR)$(pkgdocdir)/index.html
 	for dir in $(DOCDIRS) ; do \
 	  rm -f -r $(DESTDIR)$(pkgdocdir)/$$dir ; \
 	done


### PR DESCRIPTION
Breaks local navigation links, css and images