### PR TITLE
revise dcm rescale and window handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-05-10  7.0.5-6 John Cupitt <jcupitt@gmail.com>
+  * Revise DICOM window and rescale handling (reference 
+    https://github.com/ImageMagick/ImageMagick/pull/484)
+
 2017-05-06  7.0.5-6 Cristy  <quetzlzacatenango@image...>
   * Restore the -alpha Shape option (reference
     https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=31879).


### PR DESCRIPTION
The DICOM reader was multiplying pixel values by `rescale_slope`, which
it represented as `ssize_t`. Many DICOM files use double values for
`rescale_slope`, so for `rescale_slope` < 1, the reader was multiplying by
zero and producing blank images.

This patch changes `rescale_slope` and `rescale_intercept` to be double,
so dcm read now works with fractional values of rescale. A new option,
`dcm:rescale` turns rescale processing on. It is off by default for
compatibility with older versions.

The `window_center` and `window_width` fields must also be held as doubles.
These fields are now only interpreted if rescale processing is enabled,
since according to the spec, they should operate upon the rescaled
values.

A second new option, `dcm:window`, lets users overrride the
`window_center` and `window_width` fields from the file with their own
settings. This is a standard feature in other DICOM software.

Forum thread:

https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=31887&p=145852

Related PRs:

https://github.com/ImageMagick/ImageMagick/pull/477
https://github.com/ImageMagick/ImageMagick/pull/483
https://github.com/ImageMagick/Website/pull/1

DICOM spec:

https://www.dabsoft.ch/dicom/3/C.11.2.1.2/