### PR TITLE
coders/mat.c: fix build failure due to incomplete #624 patch

### DIFF
--- a/coders/mat.c
+++ b/coders/mat.c
@@ -1368,10 +1368,14 @@ END_OF_READING:
   }
   if (logging) (void)LogMagickEvent(CoderEvent,GetMagickModule(),"return");
   if (image==NULL)
+  {
     ThrowReaderException(CorruptImageError,"ImproperImageHeader")
+  }
   else
+  {
     if ((image != image2) && (image2 != (Image *) NULL))
       image2=DestroyImage(image2);
+  }
   return (image);
 }
 

--- a/coders/mat.c
+++ b/coders/mat.c
@@ -1369,7 +1369,7 @@ END_OF_READING:
   if (logging) (void)LogMagickEvent(CoderEvent,GetMagickModule(),"return");
   if (image==NULL)
   {
-    ThrowReaderException(CorruptImageError,"ImproperImageHeader")
+    ThrowReaderException(CorruptImageError,"ImproperImageHeader");
   }
   else
   {


### PR DESCRIPTION
Fix for #624 introduced a race condition on the else branch, leading to a FTBFS:
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -I./config -I. -I../.. -Wdate-time -D_FORTIFY_SOURCE=2 -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -I/usr/include/X11 -I/usr/include/libxml2 -I/usr/include/libpng16 -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/OpenEXR -I/usr/include/lqr-1 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/freetype2 -I/usr/include/freetype2 -pthread -fopenmp -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/imagemagick-6.9.7.4+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -fexceptions -pthread -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -c ../../coders/mat.c  -fPIC -DPIC -o coders/.libs/coders_mat_la-mat.o
../../coders/mat.c: In function ‘ReadMATImage’:
../../coders/mat.c:1372:3: error: ‘else’ without a previous ‘if’
   else
   ^~~~
Makefile:7883: recipe for target 'coders/coders_mat_la-mat.lo' failed

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=870047