### PR TITLE
Added missing comma to data json for delay key

### DIFF
--- a/coders/json.c
+++ b/coders/json.c
@@ -1425,7 +1425,7 @@ static MagickBooleanType EncodeImageAttributes(Image *image,FILE *file,
   JsonFormatLocaleFile(file,"    \"dispose\": %s,\n",
     CommandOptionToMnemonic(MagickDisposeOptions,(ssize_t) image->dispose));
   if (image->delay != 0)
-    (void) FormatLocaleFile(file,"    \"delay\": \"%.20gx%.20g\"\n",
+    (void) FormatLocaleFile(file,"    \"delay\": \"%.20gx%.20g\",\n",
       (double) image->delay,(double) image->ticks_per_second);
   if (image->iterations != 1)
     (void) FormatLocaleFile(file,"    \"iterations\": %.20g,\n",(double)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
I investigated this issue during ![upgrade of MiniMagick](https://github.com/minimagick/minimagick/blob/master/lib/mini_magick/image/info.rb#L123) which forced me to use `.data` method instead of deprecated `.details`.

And ImageMagick returns invalid json for `gif` images.

Example json of gif file before my change.
```
    ....
    "dispose": "Undefined",
    "delay": "10x100"
    "compression": "LZW",
    "orientation": "Undefined",
    "properties": {
      "date:create": "2017-10-12T14:49:42+00:00",
      "date:modify": "2017-10-12T12:54:23+00:00",
      "signature": "36ab25b583a7e4359c232e8f3e2ee6f372e34d8ece465b1de86ac670dee134e4"
    }, ...
```
After my change
```
    ....
    "dispose": "Undefined",
    "delay": "10x100",
    "compression": "LZW",
    "orientation": "Undefined",
    "properties": {
      "date:create": "2017-10-12T14:49:42+00:00",
      "date:modify": "2017-10-12T12:54:23+00:00",
      "signature": "36ab25b583a7e4359c232e8f3e2ee6f372e34d8ece465b1de86ac670dee134e4"
    }, ...
```

Without this fix my application is unable to upload gif images, because I check first if they are valid.