### PR TITLE
Fixed missing absolute value

### DIFF
--- a/MagickWand/drawing-wand.c
+++ b/MagickWand/drawing-wand.c
@@ -6038,7 +6038,7 @@ WandExport void DrawSetTextKerning(DrawingWand *wand,const double kerning)
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",wand->name);
   if ((wand->filter_off != MagickFalse) &&
-      ((CurrentContext->kerning-kerning) >= MagickEpsilon))
+      (fabs((CurrentContext->kerning-kerning)) >= MagickEpsilon))
     {
       CurrentContext->kerning=kerning;
       (void) MVGPrintf(wand,"kerning %lf\n",kerning);
@@ -6079,7 +6079,7 @@ WandExport void DrawSetTextInterlineSpacing(DrawingWand *wand,
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",wand->name);
   if ((wand->filter_off != MagickFalse) &&
-      ((CurrentContext->interline_spacing-interline_spacing) >= MagickEpsilon))
+      (fabs((CurrentContext->interline_spacing-interline_spacing)) >= MagickEpsilon))
     {
       CurrentContext->interline_spacing=interline_spacing;
       (void) MVGPrintf(wand,"interline-spacing %lf\n",interline_spacing);
@@ -6120,7 +6120,7 @@ WandExport void DrawSetTextInterwordSpacing(DrawingWand *wand,
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",wand->name);
   if ((wand->filter_off != MagickFalse) &&
-      ((CurrentContext->interword_spacing-interword_spacing) >= MagickEpsilon))
+      (fabs((CurrentContext->interword_spacing-interword_spacing)) >= MagickEpsilon))
     {
       CurrentContext->interword_spacing=interword_spacing;
       (void) MVGPrintf(wand,"interword-spacing %lf\n",interword_spacing);


### PR DESCRIPTION
Fixed bogus code that didn't allow for DrawSetTextInterlineSpacing,DrawSetTextKerning & DrawSetInterwordSpacing to be changed, because of a missing absolute value.

#478 