### PR TITLE
Assert image page dimension in OptimizeLayerFrames

### DIFF
--- a/MagickCore/layer.c
+++ b/MagickCore/layer.c
@@ -962,10 +962,11 @@ static Image *OptimizeLayerFrames(const Image *image,
   {
     if ((curr->columns != image->columns) || (curr->rows != image->rows))
       ThrowImageException(OptionError,"ImagesAreNotTheSameSize");
-    /*
-      FUTURE: also check that image is also fully coalesced (full page)
-      Though as long as they are the same size it should not matter.
-    */
+
+    if ((curr->page.x != 0) || (curr->page.y != 0) ||
+        (curr->page.width != image->page.width) ||
+        (curr->page.height != image->page.height))
+      ThrowImageException(OptionError,"ImagePagesAreNotCoalesced");
   }
   /*
     Allocate memory (times 2 if we allow the use of frame duplications)

--- a/config/english.xml
+++ b/config/english.xml
@@ -652,6 +652,9 @@
         <message name="ImagesAreNotTheSameSize">
           images are not the same size
         </message>
+        <message name="ImagePagesAreNotCoalesced">
+          image pages are not coalesced
+        </message>
         <message name="ImageSizeMustExceedBevelWidth">
           size must exceed bevel width
         </message>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
`OptimizeLayerFrames` initializes the background with some assumptions for image page dimension:
```C
  prev_image->page=curr->page;  /* ERROR: <-- should not be need, but is! */
  prev_image->page.x=0;
  prev_image->page.y=0;
```
https://github.com/akihikodaki/ImageMagick/blob/d4821be4b9d49934bf79913ce45f55c4b4c240e8/MagickCore/layer.c#L999