### PR TITLE
Fix RFG > RGF typo in format docs

### DIFF
--- a/ImageMagick/script/formats.html
+++ b/ImageMagick/script/formats.html
@@ -933,7 +933,7 @@ convert \( -size 15x15 canvas:black canvas:white -append \) \
   </tr>
 
   <tr>
-    <td>RFG</td>
+    <td>RGF</td>
     <td>RW</td>
     <td>LEGO Mindstorms EV3 Robot Graphics File</td>
     <td> </td>

--- a/www/formats.html
+++ b/www/formats.html
@@ -962,7 +962,7 @@ convert \( -size 15x15 canvas:black canvas:white -append \) \
   </tr>
 
   <tr>
-    <td>RFG</td>
+    <td>RGF</td>
     <td>RW</td>
     <td>LEGO Mindstorms EV3 Robot Graphics File</td>
     <td> </td>


### PR DESCRIPTION


### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

I noticed this was wrong on the ImageMagick website.

The file extension is .rgf (robot graphics file)
