### PR TITLE
Fix compiler warning about unused variable

### DIFF
--- a/MagickCore/blob.c
+++ b/MagickCore/blob.c
@@ -5531,8 +5531,10 @@ MagickExport ssize_t WriteBlob(Image *image,const size_t length,
   register const unsigned char
     *p;
 
+#if defined(MAGICKCORE_ZLIB_DELEGATE) || defined(MAGICKCORE_BZLIB_DELEGATE)
   register unsigned char
     *q;
+#endif
 
   ssize_t
     count;
@@ -5699,8 +5701,10 @@ MagickExport ssize_t WriteBlob(Image *image,const size_t length,
               return(0);
             }
         }
+#if defined(MAGICKCORE_ZLIB_DELEGATE) || defined(MAGICKCORE_BZLIB_DELEGATE)
       q=blob_info->data+blob_info->offset;
       (void) memcpy(q,p,length);
+#endif
       blob_info->offset+=length;
       if (blob_info->offset >= (MagickOffsetType) blob_info->length)
         blob_info->length=(size_t) blob_info->offset;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Some values are put in the variable, but the variable isn't ever used afterwards.

```
MagickCore/blob.c: In function 'WriteBlob':
MagickCore/blob.c:5535:6: warning: variable 'q' set but not used [-Wunused-but-set-variable]
     *q;
```

Put variable declaration and usages in appropriate cpp guards.

