### PR TITLE
[DO NOT MERGE YET] Add More Pixel Art Upscaling Algorithms

### DIFF
--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2352,7 +2352,7 @@ void Xbr2X(const Image *src_image,const Quantum *neighbourhood,
 
   if (
     w_12_18 + w_12_6 + w_8_14 + w_8_2 + (4 * w_7_13) <
-    w_13_17 + w_13_9 + w_11_7 + w_7_3 + (4 * w_12_16)
+    w_13_17 + w_13_9 + w_11_7 + w_7_3 + (4 * w_12_8)
   )
     Mix2Pixels(neighbourhood,w_12_7 <= w_12_13 ? 7 : 13,12,result,1,channels);    
   else

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2235,7 +2235,7 @@ break;
   #undef caseB
 }
 
-unsigned int Hq2XPatternToNumber(int *pattern)
+unsigned int Hq2XPatternToNumber(const int *pattern)
 {
   unsigned int
     result=0,
@@ -2274,7 +2274,7 @@ void Hq2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
 
   #define Rotated(p) p[2], p[4], p[7], p[1], p[6], p[0], p[3], p[5]
 
-  int pattern1[] = 
+  const int pattern1[] = 
   {
     !PixelsEqual(neighbourhood,4,neighbourhood,8,channels),
     !PixelsEqual(neighbourhood,4,neighbourhood,7,channels),
@@ -2286,9 +2286,9 @@ void Hq2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
     !PixelsEqual(neighbourhood,4,neighbourhood,0,channels)
   };
 
-  int pattern2[] = { Rotated(pattern1) };
-  int pattern3[] = { Rotated(pattern2) };
-  int pattern4[] = { Rotated(pattern3) };
+  const int pattern2[] = { Rotated(pattern1) };
+  const int pattern3[] = { Rotated(pattern2) };
+  const int pattern4[] = { Rotated(pattern3) };
 
   Hq2XHelper(Hq2XTable[Hq2XPatternToNumber(pattern1)],neighbourhood,result,0,
     channels,4,0,1,3,5,7);
@@ -2395,19 +2395,19 @@ void Epx2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
 void Eagle3X(const Image *src_image,const Quantum *neighbourhood,
   Quantum *result,size_t channels)
 {
-  int corner_tl =
+  const int corner_tl =
     PixelsEqual(neighbourhood,0,neighbourhood,1,channels) &&
     PixelsEqual(neighbourhood,0,neighbourhood,3,channels);
 
-  int corner_tr =
+  const int corner_tr =
     PixelsEqual(neighbourhood,1,neighbourhood,2,channels) &&
     PixelsEqual(neighbourhood,2,neighbourhood,5,channels);
 
-  int corner_bl =
+  const int corner_bl =
     PixelsEqual(neighbourhood,3,neighbourhood,6,channels) &&
     PixelsEqual(neighbourhood,6,neighbourhood,7,channels);
 
-  int corner_br =
+  const int corner_br =
     PixelsEqual(neighbourhood,5,neighbourhood,7,channels) &&
     PixelsEqual(neighbourhood,7,neighbourhood,8,channels);
 
@@ -2445,19 +2445,19 @@ void Eagle3X(const Image *src_image,const Quantum *neighbourhood,
 void Eagle3XB(const Image *src_image,const Quantum *neighbourhood,
   Quantum *result,size_t channels)
 {
-  int corner_tl =
+  const int corner_tl =
     PixelsEqual(neighbourhood,0,neighbourhood,1,channels) &&
     PixelsEqual(neighbourhood,0,neighbourhood,3,channels);
 
-  int corner_tr =
+  const int corner_tr =
     PixelsEqual(neighbourhood,1,neighbourhood,2,channels) &&
     PixelsEqual(neighbourhood,2,neighbourhood,5,channels);
 
-  int corner_bl =
+  const int corner_bl =
     PixelsEqual(neighbourhood,3,neighbourhood,6,channels) &&
     PixelsEqual(neighbourhood,6,neighbourhood,7,channels);
 
-  int corner_br =
+  const int corner_br =
     PixelsEqual(neighbourhood,5,neighbourhood,7,channels) &&
     PixelsEqual(neighbourhood,7,neighbourhood,8,channels);
 

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2080,7 +2080,7 @@ void Eagle2X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
     CopyPixel(neighbourhood,8,result,3,channels);
 }
 
-void Scale2x(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Scale2X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
 {
   register ssize_t
     i;
@@ -2170,9 +2170,28 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     algorithm;
 
   unsigned char
-    magnification = 2;
+    magnification;
+
+  void
+    (*alg_function)(const Image *, const Quantum *, Quantum *, size_t) = NULL;
 
   algorithm = GetImageOption(image->image_info,"magnify:alg");
+
+  if (algorithm == (char *) NULL)
+    {
+      alg_function = Scale2X;
+      magnification = 2;
+    }
+  else if (LocaleCompare(algorithm,"eagle2x") == 0)
+    {
+      alg_function = Eagle2X;
+      magnification = 2;
+    }
+  else
+    {
+      alg_function = Scale2X;
+      magnification = 2;
+    } 
 
   /*
     Initialize magnified image attributes.
@@ -2237,7 +2256,8 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
       channels = GetPixelChannels(image);
 
 //      Scale2x(image,p,r,channels);
-      Eagle2X(image,p,r,channels);
+//      Eagle2X(image,p,r,channels);
+        alg_function(image,p,r,channels);
 
       for (i=0; i < (ssize_t) channels * 2; i++)
         q[i]=r[i];

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2170,7 +2170,35 @@ void Eagle3X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
     CopyPixel(neighbourhood,4,result,7,channels); 
 
   CopyPixel(neighbourhood,corner_br ? 5 : 4,result,8,channels);
+}
 
+void Eagle3XB(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+{
+  int corner_tl =
+    PixelsEqual(neighbourhood,0,neighbourhood,1,channels) &&
+    PixelsEqual(neighbourhood,0,neighbourhood,3,channels);
+
+  int corner_tr =
+    PixelsEqual(neighbourhood,1,neighbourhood,2,channels) &&
+    PixelsEqual(neighbourhood,2,neighbourhood,5,channels);
+
+  int corner_bl =
+    PixelsEqual(neighbourhood,3,neighbourhood,6,channels) &&
+    PixelsEqual(neighbourhood,6,neighbourhood,7,channels);
+
+  int corner_br =
+    PixelsEqual(neighbourhood,5,neighbourhood,7,channels) &&
+    PixelsEqual(neighbourhood,7,neighbourhood,8,channels);
+
+  CopyPixel(neighbourhood,corner_tl ? 0 : 4,result,0,channels);
+  CopyPixel(neighbourhood,4,result,1,channels); 
+  CopyPixel(neighbourhood,corner_tr ? 1 : 4,result,2,channels);
+  CopyPixel(neighbourhood,4,result,3,channels); 
+  CopyPixel(neighbourhood,4,result,4,channels);
+  CopyPixel(neighbourhood,4,result,5,channels); 
+  CopyPixel(neighbourhood,corner_bl ? 3 : 4,result,6,channels);
+  CopyPixel(neighbourhood,4,result,7,channels); 
+  CopyPixel(neighbourhood,corner_br ? 5 : 4,result,8,channels);
 }
 
 void Scale3X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
@@ -2317,6 +2345,12 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     LocaleCompare(algorithm,"eagle3") == 0)
     {
       alg_function = Eagle3X;
+      magnification = 3;
+    }
+  else if (LocaleCompare(algorithm,"eagle3xb") == 0 ||
+    LocaleCompare(algorithm,"eagle3b") == 0)
+    {
+      alg_function = Eagle3XB;
       magnification = 3;
     }
   else

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2338,7 +2338,7 @@ void Scale2X(const Image *src_image,const Quantum *neighbourhood,
     }
 }
 
-void Epx2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
+void Epbx2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
   size_t channels)
 {
   #define HelperCond(a,b,c,d,e,f,g) (\
@@ -2649,11 +2649,11 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
       alg_function = Eagle3XB;
       magnification = 3;
     }
-  else if (LocaleCompare(algorithm,"epx") == 0 ||
-    LocaleCompare(algorithm,"epx2") == 0 ||
-    LocaleCompare(algorithm,"epx2x") == 0)
+  else if (LocaleCompare(algorithm,"epbx") == 0 ||
+    LocaleCompare(algorithm,"epbx2") == 0 ||
+    LocaleCompare(algorithm,"epbx2x") == 0)
     {
-      alg_function = Epx2X;
+      alg_function = Epbx2X;
       magnification = 2;
     }
   else if (LocaleCompare(algorithm,"hqx") == 0 ||

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2273,8 +2273,8 @@ void Hq2X(const Image *src_image, const Quantum *neighbourhood, Quantum *result,
 
   Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern1)],neighbourhood,result,0,channels,4,0,1,3,5,7);
   Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern2)],neighbourhood,result,1,channels,4,2,5,1,7,3);
-  Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern3)],neighbourhood,result,2,channels,4,8,7,5,3,1);
-  Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern4)],neighbourhood,result,3,channels,4,6,3,7,1,5);
+  Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern3)],neighbourhood,result,3,channels,4,8,7,5,3,1);
+  Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern4)],neighbourhood,result,2,channels,4,6,3,7,1,5);
 
   #undef Rotated
 }

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2034,6 +2034,16 @@ MagickExport Image *LiquidRescaleImage(const Image *image,
 }
 #endif
 
+
+void Scale2x(const Quantum *neighbourhood, Quantum *result, size_t channels)
+{
+  register ssize_t
+    i;
+
+  for (i=0; i < (ssize_t) channels * 4; i++)
+    result[i] = neighbourhood[4*channels+i];
+}
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -2079,6 +2089,9 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
   ssize_t
     y;
 
+  unsigned char
+    magnification = 2;
+
   /*
     Initialize magnified image attributes.
   */
@@ -2088,7 +2101,7 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",image->filename);
   assert(exception != (ExceptionInfo *) NULL);
   assert(exception->signature == MagickCoreSignature);
-  magnify_image=CloneImage(image,2*image->columns,2*image->rows,MagickTrue,
+  magnify_image=CloneImage(image,magnification*image->columns,magnification*image->rows,MagickTrue,
     exception);
   if (magnify_image == (Image *) NULL)
     return((Image *) NULL);
@@ -2111,98 +2124,47 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     register ssize_t
       x;
 
+    Quantum r[128]; // TODO - 128
+
     if (status == MagickFalse)
       continue;
-    q=QueueCacheViewAuthenticPixels(magnify_view,0,2*y,magnify_image->columns,2,
+    q=QueueCacheViewAuthenticPixels(magnify_view,0,magnification*y,magnify_image->columns,magnification,
       exception);
     if (q == (Quantum *) NULL)
       {
         status=MagickFalse;
         continue;
       }
+
     /*
       Magnify this row of pixels.
     */
     for (x=0; x < (ssize_t) image->columns; x++)
     {
-      MagickRealType
-        intensity[9];
-
       register const Quantum
         *magick_restrict p;
 
-      register Quantum
-        *magick_restrict r;
+      ssize_t
+        channels;
 
       register ssize_t
         i;
 
-      size_t
-        channels;
-
       p=GetCacheViewVirtualPixels(image_view,x-1,y-1,3,3,exception);
-      if (p == (const Quantum *) NULL)
-        {
-          status=MagickFalse;
-          continue;
-        }
-      channels=GetPixelChannels(image);
-      for (i=0; i < 9; i++)
-        intensity[i]=GetPixelIntensity(image,p+i*channels);
-      r=q;
-      if ((fabs(intensity[1]-intensity[7]) < MagickEpsilon) ||
-          (fabs(intensity[3]-intensity[5]) < MagickEpsilon))
-        {
-          /*
-            Clone center pixel.
-          */
-          for (i=0; i < (ssize_t) channels; i++)
-            r[i]=p[4*channels+i];
-          r+=GetPixelChannels(magnify_image);
-          for (i=0; i < (ssize_t) channels; i++)
-            r[i]=p[4*channels+i];
-          r+=GetPixelChannels(magnify_image)*(magnify_image->columns-1);
-          for (i=0; i < (ssize_t) channels; i++)
-            r[i]=p[4*channels+i];
-          r+=GetPixelChannels(magnify_image);
-          for (i=0; i < (ssize_t) channels; i++)
-            r[i]=p[4*channels+i];
-        }
-      else
-        {
-          /*
-            Selectively clone pixel.
-          */
-          if (fabs(intensity[1]-intensity[3]) < MagickEpsilon)
-            for (i=0; i < (ssize_t) channels; i++)
-              r[i]=p[3*channels+i];
-          else
-            for (i=0; i < (ssize_t) channels; i++)
-              r[i]=p[4*channels+i];
-          r+=GetPixelChannels(magnify_image);
-          if (fabs(intensity[1]-intensity[5]) < MagickEpsilon)
-            for (i=0; i < (ssize_t) channels; i++)
-              r[i]=p[5*channels+i];
-          else
-            for (i=0; i < (ssize_t) channels; i++)
-              r[i]=p[4*channels+i];
-          r+=GetPixelChannels(magnify_image)*(magnify_image->columns-1);
-          if (fabs(intensity[3]-intensity[7]) < MagickEpsilon)
-            for (i=0; i < (ssize_t) channels; i++)
-              r[i]=p[3*channels+i];
-          else
-            for (i=0; i < (ssize_t) channels; i++)
-              r[i]=p[4*channels+i];
-          r+=GetPixelChannels(magnify_image);
-          if (fabs(intensity[5]-intensity[7]) < MagickEpsilon)
-            for (i=0; i < (ssize_t) channels; i++)
-              r[i]=p[5*channels+i];
-          else
-            for (i=0; i < (ssize_t) channels; i++)
-              r[i]=p[4*channels+i];
-        }
-      q+=2*GetPixelChannels(magnify_image);
+      
+      channels = GetPixelChannels(image);
+
+      Scale2x(p,r,channels);
+
+      for (i=0; i < (ssize_t) channels * 2; i++)
+        q[i]=r[i];
+
+      for (i=0; i < (ssize_t) channels * 2; i++)
+        q[channels * (magnify_image->columns-1) + i]=r[2+i];
+
+      q+=magnification*GetPixelChannels(magnify_image);
     }
+
     if (SyncCacheViewAuthenticPixels(magnify_view,exception) == MagickFalse)
       status=MagickFalse;
     if (image->progress_monitor != (MagickProgressMonitor) NULL)

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2132,105 +2132,104 @@ MixPixels(src_image,(size_t[8]){A,B,C,D,E,F,G,H},8,dst_image,dst_off,channels);\
 break;
 
   switch (rule)
-    {
-      case 0:
-        CopyPixel(src_image,e,dst_image,dst_off,channels);
-        break;
+  {
+    case 0:
+      CopyPixel(src_image,e,dst_image,dst_off,channels);
+      break;
 
-      caseA(1, e,e,e,a)
-      caseA(2, e,e,e,d)
-      caseA(3, e,e,e,b)
-      caseA(4, e,e,d,b)
-      caseA(5, e,e,a,b)
-      caseA(6, e,e,a,d)
-      caseB(7, e,e,e,e,e,b,b,d)
-      caseB(8, e,e,e,e,e,d,d,b)
-      caseB(9, e,e,e,e,e,e,d,b)
-      caseB(10,e,e,d,d,d,b,b,b)
-      
-      case 11:
+    caseA(1, e,e,e,a)
+    caseA(2, e,e,e,d)
+    caseA(3, e,e,e,b)
+    caseA(4, e,e,d,b)
+    caseA(5, e,e,a,b)
+    caseA(6, e,e,a,d)
+    caseB(7, e,e,e,e,e,b,b,d)
+    caseB(8, e,e,e,e,e,d,d,b)
+    caseB(9, e,e,e,e,e,e,d,b)
+    caseB(10,e,e,d,d,d,b,b,b)
+    
+    case 11:
+      MixPixels(src_image,(size_t[16]){e,e,e,e,e,e,e,e,e,e,e,e,e,e,d,b},16,
+        dst_image,dst_off,channels);
+      break;
+
+    case 12:
+      if (PixelsEqual(src_image,b,src_image,d,channels))
+        MixPixels(src_image,(size_t[4]){e,e,d,b},4,dst_image,dst_off,
+          channels);
+      else
+        CopyPixel(src_image,e,dst_image,dst_off,channels);
+
+      break;
+
+    case 13:
+      if (PixelsEqual(src_image,b,src_image,d,channels))
+        MixPixels(src_image,(size_t[8]){e,e,d,d,d,b,b,b},8,dst_image,dst_off,
+          channels);
+      else
+        CopyPixel(src_image,e,dst_image,dst_off,channels);
+
+      break;
+
+    case 14:
+      if (PixelsEqual(src_image,b,src_image,d,channels))
         MixPixels(src_image,(size_t[16]){e,e,e,e,e,e,e,e,e,e,e,e,e,e,d,b},16,
           dst_image,dst_off,channels);
-        break;
+      else
+        CopyPixel(src_image,e,dst_image,dst_off,channels);
 
-      case 12:
-        if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[4]){e,e,d,b},4,dst_image,dst_off,
-            channels);
-        else
-          CopyPixel(src_image,e,dst_image,dst_off,channels);
+      break;
+  
+    case 15:
+      if (PixelsEqual(src_image,b,src_image,d,channels))
+        MixPixels(src_image,(size_t[4]){e,e,d,b},4,dst_image,dst_off,
+          channels);
+      else
+        MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
+          channels);
 
-        break;
+      break;
 
-      case 13:
-        if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[8]){e,e,d,d,d,b,b,b},8,dst_image,dst_off,
-            channels);
-        else
-          CopyPixel(src_image,e,dst_image,dst_off,channels);
+    case 16:
+      if (PixelsEqual(src_image,b,src_image,d,channels))
+        MixPixels(src_image,(size_t[8]){e,e,e,e,e,e,d,b},8,dst_image,dst_off,
+          channels);
+      else
+        MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
+          channels);
 
-        break;
+      break;
 
-      case 14:
-        if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[16]){e,e,e,e,e,e,e,e,e,e,e,e,e,e,d,b},16,
-            dst_image,dst_off,channels);
-        else
-          CopyPixel(src_image,e,dst_image,dst_off,channels);
+    case 17:
+      if (PixelsEqual(src_image,b,src_image,d,channels))
+        MixPixels(src_image,(size_t[8]){e,e,d,d,d,b,b,b},8,dst_image,dst_off,
+          channels);
+      else
+        MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
+          channels);
 
-        break;
-    
-      case 15:
-        if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[4]){e,e,d,b},4,dst_image,dst_off,
-            channels);
-        else
-          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
-            channels);
+      break;
 
-        break;
+    case 18:
+      if (PixelsEqual(src_image,b,src_image,f,channels))
+        MixPixels(src_image,(size_t[8]){e,e,e,e,e,b,b,d},8,dst_image,dst_off,
+          channels);
+      else
+        MixPixels(src_image,(size_t[4]){e,e,e,d},4,dst_image,dst_off,
+          channels);
 
-      case 16:
-        if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[8]){e,e,e,e,e,e,d,b},8,dst_image,dst_off,
-            channels);
-        else
-          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
-            channels);
+      break;
 
-        break;
-
-      case 17:
-        if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[8]){e,e,d,d,d,b,b,b},8,dst_image,dst_off,
-            channels);
-        else
-          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
-            channels);
-
-        break;
-
-      case 18:
-        if (PixelsEqual(src_image,b,src_image,f,channels))
-          MixPixels(src_image,(size_t[8]){e,e,e,e,e,b,b,d},8,dst_image,dst_off,
-            channels);
-        else
-          MixPixels(src_image,(size_t[4]){e,e,e,d},4,dst_image,dst_off,
-            channels);
-
-        break;
-
-      default:
-        if (PixelsEqual(src_image,d,src_image,h,channels))
-          MixPixels(src_image,(size_t[8]){e,e,e,e,e,d,d,b},8,dst_image,dst_off,
-            channels);
-        else
-          MixPixels(src_image,(size_t[4]){e,e,e,b},4,dst_image,dst_off,
-            channels);
-        
-        break;
-    }
-
+    default:
+      if (PixelsEqual(src_image,d,src_image,h,channels))
+        MixPixels(src_image,(size_t[8]){e,e,e,e,e,d,d,b},8,dst_image,dst_off,
+          channels);
+      else
+        MixPixels(src_image,(size_t[4]){e,e,e,b},4,dst_image,dst_off,
+          channels);
+      
+      break;
+  }
   #undef caseA
   #undef caseB
 }
@@ -2242,10 +2241,10 @@ unsigned int Hq2XPatternToNumber(const int *pattern)
     order=1;
 
   for (int i=7; i>=0; i--)
-    {
-      result += order * pattern[i];
-      order *= 2;
-    }
+  {
+    result += order * pattern[i];
+    order *= 2;
+  }
   return result;
 }
 
@@ -2272,8 +2271,6 @@ void Hq2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
     4, 4, 6,  2, 4, 4, 6,  2, 5,  3,  1, 12, 5,  3,  1, 14
   };
 
-  #define Rotated(p) p[2], p[4], p[7], p[1], p[6], p[0], p[3], p[5]
-
   const int pattern1[] = 
   {
     !PixelsEqual(neighbourhood,4,neighbourhood,8,channels),
@@ -2286,9 +2283,11 @@ void Hq2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
     !PixelsEqual(neighbourhood,4,neighbourhood,0,channels)
   };
 
+#define Rotated(p) p[2], p[4], p[7], p[1], p[6], p[0], p[3], p[5]
   const int pattern2[] = { Rotated(pattern1) };
   const int pattern3[] = { Rotated(pattern2) };
   const int pattern4[] = { Rotated(pattern3) };
+#undef Rotated
 
   Hq2XHelper(Hq2XTable[Hq2XPatternToNumber(pattern1)],neighbourhood,result,0,
     channels,4,0,1,3,5,7);
@@ -2301,8 +2300,6 @@ void Hq2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
 
   Hq2XHelper(Hq2XTable[Hq2XPatternToNumber(pattern4)],neighbourhood,result,2,
     channels,4,6,3,7,1,5);
-
-  #undef Rotated
 }
 
 void Fish2X(const Image *src_image,const Quantum *neighbourhood,
@@ -2314,8 +2311,10 @@ void Fish2X(const Image *src_image,const Quantum *neighbourhood,
     intensities[i] = GetPixelIntensity(src_image,neighbourhood + i*channels);
 
   CopyPixel(neighbourhood,0,result,0,channels);
-  CopyPixel(neighbourhood,intensities[0] > intensities[1] ? 0 : 1,result,1,channels);
-  CopyPixel(neighbourhood,intensities[0] > intensities[3] ? 0 : 3,result,2,channels);
+  CopyPixel(neighbourhood,intensities[0] > intensities[1] ? 0 : 1,result,1,
+    channels);
+  CopyPixel(neighbourhood,intensities[0] > intensities[3] ? 0 : 3,result,2,
+    channels);
 
   const int ae = PixelsEqual(neighbourhood,0,neighbourhood,4,channels);
   const int bd = PixelsEqual(neighbourhood,1,neighbourhood,3,channels);
@@ -2368,9 +2367,8 @@ else\
 void Xbr2X(const Image *src_image,const Quantum *neighbourhood,
   Quantum *result,size_t channels)
 {
-  #define WeightVar(M,N) const int w_##M##_##N = \
-    PixelsEqual(neighbourhood,M,neighbourhood,N,channels) ? 0 : 1;
-
+#define WeightVar(M,N) const int w_##M##_##N = \
+  PixelsEqual(neighbourhood,M,neighbourhood,N,channels) ? 0 : 1;
   WeightVar(12,11)
   WeightVar(12,7)
   WeightVar(12,13)
@@ -2399,8 +2397,7 @@ void Xbr2X(const Image *src_image,const Quantum *neighbourhood,
   WeightVar(18,22)
   WeightVar(17,23)
   WeightVar(17,19)
-
-  #undef WeightVar
+#undef WeightVar
   
   if (
     w_12_16 + w_12_8 + w_6_10 + w_6_2 + (4 * w_11_7) <
@@ -2471,14 +2468,14 @@ void Scale2X(const Image *src_image,const Quantum *neighbourhood,
 void Epbx2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
   size_t channels)
 {
-  #define HelperCond(a,b,c,d,e,f,g) (\
-    PixelsEqual(neighbourhood,a,neighbourhood,b,channels) && ( \
-      PixelsEqual(neighbourhood,c,neighbourhood,d,channels) || \
-      PixelsEqual(neighbourhood,c,neighbourhood,e,channels) || \
-      PixelsEqual(neighbourhood,a,neighbourhood,f,channels) || \
-      PixelsEqual(neighbourhood,b,neighbourhood,g,channels) \
-      )\
-    )
+#define HelperCond(a,b,c,d,e,f,g) (\
+  PixelsEqual(neighbourhood,a,neighbourhood,b,channels) && (\
+    PixelsEqual(neighbourhood,c,neighbourhood,d,channels) ||\
+    PixelsEqual(neighbourhood,c,neighbourhood,e,channels) ||\
+    PixelsEqual(neighbourhood,a,neighbourhood,f,channels) ||\
+    PixelsEqual(neighbourhood,b,neighbourhood,g,channels)\
+    )\
+  )
 
   for (unsigned char i=0; i<4; i++)
     CopyPixel(neighbourhood,4,result,i,channels);
@@ -2519,7 +2516,7 @@ void Epbx2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
         Mix2Pixels(neighbourhood,7,5,result,3,channels);
     }
 
-  #undef HelperCond
+#undef HelperCond
 }
 
 void Eagle3X(const Image *src_image,const Quantum *neighbourhood,
@@ -2755,68 +2752,68 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     algorithm = "scale2x";
   
   if (LocaleCompare(algorithm,"scale2x") == 0 ||
-    LocaleCompare(algorithm,"epx") == 0 ||
-    LocaleCompare(algorithm,"scale2") == 0)
+      LocaleCompare(algorithm,"epx") == 0 ||
+      LocaleCompare(algorithm,"scale2") == 0)
     {
       alg_function = Scale2X;
       magnification = 2;
       neighbourhood = 3;
     }
   else if (LocaleCompare(algorithm,"eagle2x") == 0 ||
-    LocaleCompare(algorithm,"eagle2") == 0 ||
-    LocaleCompare(algorithm,"eagle") == 0)
+      LocaleCompare(algorithm,"eagle2") == 0 ||
+      LocaleCompare(algorithm,"eagle") == 0)
     {
       alg_function = Eagle2X;
       magnification = 2;
       neighbourhood = 3;
     }
   else if (LocaleCompare(algorithm,"scale3x") == 0 ||
-    LocaleCompare(algorithm,"scale3") == 0)
+      LocaleCompare(algorithm,"scale3") == 0)
     {
       alg_function = Scale3X;
       magnification = 3;
       neighbourhood = 3;
     }
   else if (LocaleCompare(algorithm,"eagle3x") == 0 ||
-    LocaleCompare(algorithm,"eagle3") == 0)
+      LocaleCompare(algorithm,"eagle3") == 0)
     {
       alg_function = Eagle3X;
       magnification = 3;
       neighbourhood = 3;
     }
   else if (LocaleCompare(algorithm,"eagle3xb") == 0 ||
-    LocaleCompare(algorithm,"eagle3b") == 0)
+      LocaleCompare(algorithm,"eagle3b") == 0)
     {
       alg_function = Eagle3XB;
       magnification = 3;
       neighbourhood = 3;
     }
   else if (LocaleCompare(algorithm,"epbx") == 0 ||
-    LocaleCompare(algorithm,"epbx2") == 0 ||
-    LocaleCompare(algorithm,"epbx2x") == 0)
+      LocaleCompare(algorithm,"epbx2") == 0 ||
+      LocaleCompare(algorithm,"epbx2x") == 0)
     {
       alg_function = Epbx2X;
       magnification = 2;
       neighbourhood = 3;
     }
   else if (LocaleCompare(algorithm,"hqx") == 0 ||
-    LocaleCompare(algorithm,"hq2x") == 0)
+      LocaleCompare(algorithm,"hq2x") == 0)
     {
       alg_function = Hq2X;
       magnification = 2;
       neighbourhood = 3;
     }
   else if (LocaleCompare(algorithm,"fish") == 0 ||
-    LocaleCompare(algorithm,"fish2") == 0 ||
-    LocaleCompare(algorithm,"fish2x") == 0)
+      LocaleCompare(algorithm,"fish2") == 0 ||
+      LocaleCompare(algorithm,"fish2x") == 0)
     {
       alg_function = Fish2X;
       magnification = 2;
       neighbourhood = 3;
     }
   else if (LocaleCompare(algorithm,"xbr") == 0 ||
-    LocaleCompare(algorithm,"xbr2") == 0 ||
-    LocaleCompare(algorithm,"xbr2x") == 0)
+      LocaleCompare(algorithm,"xbr2") == 0 ||
+      LocaleCompare(algorithm,"xbr2x") == 0)
     {
       alg_function = Xbr2X;
       magnification = 2;
@@ -2832,10 +2829,12 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",image->filename);
   assert(exception != (ExceptionInfo *) NULL);
   assert(exception->signature == MagickCoreSignature);
+
   /*
     Make a working copy of the source image and convert it to RGB colorspace.
   */
-  source_image=CloneImage(image,image->columns,image->rows,MagickTrue,exception);
+  source_image=CloneImage(image,image->columns,image->rows,MagickTrue,
+    exception);
   OffsetInfo offset;
   offset.x = 0;
   offset.y = 0;
@@ -2851,8 +2850,9 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     magnification*source_image->rows,MagickTrue,exception);
   if (magnify_image == (Image *) NULL)
     return((Image *) NULL);
+
   /*
-    Magnify image.
+    Magnify the image.
   */
   status=MagickTrue;
   progress=0;
@@ -2870,7 +2870,7 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     register ssize_t
       x;
 
-    Quantum r[128];   // to hold result pixels
+    Quantum r[128]; // to hold result pixels
 
     if (status == MagickFalse)
       continue;
@@ -2903,10 +2903,13 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
 
       alg_function(source_image,p,r,channels);
 
+      /*
+        Copy the result pixels into the final image.
+      */
       for (j=0; j < magnification; j++)
-        for (i=0; i < (ssize_t) channels * magnification; i++)
-          q[j * channels * magnify_image->columns + i]=
-            r[j * magnification * channels + i];
+        for (i=0; i < (ssize_t) channels*magnification; i++)
+          q[j*channels*magnify_image->columns+i]=
+            r[j*magnification*channels+i];
 
       q+=magnification*GetPixelChannels(magnify_image);
     }

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2035,7 +2035,8 @@ MagickExport Image *LiquidRescaleImage(const Image *image,
 #endif
 
 
-void CopyPixel(const Quantum *src, size_t src_off, Quantum *dst, size_t dst_off, size_t channels)
+void CopyPixel(const Quantum *src,size_t src_off,Quantum *dst,size_t dst_off,
+  size_t channels)
 {
   register ssize_t
     i;
@@ -2044,7 +2045,11 @@ void CopyPixel(const Quantum *src, size_t src_off, Quantum *dst, size_t dst_off,
     dst[channels*dst_off+i] = src[src_off*channels+i];
 }
 
-void MixPixels(const Quantum *src, size_t *src_offs, size_t src_offs_size, Quantum *dst, size_t dst_off, size_t channels)
+/*
+  Helper function for pixel art scaling.
+*/
+void MixPixels(const Quantum *src,size_t *src_offs,size_t src_offs_size,
+  Quantum *dst,size_t dst_off,size_t channels)
 {
   int sum;
 
@@ -2062,12 +2067,14 @@ void MixPixels(const Quantum *src, size_t *src_offs, size_t src_offs_size, Quant
   }
 }
 
-void Mix2Pixels(const Quantum *src, size_t src_off1, size_t src_off2, Quantum *dst, size_t dst_off, size_t channels)
+void Mix2Pixels(const Quantum *src,size_t src_off1,size_t src_off2,Quantum *dst,
+  size_t dst_off,size_t channels)
 {
   MixPixels(src,(size_t[2]){src_off1,src_off2},2,dst,dst_off,channels);
 }
 
-int PixelsEqual(const Quantum *src1, size_t off1, const Quantum *src2, size_t off2, size_t channels)
+int PixelsEqual(const Quantum *src1,size_t off1,const Quantum *src2,size_t off2,
+  size_t channels)
 {
   register ssize_t
     i;
@@ -2075,16 +2082,17 @@ int PixelsEqual(const Quantum *src1, size_t off1, const Quantum *src2, size_t of
   off1 *= channels;
   off2 *= channels;
 
-  for (i=0; i < channels; i++)
-    if (src1[off1 + i] != src2[off2 + i])
+  for (i=0; i<channels; i++)
+    if (src1[off1+i] != src2[off2+i])
       return 0;
 
   return 1;
 }
 
-void Eagle2X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Eagle2X(const Image *src_image,const Quantum *neighbourhood,
+  Quantum *result,size_t channels)
 {
-  for (unsigned char i=0; i < 4; i++)
+  for (unsigned char i=0; i<4; i++)
     CopyPixel(neighbourhood,4,result,i,channels);
 
   if (PixelsEqual(neighbourhood,0,neighbourhood,1,channels) &&
@@ -2104,32 +2112,8 @@ void Eagle2X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
     CopyPixel(neighbourhood,8,result,3,channels);
 }
 
-unsigned int hq2x_table[] =
-{
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 15, 12, 5,  3, 17, 13,
-  4, 4, 6, 18, 4, 4, 6, 18, 5,  3, 12, 12, 5,  3,  1, 12,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 17, 13, 5,  3, 16, 14,
-  4, 4, 6, 18, 4, 4, 6, 18, 5,  3, 16, 12, 5,  3,  1, 14,
-  4, 4, 6,  2, 4, 4, 6,  2, 5, 19, 12, 12, 5, 19, 16, 12,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3, 16, 12,
-  4, 4, 6,  2, 4, 4, 6,  2, 5, 19,  1, 12, 5, 19,  1, 14,
-  4, 4, 6,  2, 4, 4, 6, 18, 5,  3, 16, 12, 5, 19,  1, 14,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 15, 12, 5,  3, 17, 13,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3, 16, 12,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 17, 13, 5,  3, 16, 14,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 13, 5,  3,  1, 14,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3, 16, 13,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3,  1, 12,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3,  1, 14,
-  4, 4, 6,  2, 4, 4, 6,  2, 5,  3,  1, 12, 5,  3,  1, 14
-};
-
-void Hq2XHelper(
-  unsigned int rule,
-  const Quantum *src_image,
-  Quantum *dst_image,
-  size_t dst_off,
-  size_t channels,
+void Hq2XHelper(unsigned int rule,const Quantum *src_image,Quantum *dst_image,
+  size_t dst_off,size_t channels,
   size_t e,
   size_t a,
   size_t b,
@@ -2137,15 +2121,15 @@ void Hq2XHelper(
   size_t f,
   size_t h)
 {
-  #define caseA(N,A,B,C,D)\
-    case N:\
-      MixPixels(src_image,(size_t[4]){A,B,C,D},4,dst_image,dst_off,channels);\
-      break;
+#define caseA(N,A,B,C,D)\
+case N:\
+MixPixels(src_image,(size_t[4]){A,B,C,D},4,dst_image,dst_off,channels);\
+break;
 
-  #define caseB(N,A,B,C,D,E,F,G,H)\
-    case N:\
-      MixPixels(src_image,(size_t[8]){A,B,C,D,E,F,G,H},8,dst_image,dst_off,channels);\
-      break;
+#define caseB(N,A,B,C,D,E,F,G,H)\
+case N:\
+MixPixels(src_image,(size_t[8]){A,B,C,D,E,F,G,H},8,dst_image,dst_off,channels);\
+break;
 
   switch (rule)
     {
@@ -2165,12 +2149,14 @@ void Hq2XHelper(
       caseB(10,e,e,d,d,d,b,b,b)
       
       case 11:
-        MixPixels(src_image,(size_t[16]){e,e,e,e,e,e,e,e,e,e,e,e,e,e,d,b},16,dst_image,dst_off,channels);
+        MixPixels(src_image,(size_t[16]){e,e,e,e,e,e,e,e,e,e,e,e,e,e,d,b},16,
+          dst_image,dst_off,channels);
         break;
 
       case 12:
         if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[4]){e,e,d,b},4,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[4]){e,e,d,b},4,dst_image,dst_off,
+            channels);
         else
           CopyPixel(src_image,e,dst_image,dst_off,channels);
 
@@ -2178,7 +2164,8 @@ void Hq2XHelper(
 
       case 13:
         if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[8]){e,e,d,d,d,b,b,b},8,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[8]){e,e,d,d,d,b,b,b},8,dst_image,dst_off,
+            channels);
         else
           CopyPixel(src_image,e,dst_image,dst_off,channels);
 
@@ -2186,7 +2173,8 @@ void Hq2XHelper(
 
       case 14:
         if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[16]){e,e,e,e,e,e,e,e,e,e,e,e,e,e,d,b},16,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[16]){e,e,e,e,e,e,e,e,e,e,e,e,e,e,d,b},16,
+            dst_image,dst_off,channels);
         else
           CopyPixel(src_image,e,dst_image,dst_off,channels);
 
@@ -2194,41 +2182,51 @@ void Hq2XHelper(
     
       case 15:
         if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[4]){e,e,d,b},4,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[4]){e,e,d,b},4,dst_image,dst_off,
+            channels);
         else
-          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
+            channels);
 
         break;
 
       case 16:
         if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[8]){e,e,e,e,e,e,d,b},8,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[8]){e,e,e,e,e,e,d,b},8,dst_image,dst_off,
+            channels);
         else
-          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
+            channels);
 
         break;
 
       case 17:
         if (PixelsEqual(src_image,b,src_image,d,channels))
-          MixPixels(src_image,(size_t[8]){e,e,d,d,d,b,b,b},8,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[8]){e,e,d,d,d,b,b,b},8,dst_image,dst_off,
+            channels);
         else
-          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[4]){e,e,e,a},4,dst_image,dst_off,
+            channels);
 
         break;
 
       case 18:
         if (PixelsEqual(src_image,b,src_image,f,channels))
-          MixPixels(src_image,(size_t[8]){e,e,e,e,e,b,b,d},8,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[8]){e,e,e,e,e,b,b,d},8,dst_image,dst_off,
+            channels);
         else
-          MixPixels(src_image,(size_t[4]){e,e,e,d},4,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[4]){e,e,e,d},4,dst_image,dst_off,
+            channels);
 
         break;
 
       default:
         if (PixelsEqual(src_image,d,src_image,h,channels))
-          MixPixels(src_image,(size_t[8]){e,e,e,e,e,d,d,b},8,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[8]){e,e,e,e,e,d,d,b},8,dst_image,dst_off,
+            channels);
         else
-          MixPixels(src_image,(size_t[4]){e,e,e,b},4,dst_image,dst_off,channels);
+          MixPixels(src_image,(size_t[4]){e,e,e,b},4,dst_image,dst_off,
+            channels);
         
         break;
     }
@@ -2239,52 +2237,81 @@ void Hq2XHelper(
 
 unsigned int Hq2XPatternToNumber(int *pattern)
 {
-  unsigned int result = 0;
-  unsigned int order = 1;
+  unsigned int
+    result=0,
+    order=1;
 
-  for (int i=7; i >= 0; i--)
-  {
-    result += order * pattern[i];
-    order *= 2;
-  }
-
+  for (int i=7; i>=0; i--)
+    {
+      result += order * pattern[i];
+      order *= 2;
+    }
   return result;
 }
 
-void Hq2X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Hq2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
+  size_t channels)
 {
+  static const unsigned int Hq2XTable[] =
+  {
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 15, 12, 5,  3, 17, 13,
+    4, 4, 6, 18, 4, 4, 6, 18, 5,  3, 12, 12, 5,  3,  1, 12,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 17, 13, 5,  3, 16, 14,
+    4, 4, 6, 18, 4, 4, 6, 18, 5,  3, 16, 12, 5,  3,  1, 14,
+    4, 4, 6,  2, 4, 4, 6,  2, 5, 19, 12, 12, 5, 19, 16, 12,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3, 16, 12,
+    4, 4, 6,  2, 4, 4, 6,  2, 5, 19,  1, 12, 5, 19,  1, 14,
+    4, 4, 6,  2, 4, 4, 6, 18, 5,  3, 16, 12, 5, 19,  1, 14,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 15, 12, 5,  3, 17, 13,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3, 16, 12,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 17, 13, 5,  3, 16, 14,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 13, 5,  3,  1, 14,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3, 16, 13,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3,  1, 12,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3, 16, 12, 5,  3,  1, 14,
+    4, 4, 6,  2, 4, 4, 6,  2, 5,  3,  1, 12, 5,  3,  1, 14
+  };
+
   #define Rotated(p) p[2], p[4], p[7], p[1], p[6], p[0], p[3], p[5]
 
   int pattern1[] = 
-    {
-      !PixelsEqual(neighbourhood,4,neighbourhood,8,channels),
-      !PixelsEqual(neighbourhood,4,neighbourhood,7,channels),
-      !PixelsEqual(neighbourhood,4,neighbourhood,6,channels),
-      !PixelsEqual(neighbourhood,4,neighbourhood,5,channels),
-      !PixelsEqual(neighbourhood,4,neighbourhood,3,channels),
-      !PixelsEqual(neighbourhood,4,neighbourhood,2,channels),
-      !PixelsEqual(neighbourhood,4,neighbourhood,1,channels),
-      !PixelsEqual(neighbourhood,4,neighbourhood,0,channels)
-    };
+  {
+    !PixelsEqual(neighbourhood,4,neighbourhood,8,channels),
+    !PixelsEqual(neighbourhood,4,neighbourhood,7,channels),
+    !PixelsEqual(neighbourhood,4,neighbourhood,6,channels),
+    !PixelsEqual(neighbourhood,4,neighbourhood,5,channels),
+    !PixelsEqual(neighbourhood,4,neighbourhood,3,channels),
+    !PixelsEqual(neighbourhood,4,neighbourhood,2,channels),
+    !PixelsEqual(neighbourhood,4,neighbourhood,1,channels),
+    !PixelsEqual(neighbourhood,4,neighbourhood,0,channels)
+  };
 
   int pattern2[] = { Rotated(pattern1) };
   int pattern3[] = { Rotated(pattern2) };
   int pattern4[] = { Rotated(pattern3) };
 
-  Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern1)],neighbourhood,result,0,channels,4,0,1,3,5,7);
-  Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern2)],neighbourhood,result,1,channels,4,2,5,1,7,3);
-  Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern3)],neighbourhood,result,3,channels,4,8,7,5,3,1);
-  Hq2XHelper(hq2x_table[Hq2XPatternToNumber(pattern4)],neighbourhood,result,2,channels,4,6,3,7,1,5);
+  Hq2XHelper(Hq2XTable[Hq2XPatternToNumber(pattern1)],neighbourhood,result,0,
+    channels,4,0,1,3,5,7);
+
+  Hq2XHelper(Hq2XTable[Hq2XPatternToNumber(pattern2)],neighbourhood,result,1,
+    channels,4,2,5,1,7,3);
+
+  Hq2XHelper(Hq2XTable[Hq2XPatternToNumber(pattern3)],neighbourhood,result,3,
+    channels,4,8,7,5,3,1);
+
+  Hq2XHelper(Hq2XTable[Hq2XPatternToNumber(pattern4)],neighbourhood,result,2,
+    channels,4,6,3,7,1,5);
 
   #undef Rotated
 }
 
-void Scale2X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Scale2X(const Image *src_image,const Quantum *neighbourhood,
+  Quantum *result,size_t channels)
 {
   if (PixelsEqual(neighbourhood,1,neighbourhood,7,channels) ||
       PixelsEqual(neighbourhood,3,neighbourhood,5,channels))
     {
-      for (unsigned char i=0; i < 4; i++)
+      for (unsigned char i=0; i<4; i++)
         CopyPixel(neighbourhood,4,result,i,channels);
     }
   else
@@ -2311,7 +2338,8 @@ void Scale2X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
     }
 }
 
-void Epx2X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Epx2X(const Image *src_image,const Quantum *neighbourhood,Quantum *result,
+  size_t channels)
 {
   #define HelperCond(a,b,c,d,e,f,g) (\
     PixelsEqual(neighbourhood,a,neighbourhood,b,channels) && ( \
@@ -2322,11 +2350,12 @@ void Epx2X(const Image *src_image, const Quantum *neighbourhood, Quantum *result
       )\
     )
 
-  for (unsigned char i=0; i < 4; i++)
+  for (unsigned char i=0; i<4; i++)
     CopyPixel(neighbourhood,4,result,i,channels);
 
   if (
-    !PixelsEqual(neighbourhood,3,neighbourhood,5,channels) && !PixelsEqual(neighbourhood,1,neighbourhood,7,channels) &&
+    !PixelsEqual(neighbourhood,3,neighbourhood,5,channels) &&
+    !PixelsEqual(neighbourhood,1,neighbourhood,7,channels) &&
     (
       PixelsEqual(neighbourhood,4,neighbourhood,3,channels) ||
       PixelsEqual(neighbourhood,4,neighbourhood,7,channels) ||
@@ -2363,7 +2392,8 @@ void Epx2X(const Image *src_image, const Quantum *neighbourhood, Quantum *result
   #undef HelperCond
 }
 
-void Eagle3X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Eagle3X(const Image *src_image,const Quantum *neighbourhood,
+  Quantum *result,size_t channels)
 {
   int corner_tl =
     PixelsEqual(neighbourhood,0,neighbourhood,1,channels) &&
@@ -2412,7 +2442,8 @@ void Eagle3X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
   CopyPixel(neighbourhood,corner_br ? 5 : 4,result,8,channels);
 }
 
-void Eagle3XB(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Eagle3XB(const Image *src_image,const Quantum *neighbourhood,
+  Quantum *result,size_t channels)
 {
   int corner_tl =
     PixelsEqual(neighbourhood,0,neighbourhood,1,channels) &&
@@ -2441,7 +2472,8 @@ void Eagle3XB(const Image *src_image, const Quantum *neighbourhood, Quantum *res
   CopyPixel(neighbourhood,corner_br ? 5 : 4,result,8,channels);
 }
 
-void Scale3X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Scale3X(const Image *src_image,const Quantum *neighbourhood,
+  Quantum *result,size_t channels)
 {
   if (!PixelsEqual(neighbourhood,1,neighbourhood,7,channels) &&
       !PixelsEqual(neighbourhood,3,neighbourhood,5,channels))
@@ -2452,9 +2484,15 @@ void Scale3X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
         CopyPixel(neighbourhood,4,result,0,channels);
 
       if (
-        ( PixelsEqual(neighbourhood,3,neighbourhood,1,channels) && !PixelsEqual(neighbourhood,4,neighbourhood,2,channels) ) ||
-        ( PixelsEqual(neighbourhood,5,neighbourhood,1,channels) && !PixelsEqual(neighbourhood,4,neighbourhood,0,channels) )
+        (
+          PixelsEqual(neighbourhood,3,neighbourhood,1,channels) &&
+          !PixelsEqual(neighbourhood,4,neighbourhood,2,channels)
+        ) ||
+        (
+          PixelsEqual(neighbourhood,5,neighbourhood,1,channels) &&
+          !PixelsEqual(neighbourhood,4,neighbourhood,0,channels)
         )
+      )
         CopyPixel(neighbourhood,1,result,1,channels);
       else
         CopyPixel(neighbourhood,4,result,1,channels);
@@ -2465,9 +2503,15 @@ void Scale3X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
         CopyPixel(neighbourhood,4,result,2,channels);
 
       if (
-        ( PixelsEqual(neighbourhood,3,neighbourhood,1,channels) && !PixelsEqual(neighbourhood,4,neighbourhood,6,channels) ) ||
-        ( PixelsEqual(neighbourhood,3,neighbourhood,7,channels) && !PixelsEqual(neighbourhood,4,neighbourhood,0,channels) )
+        (
+          PixelsEqual(neighbourhood,3,neighbourhood,1,channels) &&
+          !PixelsEqual(neighbourhood,4,neighbourhood,6,channels)
+        ) ||
+        (
+          PixelsEqual(neighbourhood,3,neighbourhood,7,channels) &&
+          !PixelsEqual(neighbourhood,4,neighbourhood,0,channels)
         )
+      )
         CopyPixel(neighbourhood,3,result,3,channels);
       else
         CopyPixel(neighbourhood,4,result,3,channels);
@@ -2475,9 +2519,15 @@ void Scale3X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
       CopyPixel(neighbourhood,4,result,4,channels);
 
       if (
-        ( PixelsEqual(neighbourhood,5,neighbourhood,1,channels) && !PixelsEqual(neighbourhood,4,neighbourhood,8,channels) ) ||
-        ( PixelsEqual(neighbourhood,5,neighbourhood,7,channels) && !PixelsEqual(neighbourhood,4,neighbourhood,2,channels) )
+        (
+          PixelsEqual(neighbourhood,5,neighbourhood,1,channels) &&
+          !PixelsEqual(neighbourhood,4,neighbourhood,8,channels)
+        ) ||
+        (
+          PixelsEqual(neighbourhood,5,neighbourhood,7,channels) &&
+          !PixelsEqual(neighbourhood,4,neighbourhood,2,channels)
         )
+      )
         CopyPixel(neighbourhood,5,result,5,channels);
       else      
         CopyPixel(neighbourhood,4,result,5,channels);
@@ -2488,9 +2538,15 @@ void Scale3X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
         CopyPixel(neighbourhood,4,result,6,channels);
 
       if (
-        ( PixelsEqual(neighbourhood,3,neighbourhood,7,channels) && !PixelsEqual(neighbourhood,4,neighbourhood,8,channels) ) ||
-        ( PixelsEqual(neighbourhood,5,neighbourhood,7,channels) && !PixelsEqual(neighbourhood,4,neighbourhood,6,channels) )
+        (
+          PixelsEqual(neighbourhood,3,neighbourhood,7,channels) &&
+          !PixelsEqual(neighbourhood,4,neighbourhood,8,channels)
+        ) ||
+        (
+          PixelsEqual(neighbourhood,5,neighbourhood,7,channels) &&
+          !PixelsEqual(neighbourhood,4,neighbourhood,6,channels)
         )
+      )
         CopyPixel(neighbourhood,7,result,7,channels);
       else      
         CopyPixel(neighbourhood,4,result,7,channels);
@@ -2621,8 +2677,8 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",image->filename);
   assert(exception != (ExceptionInfo *) NULL);
   assert(exception->signature == MagickCoreSignature);
-  magnify_image=CloneImage(image,magnification*image->columns,magnification*image->rows,MagickTrue,
-    exception);
+  magnify_image=CloneImage(image,magnification*image->columns,
+    magnification*image->rows,MagickTrue,exception);
   if (magnify_image == (Image *) NULL)
     return((Image *) NULL);
   /*
@@ -2644,12 +2700,12 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
     register ssize_t
       x;
 
-    Quantum r[128]; // TODO - 128
+    Quantum r[128];   // to hold result pixels
 
     if (status == MagickFalse)
       continue;
-    q=QueueCacheViewAuthenticPixels(magnify_view,0,magnification*y,magnify_image->columns,magnification,
-      exception);
+    q=QueueCacheViewAuthenticPixels(magnify_view,0,magnification*y,
+      magnify_image->columns,magnification,exception);
     if (q == (Quantum *) NULL)
       {
         status=MagickFalse;
@@ -2678,7 +2734,8 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
 
       for (j=0; j < magnification; j++)
         for (i=0; i < (ssize_t) channels * magnification; i++)
-          q[j * channels * magnify_image->columns + i]=r[j * magnification * channels + i];
+          q[j * channels * magnify_image->columns + i]=
+            r[j * magnification * channels + i];
 
       q+=magnification*GetPixelChannels(magnify_image);
     }

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2160,7 +2160,7 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
         q[i]=r[i];
 
       for (i=0; i < (ssize_t) channels * 2; i++)
-        q[channels * (magnify_image->columns-1) + i]=r[2+i];
+        q[channels * (magnify_image->columns-2) + i]=r[2*channels+i];
 
       q+=magnification*GetPixelChannels(magnify_image);
     }

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2121,6 +2121,29 @@ void Scale2X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
     }
 }
 
+void Scale3X(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
+{
+  register ssize_t
+    i;
+
+  MagickRealType
+    intensity[9];
+
+  for (i=0; i < 9; i++)
+    intensity[i]=GetPixelIntensity(src_image,neighbourhood+i*channels);
+
+/*  if (!IntensitiesEqual(intensity[1],intensity[7]) &&
+      !IntensitiesEqual(intensity[3],intensity1[5]))
+    {
+      
+    }
+  else */
+    {
+      for (i=0; i<9; i++)
+        CopyPixel(neighbourhood,4,result,i,channels);
+    }
+}
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -2187,6 +2210,11 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
       alg_function = Eagle2X;
       magnification = 2;
     }
+  else if (LocaleCompare(algorithm,"scale3x") == 0)
+    {
+      alg_function = Scale3X;
+      magnification = 3;
+    }
   else
     {
       alg_function = Scale2X;
@@ -2249,21 +2277,17 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
         channels;
 
       register ssize_t
-        i;
+        i, j;
 
       p=GetCacheViewVirtualPixels(image_view,x-1,y-1,3,3,exception);
       
       channels = GetPixelChannels(image);
 
-//      Scale2x(image,p,r,channels);
-//      Eagle2X(image,p,r,channels);
-        alg_function(image,p,r,channels);
+      alg_function(image,p,r,channels);
 
-      for (i=0; i < (ssize_t) channels * 2; i++)
-        q[i]=r[i];
-
-      for (i=0; i < (ssize_t) channels * 2; i++)
-        q[channels * (magnify_image->columns) + i]=r[2*channels+i];
+      for (j=0; j < magnification; j++)
+        for (i=0; i < (ssize_t) channels * magnification; i++)
+          q[j * channels * magnify_image->columns + i]=r[j * magnification * channels + i];
 
       q+=magnification*GetPixelChannels(magnify_image);
     }

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2035,7 +2035,7 @@ MagickExport Image *LiquidRescaleImage(const Image *image,
 #endif
 
 
-inline void CopyPixel(const Quantum *src, size_t src_off, Quantum *dst, size_t dst_off, size_t channels)
+void CopyPixel(const Quantum *src, size_t src_off, Quantum *dst, size_t dst_off, size_t channels)
 {
   register ssize_t
     i;
@@ -2044,7 +2044,7 @@ inline void CopyPixel(const Quantum *src, size_t src_off, Quantum *dst, size_t d
     dst[channels*dst_off+i] = src[src_off*channels+i];
 }
 
-inline int IntensitiesEqual(MagickRealType intensity1, MagickRealType intensity2)
+int IntensitiesEqual(MagickRealType intensity1, MagickRealType intensity2)
 {
   return (fabs(intensity1 - intensity2)) < MagickEpsilon;
 }
@@ -2198,7 +2198,7 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
   void
     (*alg_function)(const Image *, const Quantum *, Quantum *, size_t) = NULL;
 
-  algorithm = GetImageOption(image->image_info,"magnify:alg");
+  algorithm = GetImageOption(image->image_info,"magnify:method");
 
   if (algorithm == (char *) NULL)
     {

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2132,12 +2132,64 @@ void Scale3X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
   for (i=0; i < 9; i++)
     intensity[i]=GetPixelIntensity(src_image,neighbourhood+i*channels);
 
-/*  if (!IntensitiesEqual(intensity[1],intensity[7]) &&
-      !IntensitiesEqual(intensity[3],intensity1[5]))
+  if (!IntensitiesEqual(intensity[1],intensity[7]) &&
+      !IntensitiesEqual(intensity[3],intensity[5]))
     {
-      
+      if (IntensitiesEqual(intensity[3],intensity[1]))
+        CopyPixel(neighbourhood,3,result,0,channels);
+      else
+        CopyPixel(neighbourhood,4,result,0,channels);
+
+      if (
+        ( IntensitiesEqual(intensity[3],intensity[1]) && !IntensitiesEqual(intensity[4],intensity[2]) ) ||
+        ( IntensitiesEqual(intensity[5],intensity[1]) && !IntensitiesEqual(intensity[4],intensity[0]) )
+        )
+        CopyPixel(neighbourhood,1,result,1,channels);
+      else
+        CopyPixel(neighbourhood,4,result,1,channels);
+
+      if (IntensitiesEqual(intensity[5],intensity[1]))
+        CopyPixel(neighbourhood,5,result,2,channels);
+      else
+        CopyPixel(neighbourhood,4,result,2,channels);
+
+      if (
+        ( IntensitiesEqual(intensity[3],intensity[1]) && !IntensitiesEqual(intensity[4],intensity[6]) ) ||
+        ( IntensitiesEqual(intensity[3],intensity[7]) && !IntensitiesEqual(intensity[4],intensity[0]) )
+        )
+        CopyPixel(neighbourhood,3,result,3,channels);
+      else
+        CopyPixel(neighbourhood,4,result,3,channels);
+
+      CopyPixel(neighbourhood,4,result,4,channels);
+
+      if (
+        ( IntensitiesEqual(intensity[5],intensity[1]) && !IntensitiesEqual(intensity[4],intensity[8]) ) ||
+        ( IntensitiesEqual(intensity[5],intensity[7]) && !IntensitiesEqual(intensity[4],intensity[2]) )
+        )
+        CopyPixel(neighbourhood,5,result,5,channels);
+      else      
+        CopyPixel(neighbourhood,4,result,5,channels);
+
+      if (IntensitiesEqual(intensity[3],intensity[7]))
+        CopyPixel(neighbourhood,3,result,6,channels);
+      else 
+        CopyPixel(neighbourhood,4,result,6,channels);
+
+      if (
+        ( IntensitiesEqual(intensity[3],intensity[7]) && !IntensitiesEqual(intensity[4],intensity[8]) ) ||
+        ( IntensitiesEqual(intensity[5],intensity[7]) && !IntensitiesEqual(intensity[4],intensity[6]) )
+        )
+        CopyPixel(neighbourhood,7,result,7,channels);
+      else      
+        CopyPixel(neighbourhood,4,result,7,channels);
+
+      if (IntensitiesEqual(intensity[5],intensity[7]))
+        CopyPixel(neighbourhood,5,result,8,channels);
+      else 
+        CopyPixel(neighbourhood,4,result,8,channels);
     }
-  else */
+  else
     {
       for (i=0; i<9; i++)
         CopyPixel(neighbourhood,4,result,i,channels);
@@ -2205,7 +2257,8 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
       alg_function = Scale2X;
       magnification = 2;
     }
-  else if (LocaleCompare(algorithm,"eagle2x") == 0)
+  else if (LocaleCompare(algorithm,"eagle2x") == 0 ||
+    LocaleCompare(algorithm,"eagle") == 0)
     {
       alg_function = Eagle2X;
       magnification = 2;

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2062,6 +2062,22 @@ void Eagle2X(const Image *src_image, const Quantum *neighbourhood, Quantum *resu
   
   for (i=0; i < 4; i++)
     CopyPixel(neighbourhood,4,result,i,channels);
+
+  if (IntensitiesEqual(intensity[0],intensity[1]) &&
+      IntensitiesEqual(intensity[1],intensity[3]))
+    CopyPixel(neighbourhood,0,result,0,channels);
+
+  if (IntensitiesEqual(intensity[1],intensity[2]) &&
+      IntensitiesEqual(intensity[2],intensity[5]))
+    CopyPixel(neighbourhood,2,result,1,channels);
+
+  if (IntensitiesEqual(intensity[3],intensity[6]) &&
+      IntensitiesEqual(intensity[6],intensity[7]))
+    CopyPixel(neighbourhood,6,result,2,channels);
+
+  if (IntensitiesEqual(intensity[5],intensity[8]) &&
+      IntensitiesEqual(intensity[8],intensity[7]))
+    CopyPixel(neighbourhood,8,result,3,channels);
 }
 
 void Scale2x(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
@@ -2215,8 +2231,8 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
       
       channels = GetPixelChannels(image);
 
-      Scale2x(image,p,r,channels);
-      //Eagle2X(image,p,r,channels);
+//      Scale2x(image,p,r,channels);
+      Eagle2X(image,p,r,channels);
 
       for (i=0; i < (ssize_t) channels * 2; i++)
         q[i]=r[i];

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2166,8 +2166,13 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
   ssize_t
     y;
 
+  const char *
+    algorithm;
+
   unsigned char
     magnification = 2;
+
+  algorithm = GetImageOption(image->image_info,"magnify:alg");
 
   /*
     Initialize magnified image attributes.

--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -2035,13 +2035,54 @@ MagickExport Image *LiquidRescaleImage(const Image *image,
 #endif
 
 
-void Scale2x(const Quantum *neighbourhood, Quantum *result, size_t channels)
+void Scale2x(const Image *src_image, const Quantum *neighbourhood, Quantum *result, size_t channels)
 {
   register ssize_t
-    i;
+    i, j;
 
-  for (i=0; i < (ssize_t) channels * 4; i++)
-    result[i] = neighbourhood[4*channels+i];
+  MagickRealType
+    intensity[9];
+
+  for (i=0; i < 9; i++)
+    intensity[i]=GetPixelIntensity(src_image,neighbourhood+i*channels);
+
+  if ((fabs(intensity[1]-intensity[7]) < MagickEpsilon) ||
+      (fabs(intensity[3]-intensity[5]) < MagickEpsilon))
+    {
+      for (j=0; j < 4; j++)
+        for (i=0; i < (ssize_t) channels; i++)
+          result[j*channels+i]=neighbourhood[4*channels+i];
+    }
+  else
+    {
+      if (fabs(intensity[1]-intensity[3]) < MagickEpsilon)
+        for (i=0; i < (ssize_t) channels; i++)
+          result[i]=neighbourhood[3*channels+i];
+      else
+        for (i=0; i < (ssize_t) channels; i++)
+          result[i]=neighbourhood[4*channels+i];
+
+      if (fabs(intensity[1]-intensity[5]) < MagickEpsilon)
+        for (i=0; i < (ssize_t) channels; i++)
+          result[channels+i]=neighbourhood[5*channels+i];
+      else
+        for (i=0; i < (ssize_t) channels; i++)
+          result[channels+i]=neighbourhood[4*channels+i];
+
+      if (fabs(intensity[3]-intensity[7]) < MagickEpsilon)
+        for (i=0; i < (ssize_t) channels; i++)
+          result[2*channels+i]=neighbourhood[3*channels+i];
+      else
+        for (i=0; i < (ssize_t) channels; i++)
+          result[2*channels+i]=neighbourhood[4*channels+i];
+
+      if (fabs(intensity[5]-intensity[7]) < MagickEpsilon)
+        for (i=0; i < (ssize_t) channels; i++)
+          result[3*channels+i]=neighbourhood[5*channels+i];
+      else
+        for (i=0; i < (ssize_t) channels; i++)
+          result[3*channels+i]=neighbourhood[4*channels+i];
+    }
 }
 
 /*
@@ -2154,13 +2195,13 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
       
       channels = GetPixelChannels(image);
 
-      Scale2x(p,r,channels);
+      Scale2x(image,p,r,channels);
 
       for (i=0; i < (ssize_t) channels * 2; i++)
         q[i]=r[i];
 
       for (i=0; i < (ssize_t) channels * 2; i++)
-        q[channels * (magnify_image->columns-2) + i]=r[2*channels+i];
+        q[channels * (magnify_image->columns) + i]=r[2*channels+i];
 
       q+=magnification*GetPixelChannels(magnify_image);
     }


### PR DESCRIPTION
I am trying to add more pixel art upscaling algorithms as discussed [here](https://github.com/ImageMagick/ImageMagick/issues/1143). This PR is work in progress, I am opening it early to get potential feedback as I am new to ImageMagick and may need some guidance.

Upscaling with pixel art Scale2x algorithm is already supported by IM via `-magnify` option, but only with scale2x algorithm. After this PR I'd like to have an option to specify one of the algorithms such as HQ2x, eagle, scale3x etc. I have also [created my own algorithm](https://github.com/mgba-emu/mgba/pull/737) for MGBA emulator and could add it.

The algorithm should be specified with `-define`, e.g.:

~~`convert -magnify -define "magnify:alg=eagle" in.png out.png`.~~

`convert in.png -define "magnify:method=eagle" -magnify out.png`.

Feel free to write me feedback here. I'll fix the code formatting before merging, I'm not used to this particular style.

EDITS/Notes:

- ~~Comparing pixels based on intensity, as currently implemented, may lead to bugs as two pixels can have the same intensity but different colors, in which case they should probably be considered different.~~ <-- addressed
- Make sure lines aren't longer than 80 chars.
- While some of the algorithms (XBR, ...) usually use pixel comparison with YUV specified error, I am currently comparing pixels for exact values only. The results are basically the same, but may be different for some cases (such as photos). Is this OK or should I stick to the more complicated YUV behavior? If so, the error value might possibly be specified with another -define.
- XBR seems to be a little different from the reference (rewritten from [here](https://github.com/carlosascari/2xBR-Filter/blob/master/xbr.js), reference [here](https://upload.wikimedia.org/wikipedia/commons/c/ce/Pixel-Art_Scaling_Comparison.png)).
- Behavior with indexed-color PNGs that have an alpha channel is buggy (happens also before my changes, IM exits with `Aborted`). `SetImageColorspace` to RGB fixes this but needs to make a copy of the source image.

implemented:

- eagle2x
- HQ2x
- XBR2x
- scale2x (EPX)
- EPBX2x
- eagle3x
- eagle3xb
- scale3x
- fish (my algorithm mentioned above)