### PR TITLE
fix WriteHEICImage bug in HEIC encoder

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -620,10 +620,7 @@ static MagickBooleanType WriteHEICImage(const ImageInfo *image_info,Image *image
     if (status == MagickFalse)
       break;
     if (GetNextImageInList(image) == (Image *) NULL)
-      {
-        status=MagickFalse;
         break;
-      }
     image=SyncNextImageInList(image);
     status=SetImageProgress(image,SaveImagesTag,scene,
       GetImageListLength(image));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->

When Magick has only one image, calling MagickGetImageBlob will fail because WriteHEICImage set unnecessary status=MagickFalse when GetNextImageInList(image) == (Image *) NULL in line 622.