### PR TITLE
fix memory leaks

### DIFF
--- a/Magick++/fuzz/encoder_list.cc
+++ b/Magick++/fuzz/encoder_list.cc
@@ -14,4 +14,6 @@ extern "C" int main() {
       std::cout << format->name << std::endl;
     }
   }
+
+  RelinquishMagickMemory(formats);
 }


### PR DESCRIPTION
## COMPILE

```bash
clang++ -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -I/usr/local/include/ImageMagick-7 encoder_list.cc -o encode
r_list `Magick++-config --cppflags --cxxflags --ldflags --libs`
````

## ASAN output

```
=================================================================
==32459==ERROR: LeakSanitizer: detected memory leaks                                           
                                               
Direct leak of 2120 byte(s) in 1 object(s) allocated from:                                     
    #0 0x4cf640 in __interceptor_malloc (/home/henices/tests/ImageMagick/Magick++/fuzz/encoder_list+0x4cf640)
    #1 0x7f380b8157b6 in AcquireMagickMemory /home/henices/tests/ImageMagick/MagickCore/memory.c:464:10
    #2 0x7f380b815818 in AcquireQuantumMemory /home/henices/tests/ImageMagick/MagickCore/memory.c:537:10
    #3 0x7f380b811c76 in GetMagickInfoList /home/henices/tests/ImageMagick/MagickCore/magick.c:703:33
    #4 0x50da13 in main (/home/henices/tests/ImageMagick/Magick++/fuzz/encoder_list+0x50da13)
    #5 0x7f380a3a5009 in __libc_start_main (/lib64/libc.so.6+0x21009)
                                               
SUMMARY: AddressSanitizer: 2120 byte(s) leaked in 1 allocation(s).
```
