### PR TITLE
Revert "Revert "Fix previous image references in OptimizeImageLayers …

### DIFF
--- a/MagickCore/layer.c
+++ b/MagickCore/layer.c
@@ -1096,8 +1096,7 @@ static Image *OptimizeLayerFrames(const Image *image,
         dup_bounds.width=dup_bounds.height=0; /* no dup, no pixel added */
         if ( add_frames )
           {
-            dup_image=CloneImage(curr->previous,curr->previous->columns,
-                curr->previous->rows,MagickTrue,exception);
+            dup_image=CloneImage(curr->previous,0,0,MagickTrue,exception);
             if (dup_image == (Image *) NULL)
               {
                 bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);
@@ -1124,8 +1123,7 @@ static Image *OptimizeLayerFrames(const Image *image,
         /*
           Now compare against a simple background disposal
         */
-        bgnd_image=CloneImage(curr->previous,curr->previous->columns,
-          curr->previous->rows,MagickTrue,exception);
+        bgnd_image=CloneImage(curr->previous,0,0,MagickTrue,exception);
         if (bgnd_image == (Image *) NULL)
           {
             bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);
@@ -1280,8 +1278,7 @@ static Image *OptimizeLayerFrames(const Image *image,
           bgnd_image=DestroyImage(bgnd_image);
         if ( disposals[i-1] == NoneDispose )
           {
-            prev_image=CloneImage(curr->previous,curr->columns,
-              curr->rows,MagickTrue,exception);
+            prev_image=ReferenceImage(curr->previous);
             if (prev_image == (Image *) NULL)
               {
                 bounds=(RectangleInfo *) RelinquishMagickMemory(bounds);


### PR DESCRIPTION
…(#983)" (#984)"

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Commit 91fd0ac1dda4e0d1109ac70080f55b5286b6abc5 can be safely reverted because commit b5a7073da902c79264ef8d3ccc8dd715fed8222d has same effects in terms of intermediate image dimensions.