### PR TITLE
Find ImageMagick modules by native shared library suffix

### DIFF
--- a/MagickCore/module.c
+++ b/MagickCore/module.c
@@ -77,7 +77,7 @@ typedef void *ModuleHandle;
   Define declarations.
 */
 #if defined(MAGICKCORE_LTDL_DELEGATE)
-#  define ModuleGlobExpression "*.la"
+#  define ModuleGlobExpression "*" MAGICKCORE_LTDL_MODULE_EXT
 #else
 #  if defined(_DEBUG)
 #    define ModuleGlobExpression "IM_MOD_DB_*.dll"
@@ -1455,7 +1455,7 @@ static void TagToCoderModuleName(const char *tag,char *name)
   (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",tag);
   assert(name != (char *) NULL);
 #if defined(MAGICKCORE_LTDL_DELEGATE)
-  (void) FormatLocaleString(name,MagickPathExtent,"%s.la",tag);
+  (void) FormatLocaleString(name,MagickPathExtent,"%s" MAGICKCORE_LTDL_MODULE_EXT,tag);
   (void) LocaleLower(name);
 #else
 #if defined(MAGICKCORE_WINDOWS_SUPPORT)
@@ -1508,7 +1508,7 @@ static void TagToFilterModuleName(const char *tag,char *name)
 #elif !defined(MAGICKCORE_LTDL_DELEGATE)
   (void) FormatLocaleString(name,MagickPathExtent,"%s.dll",tag);
 #else
-  (void) FormatLocaleString(name,MagickPathExtent,"%s.la",tag);
+  (void) FormatLocaleString(name,MagickPathExtent,"%s" MAGICKCORE_LTDL_MODULE_EXT,tag);
 #endif
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -1704,6 +1704,7 @@ if test "$build_modules" != 'no' || test "X$ax_cv_check_cl_libcl" != Xno; then
       LTDL_LIBS='-lltdl'
       LIBS="$LTDL_LIBS $LIBS"
       AC_DEFINE(LTDL_DELEGATE,1,[Define if using libltdl to support dynamically loadable modules and OpenCL])
+      AC_DEFINE_UNQUOTED([LTDL_MODULE_EXT],["${shrext_cmds}"],[Native module suffix])
       AC_MSG_RESULT([yes])
       have_ltdl='yes'
     fi


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->

Find ImageMagick modules by native shared library suffix

* This allows us to delete `.la` files, which are technical debt of days when shared libraries weren't ubiquitous. This is important for distributions' QA, as libtool archives are extremely problematic nowadays (https://blog.flameeyes.eu/2011/08/library-soname-bumps-and-la-files-some-visual-clues/).