### PR TITLE
Fix variable reuse confusion in WriteTGAImage causing assertion failure

### DIFF
--- a/coders/tga.c
+++ b/coders/tga.c
@@ -714,6 +714,8 @@ static MagickBooleanType WriteTGAImage(const ImageInfo *image_info,Image *image,
 
   const char
     *value;
+  const char
+    *value2;
 
   const double
     midpoint = QuantumRange/2.0;
@@ -828,14 +830,14 @@ static MagickBooleanType WriteTGAImage(const ImageInfo *image_info,Image *image,
         else
           tga_info.colormap_size=24;
       }
-  value=GetImageArtifact(image,"tga:image-origin");
-  if (value != (const char *) NULL)
+  value2=GetImageArtifact(image,"tga:image-origin");
+  if (value2 != (const char *) NULL)
     {
       OrientationType
         origin;
 
       origin=(OrientationType) ParseCommandOption(MagickOrientationOptions,
-        MagickFalse,value);
+        MagickFalse,value2);
       if (origin == BottomRightOrientation || origin == TopRightOrientation)
         tga_info.attributes|=(1UL << 4);
       if (origin == TopLeftOrientation || origin == TopRightOrientation)


### PR DESCRIPTION
Fix variable reuse confusion in WriteTGAImage causing assertion failure in WriteBlob when running:
`convert images/bigsharp1.png images/bigsharp1.png.vda`
and
`convert images/bigsharp1.png images/bigsharp1.png.vst`
