### PR TITLE
bug fix about word-spacing

### DIFF
--- a/MagickWand/drawing-wand.c
+++ b/MagickWand/drawing-wand.c
@@ -6078,7 +6078,7 @@ WandExport void DrawSetTextInterlineSpacing(DrawingWand *wand,
 
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",wand->name);
-  if ((wand->filter_off != MagickFalse) &&
+  if ((wand->filter_off != MagickFalse) ||
       (fabs((CurrentContext->interline_spacing-
         interline_spacing)) >= MagickEpsilon))
     {
@@ -6120,7 +6120,7 @@ WandExport void DrawSetTextInterwordSpacing(DrawingWand *wand,
 
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",wand->name);
-  if ((wand->filter_off != MagickFalse) &&
+  if ((wand->filter_off != MagickFalse) ||
       (fabs((CurrentContext->interword_spacing-
         interword_spacing)) >= MagickEpsilon))
     {


### PR DESCRIPTION
should use '||' instead of '&&' to check when set word-spacing