### PR TITLE
fix fd leak for webp coder

### DIFF
--- a/coders/webp.c
+++ b/coders/webp.c
@@ -366,6 +366,7 @@ static Image *ReadWEBPImage(const ImageInfo *image_info,
   }
   WebPFreeDecBuffer(webp_image);
   stream=(unsigned char*) RelinquishMagickMemory(stream);
+  (void) CloseBlob(image);
   return(image);
 }
 #endif


### PR DESCRIPTION
Signed-off-by: zhangji <zhangji@qiniu.com>

It seams that fd leaks when parse image with format webp.

cmd such as:
convert a.webp -quality 75.0  b.webp

https://github.com/ImageMagick/ImageMagick/blob/master/coders/webp.c +250
The function ReadWEBPImage() will use OpenBlob() to open one fd for source image.
However, no CloseBlob() func was found until the end of ReadWEBPImage()

It leads to fd leak for server program which use imageMagick SDK.