### PR TITLE
Do not refer to page in OptimizeLayerFrames

### DIFF
--- a/MagickCore/layer.c
+++ b/MagickCore/layer.c
@@ -987,8 +987,7 @@ static Image *OptimizeLayerFrames(const Image *image,
   /*
     Initialise Previous Image as fully transparent
   */
-  prev_image=CloneImage(curr,curr->page.width,curr->page.height,
-    MagickTrue,exception);
+  prev_image=CloneImage(curr,curr->columns,curr->rows,MagickTrue,exception);
   if (prev_image == (Image *) NULL)
     {
       bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);
@@ -1096,8 +1095,8 @@ static Image *OptimizeLayerFrames(const Image *image,
         dup_bounds.width=dup_bounds.height=0; /* no dup, no pixel added */
         if ( add_frames )
           {
-            dup_image=CloneImage(curr->previous,curr->previous->page.width,
-                curr->previous->page.height,MagickTrue,exception);
+            dup_image=CloneImage(curr->previous,curr->previous->columns,
+                curr->previous->rows,MagickTrue,exception);
             if (dup_image == (Image *) NULL)
               {
                 bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);
@@ -1124,8 +1123,8 @@ static Image *OptimizeLayerFrames(const Image *image,
         /*
           Now compare against a simple background disposal
         */
-        bgnd_image=CloneImage(curr->previous,curr->previous->page.width,
-          curr->previous->page.height,MagickTrue,exception);
+        bgnd_image=CloneImage(curr->previous,curr->previous->columns,
+          curr->previous->rows,MagickTrue,exception);
         if (bgnd_image == (Image *) NULL)
           {
             bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);
@@ -1280,8 +1279,8 @@ static Image *OptimizeLayerFrames(const Image *image,
           bgnd_image=DestroyImage(bgnd_image);
         if ( disposals[i-1] == NoneDispose )
           {
-            prev_image=CloneImage(curr->previous,curr->previous->page.width,
-              curr->previous->page.height,MagickTrue,exception);
+            prev_image=CloneImage(curr->previous,curr->columns,
+              curr->rows,MagickTrue,exception);
             if (prev_image == (Image *) NULL)
               {
                 bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
page dimension was used to create images to compare different disposal methods. However, functions used for the comparisons, namely `CompareImagesBounds` and `IsBoundsCleared` are based on the dimensions of images themselves.

Creating image with page dimension is inefficient when converting images with larger pages and therefore should be avoided.

This is what I should have done before #983. See https://github.com/ImageMagick/ImageMagick/pull/984#issuecomment-365310862.