### PR TITLE
fix multiple memory leak in ReadYUVImage

### DIFF
--- a/coders/ycbcr.c
+++ b/coders/ycbcr.c
@@ -212,6 +212,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
     if (status == MagickFalse)
     {
       quantum_info=DestroyQuantumInfo(quantum_info);
+      canvas_image=DestroyImage(canvas_image);
       return(DestroyImageList(image));
     }
     SetImageColorspace(image,YCbCrColorspace,exception);

--- a/coders/ycbcr.c
+++ b/coders/ycbcr.c
@@ -210,7 +210,10 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         break;
     status=SetImageExtent(image,image->columns,image->rows,exception);
     if (status == MagickFalse)
+    {
+      quantum_info=DestroyQuantumInfo(quantum_info);
       return(DestroyImageList(image));
+    }
     SetImageColorspace(image,YCbCrColorspace,exception);
     switch (image_info->interlace)
     {

--- a/coders/ycbcr.c
+++ b/coders/ycbcr.c
@@ -151,7 +151,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
   status=SetImageExtent(image,image->columns,image->rows,exception);
   if (status == MagickFalse)
     return(DestroyImageList(image));
-  SetImageColorspace(image,YCbCrColorspace,exception);
+  (void) SetImageColorspace(image,YCbCrColorspace,exception);
   if (image_info->interlace != PartitionInterlace)
     {
       status=OpenBlob(image_info,image,ReadBinaryBlobMode,exception);
@@ -160,7 +160,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
           image=DestroyImageList(image);
           return((Image *) NULL);
         }
-      if (DiscardBlobBytes(image,image->offset) == MagickFalse)
+      if (DiscardBlobBytes(image,(MagickSizeType) image->offset) == MagickFalse)
         ThrowFileException(exception,CorruptImageError,"UnexpectedEndOfFile",
           image->filename);
     }
@@ -200,6 +200,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
   count=0;
   length=0;
   scene=0;
+  status=MagickTrue;
   do
   {
     /*
@@ -210,12 +211,9 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         break;
     status=SetImageExtent(image,image->columns,image->rows,exception);
     if (status == MagickFalse)
-    {
-      quantum_info=DestroyQuantumInfo(quantum_info);
-      canvas_image=DestroyImage(canvas_image);
-      return(DestroyImageList(image));
-    }
-    SetImageColorspace(image,YCbCrColorspace,exception);
+      break;
+    if (SetImageColorspace(image,YCbCrColorspace,exception) == MagickFalse)
+      break;
     switch (image_info->interlace)
     {
       case NoInterlace:
@@ -234,6 +232,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         {
           if (count != (ssize_t) length)
             {
+              status=MagickFalse;
               ThrowFileException(exception,CorruptImageError,
                 "UnexpectedEndOfFile",image->filename);
               break;
@@ -303,10 +302,11 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
           }
         for (y=0; y < (ssize_t) image->extract_info.height; y++)
         {
-          for (i=0; i < (image->alpha_trait != UndefinedPixelTrait ? 4 : 3); i++)
+          for (i=0; i < (ssize_t) (image->alpha_trait != UndefinedPixelTrait ? 4 : 3); i++)
           {
             if (count != (ssize_t) length)
               {
+                status=MagickFalse;
                 ThrowFileException(exception,CorruptImageError,
                   "UnexpectedEndOfFile",image->filename);
                 break;
@@ -391,6 +391,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         {
           if (count != (ssize_t) length)
             {
+              status=MagickFalse;
               ThrowFileException(exception,CorruptImageError,
                 "UnexpectedEndOfFile",image->filename);
               break;
@@ -435,6 +436,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         {
           if (count != (ssize_t) length)
             {
+              status=MagickFalse;
               ThrowFileException(exception,CorruptImageError,
                 "UnexpectedEndOfFile",image->filename);
               break;
@@ -479,6 +481,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         {
           if (count != (ssize_t) length)
             {
+              status=MagickFalse;
               ThrowFileException(exception,CorruptImageError,
                 "UnexpectedEndOfFile",image->filename);
               break;
@@ -525,6 +528,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
             {
               if (count != (ssize_t) length)
                 {
+                  status=MagickFalse;
                   ThrowFileException(exception,CorruptImageError,
                     "UnexpectedEndOfFile",image->filename);
                   break;
@@ -588,7 +592,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
             image=DestroyImageList(image);
             return((Image *) NULL);
           }
-        if (DiscardBlobBytes(image,image->offset) == MagickFalse)
+        if (DiscardBlobBytes(image,(MagickSizeType) image->offset) == MagickFalse)
           ThrowFileException(exception,CorruptImageError,"UnexpectedEndOfFile",
             image->filename);
         length=GetQuantumExtent(canvas_image,quantum_info,RedQuantum);
@@ -599,6 +603,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
               GetQuantumPixels(quantum_info),&count);
             if (count != (ssize_t) length)
               {
+                status=MagickFalse;
                 ThrowFileException(exception,CorruptImageError,
                   "UnexpectedEndOfFile",image->filename);
                 break;
@@ -610,6 +615,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         {
           if (count != (ssize_t) length)
             {
+              status=MagickFalse;
               ThrowFileException(exception,CorruptImageError,
                 "UnexpectedEndOfFile",image->filename);
               break;
@@ -667,6 +673,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
               GetQuantumPixels(quantum_info),&count);
             if (count != (ssize_t) length)
               {
+                status=MagickFalse;
                 ThrowFileException(exception,CorruptImageError,
                   "UnexpectedEndOfFile",image->filename);
                 break;
@@ -678,6 +685,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         {
           if (count != (ssize_t) length)
             {
+              status=MagickFalse;
               ThrowFileException(exception,CorruptImageError,
                 "UnexpectedEndOfFile",image->filename);
               break;
@@ -735,6 +743,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
               GetQuantumPixels(quantum_info),&count);
             if (count != (ssize_t) length)
               {
+                status=MagickFalse;
                 ThrowFileException(exception,CorruptImageError,
                   "UnexpectedEndOfFile",image->filename);
                 break;
@@ -746,6 +755,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
         {
           if (count != (ssize_t) length)
             {
+              status=MagickFalse;
               ThrowFileException(exception,CorruptImageError,
                 "UnexpectedEndOfFile",image->filename);
               break;
@@ -805,6 +815,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
                   GetQuantumPixels(quantum_info),&count);
                 if (count != (ssize_t) length)
                   {
+                    status=MagickFalse;
                     ThrowFileException(exception,CorruptImageError,
                       "UnexpectedEndOfFile",image->filename);
                     break;
@@ -816,6 +827,7 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
             {
               if (count != (ssize_t) length)
                 {
+                  status=MagickFalse;
                   ThrowFileException(exception,CorruptImageError,
                     "UnexpectedEndOfFile",image->filename);
                   break;
@@ -896,6 +908,8 @@ static Image *ReadYCBCRImage(const ImageInfo *image_info,
   quantum_info=DestroyQuantumInfo(quantum_info);
   canvas_image=DestroyImage(canvas_image);
   (void) CloseBlob(image);
+  if (status == MagickFalse)
+    return(DestroyImageList(image));
   return(GetFirstImageInList(image));
 }
 

--- a/coders/yuv.c
+++ b/coders/yuv.c
@@ -207,7 +207,10 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
       horizontal_factor,(image->rows+vertical_factor-1)/vertical_factor,
       MagickTrue,exception);
     if (chroma_image == (Image *) NULL)
-      ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
+      {
+	    scanline=(unsigned char *) RelinquishMagickMemory(scanline);
+	    ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
+	  }
     /*
       Convert raster image to pixel packets.
     */
@@ -216,13 +219,17 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
         break;
     status=SetImageExtent(image,image->columns,image->rows,exception);
     if (status == MagickFalse)
-      return(DestroyImageList(image));
+      {
+	    scanline=(unsigned char *) RelinquishMagickMemory(scanline);
+	    return(DestroyImageList(image));
+	  }
     if (interlace == PartitionInterlace)
       {
         AppendImageFormat("Y",image->filename);
         status=OpenBlob(image_info,image,ReadBinaryBlobMode,exception);
         if (status == MagickFalse)
           {
+		    scanline=(unsigned char *) RelinquishMagickMemory(scanline);
             image=DestroyImageList(image);
             return((Image *) NULL);
           }
@@ -329,6 +336,7 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
         status=OpenBlob(image_info,image,ReadBinaryBlobMode,exception);
         if (status == MagickFalse)
           {
+            scanline=(unsigned char *) RelinquishMagickMemory(scanline);
             image=DestroyImageList(image);
             return((Image *) NULL);
           }
@@ -367,6 +375,7 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
           status=OpenBlob(image_info,image,ReadBinaryBlobMode,exception);
           if (status == MagickFalse)
             {
+              scanline=(unsigned char *) RelinquishMagickMemory(scanline);
               image=DestroyImageList(image);
               return((Image *) NULL);
             }
@@ -402,7 +411,10 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
       TriangleFilter,exception);
     chroma_image=DestroyImage(chroma_image);
     if (resize_image == (Image *) NULL)
-      ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
+      {
+        scanline=(unsigned char *) RelinquishMagickMemory(scanline);
+        ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
+      }
     for (y=0; y < (ssize_t) image->rows; y++)
     {
       q=GetAuthenticPixels(image,0,y,image->columns,1,exception);
@@ -450,6 +462,7 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
         AcquireNextImage(image_info,image,exception);
         if (GetNextImageInList(image) == (Image *) NULL)
           {
+            scanline=(unsigned char *) RelinquishMagickMemory(scanline);
             image=DestroyImageList(image);
             return((Image *) NULL);
           }

--- a/coders/yuv.c
+++ b/coders/yuv.c
@@ -124,9 +124,12 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
   ssize_t
     count,
     horizontal_factor,
-    quantum,
     vertical_factor,
     y;
+
+  size_t
+    length,
+    quantum;
 
   unsigned char
     *scanline;
@@ -147,7 +150,7 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
   status=SetImageExtent(image,image->columns,image->rows,exception);
   if (status == MagickFalse)
     return(DestroyImageList(image));
-  quantum=image->depth <= 8 ? 1 : 2;
+  quantum=(ssize_t) (image->depth <= 8 ? 1 : 2);
   interlace=image_info->interlace;
   horizontal_factor=2;
   vertical_factor=2;
@@ -186,7 +189,7 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
           image=DestroyImageList(image);
           return((Image *) NULL);
         }
-      if (DiscardBlobBytes(image,image->offset) == MagickFalse)
+      if (DiscardBlobBytes(image,(MagickSizeType) image->offset) == MagickFalse)
         ThrowFileException(exception,CorruptImageError,"UnexpectedEndOfFile",
           image->filename);
     }
@@ -194,13 +197,14 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
     Allocate memory for a scanline.
   */
   if (interlace == NoInterlace)
-    scanline=(unsigned char *) AcquireQuantumMemory((size_t) 2UL*
-      image->columns+2UL,quantum*sizeof(*scanline));
+    scanline=(unsigned char *) AcquireQuantumMemory((size_t) (2UL*
+      image->columns+2UL),(size_t) quantum*sizeof(*scanline));
   else
     scanline=(unsigned char *) AcquireQuantumMemory(image->columns,
-      quantum*sizeof(*scanline));
+      (size_t) quantum*sizeof(*scanline));
   if (scanline == (unsigned char *) NULL)
     ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
+  status=MagickTrue;
   do
   {
     chroma_image=CloneImage(image,(image->columns+horizontal_factor-1)/
@@ -208,9 +212,9 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
       MagickTrue,exception);
     if (chroma_image == (Image *) NULL)
       {
-	    scanline=(unsigned char *) RelinquishMagickMemory(scanline);
-	    ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
-	  }
+        scanline=(unsigned char *) RelinquishMagickMemory(scanline);
+        ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
+      }
     /*
       Convert raster image to pixel packets.
     */
@@ -219,17 +223,14 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
         break;
     status=SetImageExtent(image,image->columns,image->rows,exception);
     if (status == MagickFalse)
-      {
-	    scanline=(unsigned char *) RelinquishMagickMemory(scanline);
-	    return(DestroyImageList(image));
-	  }
+      break;
     if (interlace == PartitionInterlace)
       {
         AppendImageFormat("Y",image->filename);
         status=OpenBlob(image_info,image,ReadBinaryBlobMode,exception);
         if (status == MagickFalse)
           {
-		    scanline=(unsigned char *) RelinquishMagickMemory(scanline);
+            scanline=(unsigned char *) RelinquishMagickMemory(scanline);
             image=DestroyImageList(image);
             return((Image *) NULL);
           }
@@ -242,7 +243,17 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
       if (interlace == NoInterlace)
         {
           if ((y > 0) || (GetPreviousImageInList(image) == (Image *) NULL))
-            count=ReadBlob(image,(size_t) (2*quantum*image->columns),scanline);
+            {
+              length=2*quantum*image->columns;
+              count=ReadBlob(image,length,scanline);
+              if (count != (ssize_t) length)
+                {
+                  status=MagickFalse;
+                  ThrowFileException(exception,CorruptImageError,
+                    "UnexpectedEndOfFile",image->filename);
+                  break;
+                }
+            }
           p=scanline;
           q=QueueAuthenticPixels(image,0,y,image->columns,1,exception);
           if (q == (Quantum *) NULL)
@@ -297,7 +308,17 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
       else
         {
           if ((y > 0) || (GetPreviousImageInList(image) == (Image *) NULL))
-            count=ReadBlob(image,(size_t) quantum*image->columns,scanline);
+            {
+              length=quantum*image->columns;
+              count=ReadBlob(image,length,scanline);
+              if (count != (ssize_t) length)
+                {
+                  status=MagickFalse;
+                  ThrowFileException(exception,CorruptImageError,
+                    "UnexpectedEndOfFile",image->filename);
+                  break;
+                }
+            }
           p=scanline;
           q=QueueAuthenticPixels(image,0,y,image->columns,1,exception);
           if (q == (Quantum *) NULL)
@@ -345,7 +366,15 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
       {
         for (y=0; y < (ssize_t) chroma_image->rows; y++)
         {
-          count=ReadBlob(image,(size_t) quantum*chroma_image->columns,scanline);
+          length=quantum*chroma_image->columns;
+          count=ReadBlob(image,length,scanline);
+          if (count != (ssize_t) length)
+            {
+              status=MagickFalse;
+              ThrowFileException(exception,CorruptImageError,
+                "UnexpectedEndOfFile",image->filename);
+              break;
+            }
           p=scanline;
           q=QueueAuthenticPixels(chroma_image,0,y,chroma_image->columns,1,
             exception);
@@ -382,7 +411,15 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
         }
       for (y=0; y < (ssize_t) chroma_image->rows; y++)
       {
-        count=ReadBlob(image,(size_t) quantum*chroma_image->columns,scanline);
+        length=quantum*chroma_image->columns;
+        count=ReadBlob(image,length,scanline);
+        if (count != (ssize_t) length)
+          {
+            status=MagickFalse;
+            ThrowFileException(exception,CorruptImageError,
+              "UnexpectedEndOfFile",image->filename);
+            break;
+          }
         p=scanline;
         q=GetAuthenticPixels(chroma_image,0,y,chroma_image->columns,1,
           exception);
@@ -434,7 +471,8 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
         break;
     }
     resize_image=DestroyImage(resize_image);
-    SetImageColorspace(image,YCbCrColorspace,exception);
+    if (SetImageColorspace(image,YCbCrColorspace,exception) == MagickFalse)
+      break;
     if (interlace == PartitionInterlace)
       (void) CopyMagickString(image->filename,image_info->filename,
         MagickPathExtent);
@@ -475,6 +513,8 @@ static Image *ReadYUVImage(const ImageInfo *image_info,ExceptionInfo *exception)
   } while (count != 0);
   scanline=(unsigned char *) RelinquishMagickMemory(scanline);
   (void) CloseBlob(image);
+  if (status == MagickFalse)
+    return(DestroyImageList(image));
   return(GetFirstImageInList(image));
 }
 


### PR DESCRIPTION
We found that there is multiple memory leak vulnerability in ReadYUVImage  because no memory free on exception condition. And we create patch here.

Credit: ADLab of Venustech