### PR TITLE
temporary workaround to fix ubsan oss-fuzz

### DIFF
--- a/Magick++/fuzz/build.sh
+++ b/Magick++/fuzz/build.sh
@@ -17,7 +17,7 @@ make install
 popd
 
 # Build ImageMagick
-./configure --prefix="$WORK" --disable-shared --disable-docs LIBS="-lc++" LDFLAGS="${LDFLAGS:-} -L$WORK/lib" CFLAGS="$CFLAGS -I$WORK/include" PKG_CONFIG_PATH="$WORK/lib/pkgconfig"
+./configure --prefix="$WORK" --disable-shared --disable-docs LIBS="-lc++ -lubsan" LDFLAGS="${LDFLAGS:-} -L$WORK/lib" CFLAGS="$CFLAGS -I$WORK/include" PKG_CONFIG_PATH="$WORK/lib/pkgconfig"
 make "-j$(nproc)"
 make install
 


### PR DESCRIPTION
This isn't really the right fix, but will work around the linker issue for the moment.

The right fix is probably to add a flag to the configure script that allows us to build only the libraries and not the utilities, but to do that I need to learn some autoconf 😬

refs: https://github.com/google/oss-fuzz/issues/1266