### PR TITLE
Update AppRun for AppImage (fixes warnings about 'UnableToOpenConfigureFile')

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -7,9 +7,12 @@
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 
-export MAGICK_HOME="$HERE/usr" # http://www.imagemagick.org/QuickStart.txt
-export MAGICK_CONFIGURE_PATH=$(readlink -f "$HERE/usr/lib/ImageMagick-*/config-*/") # Undocumented?
- 
+export MAGICK_HOME="$HERE/usr:$MAGICK_HOME" # http://www.imagemagick.org/QuickStart.txt
+export MAGICK_CONFIGURE_PATH=$(readlink -f "$HERE/usr/lib/ImageMagick-7.0.7/config-Q16HDRI"):$(readlink -f "$HERE/usr/share/ImageMagick-7"):$(readlink -f "$HERE/usr/etc/ImageMagick-7"):$MAGICK_CONFIGURE_PATH #Wildcards don't work
+
+export LD_LIBRARY_PATH=$(readlink -f "$HERE/usr/lib"):$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${HERE}/usr/lib/ImageMagick-7.0.7/modules-Q16HDRI/coders:$LD_LIBRARY_PATH
+
 if [ "$1" == "man" ] ; then
   export MANPATH="$HERE/usr/share/man:$MANPATH" ; exec "$@" ; exit $?
 elif [ "$1" == "info" ] ; then


### PR DESCRIPTION
This is a short-term fix for an issue leading to warning messages.
The list of such messages appearing under certain conditions is this:

````
magick: UnableToOpenConfigureFile `magic.xml' @ warning/configure.c/GetConfigureOptions/714.
magick: UnableToOpenConfigureFile `coder.xml' @ warning/configure.c/GetConfigureOptions/714.
magick: UnableToOpenConfigureFile `colors.xml' @ warning/configure.c/GetConfigureOptions/714.
magick: UnableToOpenConfigureFile `configure.xml' @ warning/configure.c/GetConfigureOptions/714.
magick: UnableToOpenConfigureFile `delegates.xml' @ warning/configure.c/GetConfigureOptions/714.
magick: UnableToOpenConfigureFile `type.xml' @ warning/configure.c/GetConfigureOptions/714.
magick: UnableToOpenConfigureFile `mime.xml' @ warning/configure.c/GetConfigureOptions/714.
magick: UnableToOpenConfigureFile `thresholds.xml' @ warning/configure.c/GetConfigureOptions/714.
````

Note, I've been working on an improved and extended AppRun script for the AppImage, which I've not yet completed due to some heavy time restrictions. Hopefully I can complete this soon...

----

**Update:** Actually, it is more than just warning messages. Some commands do not work. Example:

* **Before fix:**

    ````
    magick -list threshold
    
       Threshold Maps for Ordered Dither Operations
    magick: UnableToOpenConfigureFile `thresholds.xml' @ warning/configure.c/GetConfigureOptions/714.

    ````

* **After fix:**

    ````
    magick -list threshold

       Threshold Maps for Ordered Dither Operations

    Path: /tmp/.mount_magickMJ36qd/usr/etc/ImageMagick-7/thresholds.xml

    Map              Alias        Description
    ----------------------------------------------------
    threshold        1x1          Threshold 1x1 (non-dither)
    checks           2x1          Checkerboard 2x1 (dither)
    o2x2             2x2          Ordered 2x2 (dispersed)
    o3x3             3x3          Ordered 3x3 (dispersed)
    o4x4             4x4          Ordered 4x4 (dispersed)
    o8x8             8x8          Ordered 8x8 (dispersed)
    h4x4a            4x1          Halftone 4x4 (angled)
    h6x6a            6x1          Halftone 6x6 (angled)
    h8x8a            8x1          Halftone 8x8 (angled)
    h4x4o                         Halftone 4x4 (orthogonal)
    h6x6o                         Halftone 6x6 (orthogonal)
    h8x8o                         Halftone 8x8 (orthogonal)
    h16x16o                       Halftone 16x16 (orthogonal)
    c5x5b            c5x5         Circles 5x5 (black)
    c5x5w                         Circles 5x5 (white)
    c6x6b            c6x6         Circles 6x6 (black)
    c6x6w                         Circles 6x6 (white)
    c7x7b            c7x7         Circles 7x7 (black)
    c7x7w                         Circles 7x7 (white)
````

Likewise, the following commands didn't work:

    magick -list configure
    magick -list mime