### PR TITLE
reorder build to make tiff happy

### DIFF
--- a/Magick++/fuzz/build.sh
+++ b/Magick++/fuzz/build.sh
@@ -1,5 +1,19 @@
 #!/bin/bash -eu
 
+# Build libjpeg-turbo
+pushd "$SRC/libjpeg-turbo"
+cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DENABLE_STATIC=on -DENABLE_SHARED=off
+make -j$(nproc)
+make install
+popd
+
+# Build libtiff
+pushd "$SRC/libtiff"
+cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DBUILD_SHARED_LIBS=off
+make -j$(nproc)
+make install
+popd
+
 # build zlib
 pushd "$SRC/zlib"
 ./configure --static --prefix="$WORK"
@@ -17,20 +31,6 @@ popd
 
 pushd "$SRC/libpng"
 cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DPNG_SHARED=off
-make -j$(nproc)
-make install
-popd
-
-# Build libjpeg-turbo
-pushd "$SRC/libjpeg-turbo"
-cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DENABLE_STATIC=on -DENABLE_SHARED=off
-make -j$(nproc)
-make install
-popd
-
-# Build libtiff
-pushd "$SRC/libtiff"
-cmake . -DCMAKE_INSTALL_PREFIX=$WORK
 make -j$(nproc)
 make install
 popd


### PR DESCRIPTION
With the current build order the IM configure script refuses to link against libtiff for reasons unknown. By building libjpeg and libtiff early we work around whatever is going on there. Investigating further would probably be a good idea, but ¯\_(ツ)_/¯ 