### PR TITLE
Fix compiler warning about unused variable

### DIFF
--- a/MagickCore/blob.c
+++ b/MagickCore/blob.c
@@ -5531,9 +5531,6 @@ MagickExport ssize_t WriteBlob(Image *image,const size_t length,
   register const unsigned char
     *p;
 
-  register unsigned char
-    *q;
-
   ssize_t
     count;
 
@@ -5547,7 +5544,6 @@ MagickExport ssize_t WriteBlob(Image *image,const size_t length,
   blob_info=image->blob;
   count=0;
   p=(const unsigned char *) data;
-  q=(unsigned char *) data;
   switch (blob_info->type)
   {
     case UndefinedStream:
@@ -5699,8 +5695,6 @@ MagickExport ssize_t WriteBlob(Image *image,const size_t length,
               return(0);
             }
         }
-      q=blob_info->data+blob_info->offset;
-      (void) memcpy(q,p,length);
       blob_info->offset+=length;
       if (blob_info->offset >= (MagickOffsetType) blob_info->length)
         blob_info->length=(size_t) blob_info->offset;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Some values are put in the variable, but the variable isn't ever used afterwards.

```
MagickCore/blob.c: In function 'WriteBlob':
MagickCore/blob.c:5535:6: warning: variable 'q' set but not used [-Wunused-but-set-variable]
     *q;
```