### PR TITLE
Fix compile warning bug for deprecated register

### DIFF
--- a/MagickCore/MagickCore.h
+++ b/MagickCore/MagickCore.h
@@ -47,6 +47,9 @@ extern "C" {
 #  undef inline
 # endif
 #endif
+#if __cplusplus > 199711L
+#define register
+#endif
 
 #define MAGICKCORE_CHECK_VERSION(major,minor,micro) \
   ((MAGICKCORE_MAJOR_VERSION > (major)) || \


### PR DESCRIPTION
There is stall a compiler warning for Magick++ as discussed in the previous issue:

https://github.com/ImageMagick/ImageMagick/issues/249
Changes for previous issue: https://github.com/ImageMagick/ImageMagick/commit/1e4662d6938e2780173db729b9fc32fd30718180

This pull request adds the register define in a needed core header