### PR TITLE
Reset magick_list_initialized when needed

### DIFF
--- a/magick/magick.c
+++ b/magick/magick.c
@@ -1075,7 +1075,10 @@ MagickExport void MagickComponentTerminus(void)
     ActivateSemaphoreInfo(&magick_semaphore);
   LockSemaphoreInfo(magick_semaphore);
   if (magick_list != (SplayTreeInfo *) NULL)
-    magick_list=DestroySplayTree(magick_list);
+    {
+      magick_list=DestroySplayTree(magick_list);
+      magick_list_initialized=MagickFalse;
+    }
   UnlockSemaphoreInfo(magick_semaphore);
   DestroySemaphoreInfo(&magick_semaphore);
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

This fixes #825 by resetting the `magick_list_initialized` boolean when needed.
Failure to do so makes it impossible to re-init magick_list as it is already
marked as initialized even if it was destroyed.

<!-- Thanks for contributing to ImageMagick! -->
