### PR TITLE
make DICOM read work for fractional rescale

### DIFF
--- a/coders/dcm.c
+++ b/coders/dcm.c
@@ -3104,7 +3104,7 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
   info.samples_per_pixel=1;
   info.signed_data=(~0UL);
   info.significant_bits=0;
-  info.rescale=0;
+  info.rescale=MagickFalse;
   info.rescale_intercept=0.0;
   info.rescale_slope=1.0;
   info.window_center=0.0;
@@ -4097,8 +4097,7 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
           }
         option=GetImageOption(image_info,"dcm:rescale");
         if (option != (char *) NULL)
-          info.rescale=(int) ParseCommandOption(MagickBooleanOptions,
-            MagickFalse,option);
+          info.rescale=IsStringTrue(option);
         status=ReadDCMPixels(image,&info,stream_info,MagickTrue,exception);
         if ((status != MagickFalse) && (stream_info->segment_count > 1))
           {

--- a/coders/dcm.c
+++ b/coders/dcm.c
@@ -2693,13 +2693,16 @@ typedef struct _DCMInfo
     max_value,
     samples_per_pixel,
     signed_data,
-    significant_bits,
-    window_width;
+    significant_bits;
 
-  ssize_t
+  MagickBooleanType
+    rescale;
+
+  double
     rescale_intercept,
     rescale_slope,
-    window_center;
+    window_center,
+    window_width;
 } DCMInfo;
 
 typedef struct _DCMStreamInfo
@@ -2877,32 +2880,43 @@ static MagickBooleanType ReadDCMPixels(Image *image,DCMInfo *info,
                   }
                 i++;
               }
-          index=(int) ((pixel_value*info->rescale_slope)+
-            info->rescale_intercept);
-          if (info->window_width == 0)
+          if (info->rescale)
             {
-              if (info->signed_data == 1)
-                index-=32767;
+              double
+                scaled_value;
+
+              scaled_value=pixel_value*info->rescale_slope+
+                info->rescale_intercept;
+              if (info->window_width == 0)
+                {
+                  index=(int) scaled_value;
+                }
+              else
+                {
+                  double
+                    window_max,
+                    window_min;
+    
+                  window_min=ceil(info->window_center-
+                    (info->window_width-1.0)/2.0-0.5);
+                  window_max=floor(info->window_center+
+                    (info->window_width-1.0)/2.0+0.5);
+                  if (scaled_value <= window_min)
+                    index=0;
+                  else
+                    if (scaled_value > window_max)
+                      index=(int) info->max_value;
+                    else
+                      index=(int) (info->max_value*(((scaled_value-
+                        info->window_center-0.5)/(info->window_width-1))+0.5));
+                }
             }
           else
             {
-              ssize_t
-                window_max,
-                window_min;
-
-              window_min=(ssize_t) ceil((double) info->window_center-
-                (info->window_width-1.0)/2.0-0.5);
-              window_max=(ssize_t) floor((double) info->window_center+
-                (info->window_width-1.0)/2.0+0.5);
-              if ((ssize_t) index <= window_min)
-                index=0;
-              else
-                if ((ssize_t) index > window_max)
-                  index=(int) info->max_value;
-                else
-                  index=(int) (info->max_value*(((index-info->window_center-
-                    0.5)/(info->window_width-1))+0.5));
+              index=pixel_value;
             }
+          if (info->signed_data == 1)
+            index-=32767;
           index&=info->mask;
           index=(int) ConstrainColormapIndex(image,(size_t) index);
           if (first_segment != MagickFalse)
@@ -3080,20 +3094,21 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
     Read DCM Medical image.
   */
   (void) CopyMagickString(photometric,"MONOCHROME1 ",MaxTextExtent);
+  info.polarity=MagickFalse;
+  info.scale=(Quantum *) NULL;
   info.bits_allocated=8;
   info.bytes_per_pixel=1;
   info.depth=8;
-  info.max_value=255UL;
   info.mask=0xffff;
-  info.rescale_intercept=0;
-  info.rescale_slope=1;
+  info.max_value=255UL;
   info.samples_per_pixel=1;
-  info.scale=(Quantum *) NULL;
   info.signed_data=(~0UL);
   info.significant_bits=0;
-  info.window_center=0;
-  info.window_width=0;
-  info.polarity=MagickFalse;
+  info.rescale=0;
+  info.rescale_intercept=0.0;
+  info.rescale_slope=1.0;
+  info.window_center=0.0;
+  info.window_width=0.0;
   data=(unsigned char *) NULL;
   element=0;
   explicit_vr[2]='\0';
@@ -3496,7 +3511,8 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
               Visible pixel range: center.
             */
             if (data != (unsigned char *) NULL)
-              info.window_center=(ssize_t) StringToLong((char *) data);
+              info.window_center=StringToDouble((char *) data,
+                (char **) NULL);
             break;
           }
           case 0x1051:
@@ -3505,7 +3521,8 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
               Visible pixel range: width.
             */
             if (data != (unsigned char *) NULL)
-              info.window_width=StringToUnsignedLong((char *) data);
+              info.window_width=StringToDouble((char *) data,
+                (char **) NULL);
             break;
           }
           case 0x1052:
@@ -3514,7 +3531,8 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
               Rescale intercept
             */
             if (data != (unsigned char *) NULL)
-              info.rescale_intercept=(ssize_t) StringToLong((char *) data);
+              info.rescale_intercept=StringToDouble((char *) data,
+                (char **) NULL);
             break;
           }
           case 0x1053:
@@ -3523,7 +3541,8 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
               Rescale slope
             */
             if (data != (unsigned char *) NULL)
-              info.rescale_slope=(ssize_t) StringToLong((char *) data);
+              info.rescale_slope=StringToDouble((char *) data,
+                (char **) NULL);
             break;
           }
           case 0x1200:
@@ -4076,6 +4095,10 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
             if (LocaleCompare(option,"reset") == 0)
               info.window_width=0;
           }
+        option=GetImageOption(image_info,"dcm:rescale");
+        if (option != (char *) NULL)
+          info.rescale=(int) ParseCommandOption(MagickBooleanOptions,
+            MagickFalse,option);
         status=ReadDCMPixels(image,&info,stream_info,MagickTrue,exception);
         if ((status != MagickFalse) && (stream_info->segment_count > 1))
           {


### PR DESCRIPTION
The DICOM reader was multiplying pixel values by `rescale_slope`, which it
represented as `ssize_t`. Many DICOM files use double values for
`rescale_slope`, so for `rescale_slope` < 1, the reader was multiplying by
zero and producing blank images.

This patch changes `rescale_slope` and `rescale_intercept` to be double, so
dcm read now works with fractional values of rescale.
This patch should be applied to the 7.x branch as well.

This patch incorporates a couple of other small changes too:

* Previous versions of ImageMagick did not apply the rescale
  values, so for compatibility, application of them now defaults to
  off. Use `-define dcm:rescale` to enable rescale processing.

* `window_center` and `window_width` should also be double-valued, from
  the spec.

* The `window_center` and `window_width` fields were always applied before,
  but from the DICOM spec, they should be only be applied to the rescaled
  values.

  The patch makes width and center processing only happen if `dcm:rescale`
  is on.

* Previously, the offset for signed data was only being applied if
  windowing was disabled. It is now always applied.

Here's a sample file that shows the problem:

http://www.rollthepotato.net/~john/MRIm5.dcm

You're welcome to use this image in a test suite. Before this patch:

$ identify -verbose MRIm5.dcm
Image: MRIm5.dcm
Format: DCM (Digital Imaging and Communications in Medicine image)
Gray:
min: 32769 (0.500023)
max: 32769 (0.500023)

After:

$ identify -verbose MRIm5.dcm
Image: MRIm5.dcm
Format: DCM (Digital Imaging and Communications in Medicine image)
Gray:
min: 0 (0)
max: 65535 (1)

Forum thread:

https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=31887&p=145852

Related PR:

https://github.com/ImageMagick/ImageMagick/pull/477