### PR TITLE
fix memory leak in ReadYCBCRImage as SetImageExtent failure

### DIFF
--- a/coders/ycbcr.c
+++ b/coders/ycbcr.c
@@ -212,6 +212,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
     if (status == MagickFalse)
     {
       quantum_info=DestroyQuantumInfo(quantum_info);
+      canvas_image=DestroyImage(canvas_image);
       return(DestroyImageList(image));
     }
     SetImageColorspace(image,YCbCrColorspace,exception);

--- a/coders/ycbcr.c
+++ b/coders/ycbcr.c
@@ -210,7 +210,10 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         break;
     status=SetImageExtent(image,image->columns,image->rows,exception);
     if (status == MagickFalse)
+    {
+      quantum_info=DestroyQuantumInfo(quantum_info);
       return(DestroyImageList(image));
+    }
     SetImageColorspace(image,YCbCrColorspace,exception);
     switch (image_info->interlace)
     {


### PR DESCRIPTION

Here is critical code:
```
  //...

  quantum_info=AcquireQuantumInfo(image_info,canvas_image);
  if (quantum_info == (QuantumInfo *) NULL)
    ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");

 //...

    status=SetImageExtent(image,image->columns,image->rows,exception);
    if (status == MagickFalse)
      return(DestroyImageList(image));    //should free the memory about quantum_info

//...


Credit: ADLab of Venustech

