### PR TITLE
MagickCore/constitute.c: resolve possible null pointer dereference

### DIFF
--- a/MagickCore/constitute.c
+++ b/MagickCore/constitute.c
@@ -1068,10 +1068,10 @@ MagickExport MagickBooleanType WriteImage(const ImageInfo *image_info,
   */
   assert(image_info != (ImageInfo *) NULL);
   assert(image_info->signature == MagickCoreSignature);
+  assert(image != (Image *) NULL);
   if (image->debug != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",
       image_info->filename);
-  assert(image != (Image *) NULL);
   assert(image->signature == MagickCoreSignature);
   assert(exception != (ExceptionInfo *) NULL);
   sans_exception=AcquireExceptionInfo();


### PR DESCRIPTION
found by cppcheck

[MagickCore/constitute.c:1074] -> [MagickCore/constitute.c:1071]: (warning) Either the condition 'image!=(Image*)NULL' is redundant or there is possible null pointer dereference: image
