### PR TITLE
temporarily remove bzip2 from the oss-fuzz builds

### DIFF
--- a/Magick++/fuzz/build.sh
+++ b/Magick++/fuzz/build.sh
@@ -1,14 +1,5 @@
 #!/bin/bash -eu
 
-# build bzip2
-pushd $SRC
-tar zxf bzip2-1.0.6.tar.gz
-popd
-pushd "$SRC/bzip2-1.0.6"
-make -j$(nproc) CFLAGS="$CFLAGS -fPIC" CC="$CC"
-make install PREFIX="$WORK"
-popd
-
 # build zlib
 pushd "$SRC/zlib"
 ./configure --static --prefix="$WORK"
@@ -74,7 +65,7 @@ MAGICK_COMPILER=$CXX
 MAGICK_COMPILER_FLAGS=$CXXFLAGS
 MAGICK_INCLUDE="$WORK/include/ImageMagick-7"
 MAGICK_SRC="$SRC/imagemagick/Magick++/fuzz"
-MAGICK_LIBS="-lFuzzingEngine $WORK/lib/libMagick++-7.Q16HDRI.a $WORK/lib/libMagickWand-7.Q16HDRI.a $WORK/lib/libMagickCore-7.Q16HDRI.a $WORK/lib/libz.a $WORK/lib/libbz2.a $WORK/lib/libtiff.a $WORK/lib/libde265.a $WORK/lib/libopenjp2.a $WORK/lib/libwebp.a $WORK/lib/libturbojpeg.a $WORK/lib/libjpeg.a $WORK/lib/libfreetype.a"
+MAGICK_LIBS="-lFuzzingEngine $WORK/lib/libMagick++-7.Q16HDRI.a $WORK/lib/libMagickWand-7.Q16HDRI.a $WORK/lib/libMagickCore-7.Q16HDRI.a $WORK/lib/libz.a $WORK/lib/libtiff.a $WORK/lib/libde265.a $WORK/lib/libopenjp2.a $WORK/lib/libwebp.a $WORK/lib/libturbojpeg.a $WORK/lib/libjpeg.a $WORK/lib/libfreetype.a"
 MAGICK_OUTPUT=$OUT
 MAGICK_FAST_BUILD=0
 


### PR DESCRIPTION
bzip2 isn't UBSAN clean right now. The issue has been reported upstream but for the moment we don't want to build it until that's fixed.

I'll re-add this when/if bzip2 1.0.7 is released.