### PR TITLE
Properly set the compressed data size when encoding JPEG compressed PICT files

### DIFF
--- a/coders/pict.c
+++ b/coders/pict.c
@@ -1898,8 +1898,9 @@ static MagickBooleanType WritePICTImage(const ImageInfo *image_info,
       (void) WriteBlobMSBShort(image,(unsigned short) x_resolution);
       (void) WriteBlobMSBShort(image,0x0000);
       (void) WriteBlobMSBShort(image,(unsigned short) y_resolution);
-      (void) WriteBlobMSBLong(image,0x00000000U);
-      (void) WriteBlobMSBLong(image,0x87AC0001U);
+      (void) WriteBlobMSBShort(image,0x0000);
+      (void) WriteBlobMSBLong(image,length);
+      (void) WriteBlobMSBShort(image,0x0001);
       (void) WriteBlobMSBLong(image,0x0B466F74U);
       (void) WriteBlobMSBLong(image,0x6F202D20U);
       (void) WriteBlobMSBLong(image,0x4A504547U);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
This portion of the file format obeys the following specification:
http://mirror.informatimago.com/next/developer.apple.com/documentation/QuickTime/INMAC/QT/iqImageCompMgr.17.htm#26170

With this fix, PICT files compressed with JPEG data can be opened with other programs.
