### PR TITLE
fix ; same variable i is used in nexted loop

### DIFF
--- a/MagickCore/resource.c
+++ b/MagickCore/resource.c
@@ -563,6 +563,7 @@ MagickExport int AcquireUniqueFileResource(char *path)
     *p;
 
   register ssize_t
+    j,
     i;
 
   static const char
@@ -585,7 +586,7 @@ MagickExport int AcquireUniqueFileResource(char *path)
       UnlockSemaphoreInfo(resource_semaphore);
     }
   file=(-1);
-  for (i=0; i < (ssize_t) TMP_MAX; i++)
+  for (j=0; j < (ssize_t) TMP_MAX; j++)
   {
     /*
       Get temporary pathname.

--- a/coders/pict.c
+++ b/coders/pict.c
@@ -1035,7 +1035,7 @@ static Image *ReadPICTImage(const ImageInfo *image_info,
                     break;
               }
             else
-              for (j=0; j < (int) height; j++)
+              for (i=0; i < (int) height; i++)
                 if (length > 200)
                   {
                     for (j=0; j < (ssize_t) ReadBlobMSBShort(image); j++)


### PR DESCRIPTION
A loop variable is used for a nested loop. It should assign different variables for these loops.