### PR TITLE
Fixed memory leak in ReadJP2Image.

### DIFF
--- a/coders/jp2.c
+++ b/coders/jp2.c
@@ -425,7 +425,10 @@ static Image *ReadJP2Image(const ImageInfo *image_info,ExceptionInfo *exception)
       profile=BlobToStringInfo(jp2_image->icc_profile_buf,
         jp2_image->icc_profile_len);
       if (profile != (StringInfo *) NULL)
-        SetImageProfile(image,"icc",profile,exception);
+        {
+          SetImageProfile(image,"icc",profile,exception);
+          profile=DestroyStringInfo(profile);
+        }
     }
   if (image->ping != MagickFalse)
     {


### PR DESCRIPTION
Destory profile memory after using.

### Prerequisites

- [v] I have written a descriptive pull-request title
- [v] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [v] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->
This PR is for fixing memory leak.
Writed test results in https://github.com/ImageMagick/ImageMagick/issues/1085

<!-- Thanks for contributing to ImageMagick! -->
