### PR TITLE
fix gif loop iterations

### DIFF
--- a/coders/gif.c
+++ b/coders/gif.c
@@ -1111,7 +1111,11 @@ static Image *ReadGIFImage(const ImageInfo *image_info,ExceptionInfo *exception)
             if (loop != MagickFalse)
               {
                 while (ReadBlobBlock(image,buffer) != 0)
+                {
                   iterations=(size_t) ((buffer[2] << 8) | buffer[1]);
+                  if (iterations)
+                    iterations++;
+                }
                 break;
               }
             else
@@ -1739,7 +1743,7 @@ static MagickBooleanType WriteGIFImage(const ImageInfo *image_info,Image *image,
             (void) WriteBlob(image,11,(unsigned char *) "NETSCAPE2.0");
             (void) WriteBlobByte(image,(unsigned char) 0x03);
             (void) WriteBlobByte(image,(unsigned char) 0x01);
-            (void) WriteBlobLSBShort(image,(unsigned short) image->iterations);
+            (void) WriteBlobLSBShort(image,(unsigned short) (image->iterations ? image->iterations - 1 : 0));
             (void) WriteBlobByte(image,(unsigned char) 0x00);
           }
         if ((image->gamma != 1.0f/2.2f))


### PR DESCRIPTION
Value 0 in "NETSCAPE2.0" means loop forever.
Missing "NETSCAPE2.0" block means 0 repetitions = loop once.
Value 1 in "NETSCAPE2.0" means 1 repetition = 2 loops.
Value 2 in "NETSCAPE2.0" means 2 repetitions = 3 loops.

https://bugs.chromium.org/p/chromium/issues/detail?id=592735
https://bugzilla.mozilla.org/show_bug.cgi?id=1255497
https://stackoverflow.com/questions/27066511/how-to-make-an-animated-gif-loop-twice-in-imagemagick