### PR TITLE
bugfix: (thread-safty) the id would be changed before it is returned. 

### DIFF
--- a/MagickWand/wand.c
+++ b/MagickWand/wand.c
@@ -75,7 +75,7 @@ WandExport size_t AcquireWandId(void)
 {
   static size_t
     id = 0;
-
+  size_t nID = 0;
   if (wand_semaphore == (SemaphoreInfo *) NULL)
     ActivateSemaphoreInfo(&wand_semaphore);
   LockSemaphoreInfo(wand_semaphore);
@@ -85,8 +85,9 @@ WandExport size_t AcquireWandId(void)
   id++;
   (void) AddValueToSplayTree(wand_ids,(const void *) id,(const void *) id);
   instantiate_wand=MagickTrue;
+  nID = id;
   UnlockSemaphoreInfo(wand_semaphore);
-  return(id);
+  return(nID);
 }
 
 /*
@@ -147,6 +148,6 @@ WandExport void RelinquishWandId(const size_t id)
 {
   LockSemaphoreInfo(wand_semaphore);
   if (wand_ids != (SplayTreeInfo *) NULL)
-    (void) DeleteNodeByValueFromSplayTree(wand_ids,(const void *) id);
+    (void) DeleteNodeFromSplayTree(wand_ids,(const void *) id);
   UnlockSemaphoreInfo(wand_semaphore);
 }

--- a/MagickWand/wand.c
+++ b/MagickWand/wand.c
@@ -75,7 +75,7 @@ WandExport size_t AcquireWandId(void)
 {
   static size_t
     id = 0;
-  size_t nID = 0;
+  size_t wand_id = 0;
   if (wand_semaphore == (SemaphoreInfo *) NULL)
     ActivateSemaphoreInfo(&wand_semaphore);
   LockSemaphoreInfo(wand_semaphore);
@@ -85,9 +85,9 @@ WandExport size_t AcquireWandId(void)
   id++;
   (void) AddValueToSplayTree(wand_ids,(const void *) id,(const void *) id);
   instantiate_wand=MagickTrue;
-  nID = id;
+  wand_id = id;
   UnlockSemaphoreInfo(wand_semaphore);
-  return(nID);
+  return(wand_id);
 }
 
 /*


### PR DESCRIPTION
the code in wand/wand.c is not thread-safe. The id would be changed before it returned. That would cause memory leaking and performance drop down after a long time running. 

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
