### PR TITLE
Fix previous image references in OptimizeImageLayers

### DIFF
--- a/MagickCore/layer.c
+++ b/MagickCore/layer.c
@@ -1096,8 +1096,7 @@ static Image *OptimizeLayerFrames(const Image *image,
         dup_bounds.width=dup_bounds.height=0; /* no dup, no pixel added */
         if ( add_frames )
           {
-            dup_image=CloneImage(curr->previous,curr->previous->page.width,
-                curr->previous->page.height,MagickTrue,exception);
+            dup_image=CloneImage(curr->previous,0,0,MagickTrue,exception);
             if (dup_image == (Image *) NULL)
               {
                 bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);
@@ -1124,8 +1123,7 @@ static Image *OptimizeLayerFrames(const Image *image,
         /*
           Now compare against a simple background disposal
         */
-        bgnd_image=CloneImage(curr->previous,curr->previous->page.width,
-          curr->previous->page.height,MagickTrue,exception);
+        bgnd_image=CloneImage(curr->previous,0,0,MagickTrue,exception);
         if (bgnd_image == (Image *) NULL)
           {
             bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);
@@ -1280,8 +1278,7 @@ static Image *OptimizeLayerFrames(const Image *image,
           bgnd_image=DestroyImage(bgnd_image);
         if ( disposals[i-1] == NoneDispose )
           {
-            prev_image=CloneImage(curr->previous,curr->previous->page.width,
-              curr->previous->page.height,MagickTrue,exception);
+            prev_image=ReferenceImage(curr->previous);
             if (prev_image == (Image *) NULL)
               {
                 bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The code used CloneImage with columns and rows arguments to create
previous image references.

However, the documentation of CloneImage says:
> If the specified columns and rows is 0, an exact copy of the image is
> returned, otherwise the pixel data is undefined and must be initialized
> with the QueueAuthenticPixels() and SyncAuthenticPixels() methods.  On
> failure, a NULL image is returned and exception describes the reason for the
> failure.

Therfore, the pixel data given by such a statement was undefined, which is
not expected.

This alters those arguments to 0, or replaces CloneImage with
ReferenceImage if it is enough.