### PR TITLE
add configure support for disabling utilities with --disable-utilities

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -782,6 +782,12 @@ AC_ARG_ENABLE(legacy-support,
               [with_legacy_support='no'])
 AM_CONDITIONAL(LEGACY_SUPPORT, test "$with_legacy_support" != 'no')
 
+# Enable building command line utilities (default yes)
+AC_ARG_WITH(utilities,
+            [  --with-utilities enable building command-line utilities (default yes)],
+            [with_utilities=$withval], [with_utilities='yes'])
+AM_CONDITIONAL(WITH_UTILITIES, test "$with_utilities" = 'yes')
+
 # Number of bits in a Quantum
 AC_ARG_WITH([quantum-depth],
     [AC_HELP_STRING([--with-quantum-depth=DEPTH],
@@ -4006,6 +4012,7 @@ matches your expectations.
   ------------------------------------------------------------------------------
   Shared libraries  --enable-shared=$enable_shared		$libtool_build_shared_libs
   Static libraries  --enable-static=$enable_static		$libtool_build_static_libs
+  Build utilities   --with-utilities=$with_utilities        $with_utilities
   Module support    --with-modules=$build_modules		$build_modules
   GNU ld            --with-gnu-ld=$with_gnu_ld		$lt_cv_prog_gnu_ld
   Quantum depth     --with-quantum-depth=$with_quantum_depth	$with_quantum_depth

--- a/utilities/Makefile.am
+++ b/utilities/Makefile.am
@@ -14,8 +14,9 @@
 #
 #  Makefile for building ImageMagick utilities.
 
+if WITH_UTILITIES
 UTILITIES_PGMS = \
-	utilities/magick 
+	utilities/magick
 
 UTILITIES_XFAIL_TESTS = \
   $(UTILITIES_TTF_XFAIL_TESTS) \
@@ -60,12 +61,21 @@ UTILITIES_CONFIGURE = \
 
 UTILITIES_EXTRA_DIST = \
 	$(UTILITIES_MANS) \
-	$(UTILITIES_TESTS) 
+	$(UTILITIES_TESTS)
 
-UTILITIES_CLEANFILES = 
+UTILITIES_CLEANFILES =
 
 # Link these utilities to 'magick'.
 MAGICK_UTILITIES=animate compare composite conjure convert display identify import magick-script mogrify montage stream
+
+else
+UTILITIES_PGMS =
+UTILITIES_MANS =
+UTILITIES_CONFIGURE =
+UTILITIES_EXTRA_DIST =
+UTILITIES_CLEANFILES =
+MAGICK_UTILITIES=
+endif
 
 UTILITIES_INSTALL_EXEC_LOCAL_TARGETS=install-exec-local-utilities
 install-exec-local-utilities:


### PR DESCRIPTION
This PR adds a configure flag (`--with-utilities=yes/no`) that allows us to avoid building the utilities when they are not needed.

I have not rebuilt the Makefile.in and configure scripts from these sources because I have a different version of autotools/automake than what was used to generate the ones in version control and I don't want to clutter the diff.