### PR TITLE
Make png creation reproducible

### DIFF
--- a/MagickCore/constitute.c
+++ b/MagickCore/constitute.c
@@ -792,12 +792,15 @@ MagickExport Image *ReadImage(const ImageInfo *image_info,
     profile=GetImageProfile(next,"iptc");
     if (profile == (const StringInfo *) NULL)
       profile=GetImageProfile(next,"8bim");
-    (void) FormatMagickTime((time_t) GetBlobProperties(next)->st_mtime,
-      MagickPathExtent,timestamp);
-    (void) SetImageProperty(next,"date:modify",timestamp,exception);
-    (void) FormatMagickTime((time_t) GetBlobProperties(next)->st_ctime,
-      MagickPathExtent,timestamp);
-    (void) SetImageProperty(next,"date:create",timestamp,exception);
+    if (getenv("SOURCE_DATE_EPOCH") == (const char *) NULL)
+      {
+        (void) FormatMagickTime((time_t) GetBlobProperties(next)->st_mtime,
+          MagickPathExtent,timestamp);
+        (void) SetImageProperty(next,"date:modify",timestamp,exception);
+        (void) FormatMagickTime((time_t) GetBlobProperties(next)->st_ctime,
+          MagickPathExtent,timestamp);
+        (void) SetImageProperty(next,"date:create",timestamp,exception);
+      }
     option=GetImageOption(image_info,"delay");
     if (option != (const char *) NULL)
       {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Many (Linux distribution) package build processes use `convert` to create png files.
For those source files, ctime will often vary (and sometimes mtime, too).
This results in png files (and thus packages) that differ for every build.

When users intend to do a reproducible build, they set `SOURCE_DATE_EPOCH`,
so in this case we default to the equivalent of
`convert +set date:create +set date:modify`
in order to make png creation reproducible.

See https://reproducible-builds.org/ for why this is good.


The alternative of patching individual callers is an infinite effort:
* https://github.com/awesomeWM/awesome/pull/768/files
* https://github.com/dankelley/gri/pull/10/files
* https://sourceforge.net/p/testlilyissues/issues/5290/
* https://build.opensuse.org/request/show/368622
* https://build.opensuse.org/request/show/368637
* https://build.opensuse.org/request/show/368625
* https://build.opensuse.org/request/show/368574
* https://build.opensuse.org/request/show/368631
* https://build.opensuse.org/request/show/368646
* https://build.opensuse.org/request/show/368700
* https://build.opensuse.org/request/show/368709
* https://build.opensuse.org/request/show/368718
* https://build.opensuse.org/request/show/557607
* https://build.opensuse.org/request/show/592370
* https://build.opensuse.org/request/show/605520
* https://build.opensuse.org/request/show/630019