### PR TITLE
png.c: unbreak build without JPEG support

### DIFF
--- a/coders/png.c
+++ b/coders/png.c
@@ -1229,7 +1229,6 @@ static void PNGLong(png_bytep p,png_uint_32 value)
   *p++=(png_byte) (value & 0xff);
 }
 
-#if defined(JNG_SUPPORTED)
 static void PNGsLong(png_bytep p,png_int_32 value)
 {
   *p++=(png_byte) ((value >> 24) & 0xff);
@@ -1237,7 +1236,6 @@ static void PNGsLong(png_bytep p,png_int_32 value)
   *p++=(png_byte) ((value >> 8) & 0xff);
   *p++=(png_byte) (value & 0xff);
 }
-#endif
 
 static void PNGShort(png_bytep p,png_uint_16 value)
 {


### PR DESCRIPTION
Since commit a9e228f8ac26 (Implemented a private PNG caNv (canvas) chunk),
PNGsLong gets called unconditionally, but it is only defined if JPEG
support is enabled (which defines JNG_SUPPORTED), breaking the build:

MagickCore/.libs/libMagickCore-7.Q16HDRI.a(MagickCore_libMagickCore_7_Q16HDRI_la-png.o): In function `WriteOnePNGImage':
png.c:(.text+0x748d): undefined reference to `PNGsLong'
png.c:(.text+0x74b7): undefined reference to `PNGsLong'

For build log, see:
http://autobuild.buildroot.net/results/d20/d20eecec8e7b947759185f77a6c8e610dd7393f3/build-end.log

Fix it by unconditionally defining the helper function.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>