### PR TITLE
coders/cut.c: remove unused code

### DIFF
--- a/coders/cut.c
+++ b/coders/cut.c
@@ -414,11 +414,7 @@ static Image *ReadCUTImage(const ImageInfo *image_info,ExceptionInfo *exception)
   if (image_info->ping != MagickFalse) goto Finish;
   status=SetImageExtent(image,image->columns,image->rows,exception);
   if (status == MagickFalse)
-    {
-      if (clone_info != NULL) 
-        clone_info=DestroyImageInfo(clone_info); 
-      return(DestroyImageList(image));
-    }
+    return(DestroyImageList(image));
 
   /* ----- Do something with palette ----- */
   if ((clone_info=CloneImageInfo(image_info)) == NULL) goto NoPalette;


### PR DESCRIPTION
found by coverity

clone_info is assigned NULL at line 317
