### PR TITLE
Fixed memory leak in heif

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -191,7 +191,10 @@ static Image *ReadHEICImage(const ImageInfo *image_info,
   error=heif_context_read_from_memory(heif_context,file_data,length,NULL);
   file_data=RelinquishMagickMemory(file_data);
   if (error.code != 0)
-    ThrowReaderException(CorruptImageError,"UnableToReadImageData");
+    {
+      heif_context_free(heif_context);
+      ThrowReaderException(CorruptImageError,"UnableToReadImageData");
+    }
   image_handle=(struct heif_image_handle *) NULL;
   error=heif_context_get_primary_image_handle(heif_context,&image_handle);
   if (error.code != 0)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Fixed a straightforward memory leak
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
