### PR TITLE
add dcm:window option

### DIFF
--- a/coders/dcm.c
+++ b/coders/dcm.c
@@ -2880,6 +2880,8 @@ static MagickBooleanType ReadDCMPixels(Image *image,DCMInfo *info,
                   }
                 i++;
               }
+          if (info->signed_data == 1)
+            pixel_value-=32767;
           if (info->rescale)
             {
               double
@@ -2914,8 +2916,6 @@ static MagickBooleanType ReadDCMPixels(Image *image,DCMInfo *info,
           else
             {
               index=pixel_value;
-              if (info->signed_data == 1)
-                index-=32767;
             }
           index&=info->mask;
           index=(int) ConstrainColormapIndex(image,(size_t) index);
@@ -4093,15 +4093,12 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
             if (LocaleCompare(option,"reset") == 0)
               info.window_width=0;
           }
-        option=GetImageOption(image_info,"dcm:rescale");
-        if (option != (char *) NULL)
-          info.rescale=(int) ParseCommandOption(MagickBooleanOptions,
-	    MagickFalse,option);
         option=GetImageOption(image_info,"dcm:window");
         if (option != (char *) NULL)
 	  {
             GeometryInfo
               geometry_info;
+
             MagickStatusType
               flags;
 
@@ -4110,7 +4107,12 @@ static Image *ReadDCMImage(const ImageInfo *image_info,ExceptionInfo *exception)
               info.window_center=geometry_info.rho;
             if (flags & SigmaValue)
 	      info.window_width=geometry_info.sigma;
+            info.rescale=MagickTrue;
 	  }
+        option=GetImageOption(image_info,"dcm:rescale");
+        if (option != (char *) NULL)
+          info.rescale=(int) ParseCommandOption(MagickBooleanOptions,
+	    MagickFalse,option);
         if ((info.window_center != 0) && (info.window_width == 0))
           info.window_width=info.window_center;
         status=ReadDCMPixels(image,&info,stream_info,MagickTrue,exception);


### PR DESCRIPTION
This patch adds a new `dcm:window` option which lets you override the
window center and width stored in the DICOM file with a new centerXwidth
pair. You can also use centerX or Xwidth. The window settings are ony
applied if the `dcm:rescale` option is enabled.

This is useful for transforming images from scan units to display units for
visualisation.

Example:

convert -define dcm:rescale -define dcm:window=2500x3000 MRIm5.dcm x.tif

This patch also reverts an earlier change which moved the transform for
signed data into the main path. Window handling assumes a 0 - `max_value`
output range and takes no account of signedness of the data, so
the subtract for signed data is not appropriate. Perhaps it should be,
but we'd need to track `min_value` as well, and that's beyound the scope
of this PR.

Related PR:

https://github.com/ImageMagick/ImageMagick/pull/483

DICOM spec:

https://www.dabsoft.ch/dicom/3/C.11.2.1.2/