### PR TITLE
Revert "Find ImageMagick modules by native shared library suffix"

### DIFF
--- a/MagickCore/module.c
+++ b/MagickCore/module.c
@@ -77,7 +77,7 @@ typedef void *ModuleHandle;
   Define declarations.
 */
 #if defined(MAGICKCORE_LTDL_DELEGATE)
-#  define ModuleGlobExpression "*" MAGICKCORE_LTDL_MODULE_EXT
+#  define ModuleGlobExpression "*.la"
 #else
 #  if defined(_DEBUG)
 #    define ModuleGlobExpression "IM_MOD_DB_*.dll"
@@ -1455,7 +1455,7 @@ static void TagToCoderModuleName(const char *tag,char *name)
   (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",tag);
   assert(name != (char *) NULL);
 #if defined(MAGICKCORE_LTDL_DELEGATE)
-  (void) FormatLocaleString(name,MagickPathExtent,"%s" MAGICKCORE_LTDL_MODULE_EXT,tag);
+  (void) FormatLocaleString(name,MagickPathExtent,"%s.la",tag);
   (void) LocaleLower(name);
 #else
 #if defined(MAGICKCORE_WINDOWS_SUPPORT)
@@ -1508,7 +1508,7 @@ static void TagToFilterModuleName(const char *tag,char *name)
 #elif !defined(MAGICKCORE_LTDL_DELEGATE)
   (void) FormatLocaleString(name,MagickPathExtent,"%s.dll",tag);
 #else
-  (void) FormatLocaleString(name,MagickPathExtent,"%s" MAGICKCORE_LTDL_MODULE_EXT,tag);
+  (void) FormatLocaleString(name,MagickPathExtent,"%s.la",tag);
 #endif
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -1704,7 +1704,6 @@ if test "$build_modules" != 'no' || test "X$ax_cv_check_cl_libcl" != Xno; then
       LTDL_LIBS='-lltdl'
       LIBS="$LTDL_LIBS $LIBS"
       AC_DEFINE(LTDL_DELEGATE,1,[Define if using libltdl to support dynamically loadable modules and OpenCL])
-      AC_DEFINE_UNQUOTED([LTDL_MODULE_EXT],["${shrext_cmds}"],[Native module suffix])
       AC_MSG_RESULT([yes])
       have_ltdl='yes'
     fi


### PR DESCRIPTION
Reverts ImageMagick/ImageMagick#895.  Unit test fail:

```
./configure --with-modules
make check
```