### PR TITLE
fix DICOM read with fractional slope

### DIFF
--- a/coders/dcm.c
+++ b/coders/dcm.c
@@ -2877,12 +2877,10 @@ static MagickBooleanType ReadDCMPixels(Image *image,DCMInfo *info,
                   }
                 i++;
               }
-          index=(int) ((pixel_value*info->rescale_slope)+
-            info->rescale_intercept);
           if (info->window_width == 0)
             {
               if (info->signed_data == 1)
-                index-=32767;
+                index=pixel_value-32767;
             }
           else
             {
@@ -2894,14 +2892,14 @@ static MagickBooleanType ReadDCMPixels(Image *image,DCMInfo *info,
                 (info->window_width-1.0)/2.0-0.5);
               window_max=(ssize_t) floor((double) info->window_center+
                 (info->window_width-1.0)/2.0+0.5);
-              if ((ssize_t) index <= window_min)
+              if ((ssize_t) pixel_value <= window_min)
                 index=0;
               else
-                if ((ssize_t) index > window_max)
+                if ((ssize_t) pixel_value > window_max)
                   index=(int) info->max_value;
                 else
-                  index=(int) (info->max_value*(((index-info->window_center-
-                    0.5)/(info->window_width-1))+0.5));
+                  index=(int) (info->max_value*(((pixel_value-
+		    info->window_center-0.5)/(info->window_width-1))+0.5));
             }
           index&=info->mask;
           index=(int) ConstrainColormapIndex(image,(size_t) index);

--- a/coders/dcm.c
+++ b/coders/dcm.c
@@ -2697,8 +2697,6 @@ typedef struct _DCMInfo
     window_width;
 
   ssize_t
-    rescale_intercept,
-    rescale_slope,
     window_center;
 } DCMInfo;
 
@@ -3083,8 +3081,6 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
   info.depth=8;
   info.max_value=255UL;
   info.mask=0xffff;
-  info.rescale_intercept=0;
-  info.rescale_slope=1;
   info.samples_per_pixel=1;
   info.scale=(Quantum *) NULL;
   info.signed_data=(~0UL);
@@ -3504,24 +3500,6 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
             */
             if (data != (unsigned char *) NULL)
               info.window_width=StringToUnsignedLong((char *) data);
-            break;
-          }
-          case 0x1052:
-          {
-            /*
-              Rescale intercept
-            */
-            if (data != (unsigned char *) NULL)
-              info.rescale_intercept=(ssize_t) StringToLong((char *) data);
-            break;
-          }
-          case 0x1053:
-          {
-            /*
-              Rescale slope
-            */
-            if (data != (unsigned char *) NULL)
-              info.rescale_slope=(ssize_t) StringToLong((char *) data);
             break;
           }
           case 0x1200:


### PR DESCRIPTION
The DICOM reader was multiplying pixel values by rescale_slope, which it
represented as ssize_t. Many DICOM files use double values for
rescale_slope, so for rescale_slope < 1, the reader was multiplying by
zero and producing blank images.

This commit removes all internal handling of rescale_slope and
rescale_intercept, leaving it to the caller to apply these values. It
should be applied to the 7.x branch as well.

This change makes sense within the DICOM standard, since rescale_slope
and rescale_intercept say how to get from the uint16 (or whatever the
file holds) to the value in the units that the file represents, perhaps kBQ/ml.
These are almost always fractional quantities and int-valued pixels
cannot represent them.

Here's a sample file that shows the problem:

http://www.rollthepotato.net/~john/MRIm5.dcm

You're welcome to use this image in a test suite. Before this commit:

$ identify -verbose MRIm5.dcm
  Image: MRIm5.dcm
  Format: DCM (Digital Imaging and Communications in Medicine image)
  Gray:
    min: 32769 (0.500023)
    max: 32769 (0.500023)

After:

$ identify -verbose MRIm5.dcm
  Image: MRIm5.dcm
  Format: DCM (Digital Imaging and Communications in Medicine image)
  Gray:
    min: 0 (0)
    max: 65535 (1)

Forum thread:

https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=31887&p=145852