### PR TITLE
close stdout/stderr on the fuzzers to reduce noise in oss-fuzz logs

### DIFF
--- a/Magick++/fuzz/build_fuzzers.sh
+++ b/Magick++/fuzz/build_fuzzers.sh
@@ -13,6 +13,7 @@ for f in $MAGICK_SRC/*_fuzzer.cc; do
     fi
     $MAGICK_COMPILER $MAGICK_COMPILER_FLAGS -std=c++11 -I$MAGICK_INCLUDE \
         "$f" -o "$MAGICK_OUTPUT/${fuzzer}_fuzzer" $MAGICK_LIBS
+    echo -e "[libfuzzer]\nclose_fd_mask=3" > "$MAGICK_OUTPUT/${fuzzer}_fuzzer.options"
 done
 
 for item in $("$MAGICK_SRC/encoder_list"); do
@@ -29,6 +30,8 @@ for item in $("$MAGICK_SRC/encoder_list"); do
     $MAGICK_COMPILER $MAGICK_COMPILER_FLAGS -std=c++11 -I$MAGICK_INCLUDE \
         "$MAGICK_SRC/encoder_fuzzer.cc" -o "$MAGICK_OUTPUT/encoder_${encoder,,}_fuzzer" \
          $encoder_flags $MAGICK_LIBS
+
+    echo -e "[libfuzzer]\nclose_fd_mask=3" > "$MAGICK_OUTPUT/encoder_${encoder,,}_fuzzer.options"
 
     if [ $MAGICK_FAST_BUILD -eq 1 ]; then
         break


### PR DESCRIPTION
This writes an options file so clusterfuzz will run the fuzzers with -close_fd_mask=3 (which closes stdout/stderr).  See https://github.com/google/oss-fuzz/blob/master/docs/new_project_guide.md#custom-libfuzzer-options-for-clusterfuzz for more details.

Should significantly reduce the noise we see in the logs.