### PR TITLE
Fix undefined behavior when calling isdigit

### DIFF
--- a/MagickCore/delegate.c
+++ b/MagickCore/delegate.c
@@ -931,7 +931,7 @@ RestoreMSCWarning
   extent=MagickPathExtent;  /* allocated space in string */
   number=MagickFalse;  /* is last char a number? */
   for (q=interpret_text; *p!='\0';
-    number=isdigit(*p) ? MagickTrue : MagickFalse,p++)
+    number=isdigit((int) ((unsigned char) *p)) ? MagickTrue : MagickFalse,p++)
   {
     /*
       Interpret escape characters (e.g. Filename: %M).


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
`isdigit` must not be called with negative arguments.