### PR TITLE
Fix compiler warning about unused function.

### DIFF
--- a/coders/miff.c
+++ b/coders/miff.c
@@ -161,6 +161,7 @@ static MagickBooleanType IsMIFF(const unsigned char *magick,const size_t length)
 %
 */
 
+#if defined(MAGICKCORE_BZLIB_DELEGATE) || defined(MAGICKCORE_LZMA_DELEGATE) || defined(MAGICKCORE_ZLIB_DELEGATE)
 static void *AcquireCompressionMemory(void *context,const size_t items,
   const size_t size)
 {
@@ -175,6 +176,7 @@ static void *AcquireCompressionMemory(void *context,const size_t items,
     return((void *) NULL);
   return(AcquireMagickMemory(extent));
 }
+#endif
 
 #if defined(MAGICKCORE_BZLIB_DELEGATE)
 static void *AcquireBZIPMemory(void *context,int items,int size)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

When neither of those compiler macros are available, the compiler is going to spit a warning about the unused static function.

```
coders/miff.c:164:14: warning: 'AcquireCompressionMemory' defined but not used [-Wunused-function]
 static void *AcquireCompressionMemory(void *context,const size_t items,
```

Fix this by making sure the static function is only defined when it's going to be used.

You can easily reproduce the warning with this if you have docker:

```
docker run -ti debian:stretch bash -c 'git clone https://github.com/ImageMagick/ImageMagick && apt-get update && apt-get install autoconf && cd ImageMagick && ./configure && make'
```