### PR TITLE
add attribute to get in perl doc

### DIFF
--- a/www/perl-magick.html
+++ b/www/perl-magick.html
@@ -1865,6 +1865,12 @@ $width = $image-&gt;[3]-&gt;Get('columns');
   </tr>
 
   <tr>
+    <td>magick</td>
+    <td><i>string</i></td>
+    <td>get the image format tag</td>
+  </tr>
+
+  <tr>
     <td>mean-error</td>
     <td><i>double</i></td>
     <td>the normalized mean error per pixel computed with methods Compare() or Quantize()</td>


### PR DESCRIPTION
Attribute "magick" can be used to get image format tag.

This attribute is important e.g. to determine file type of unknown file.
