### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Let Git determine what is a text file and handle line ending normalization
+* text=auto
+
+# Files on Windows that should retain LF line endings
+*.sh        eol=lf
+Makefile*   eol=lf


### PR DESCRIPTION
I'm going to assume everyone knows what a `.gitattributes` file is, so I won't go over that here. If not please ask.

The main benefit to having this (especially the `* text=auto` part) is repository-centric handling of EOL characters and conversions, which completely supersede the `core.eol` and `core.autocrlf` settings, which are a nightmare to setup properly depending on platform.

I followed [github's recommended process for normalizing line endings](https://help.github.com/articles/dealing-with-line-endings/#refreshing-a-repository-after-changing-line-endings) in the repository, and I didn't see any conversions needed.

Please let me know which files must explicitly maintain LF line endings on Windows platform, because that is the only thing that needs to be explicitly set up in the `.gitattributes` file. For example, *.sh scripts usually won't work on Windows with CRLF line endings (when executing them through mingw).