### PR TITLE
MagickCore/pixel-accessor.h: resolve null pointer dereference

### DIFF
--- a/MagickCore/pixel-accessor.h
+++ b/MagickCore/pixel-accessor.h
@@ -399,27 +399,27 @@ static inline void GetPixelInfoPixel(const Image *magick_restrict image,
       pixel_info->fuzz=image->fuzz;
       pixel_info->depth=image->depth;
       pixel_info->alpha_trait=image->alpha_trait;
-    }
-  if (pixel != (Quantum *) NULL)
-    {
-      pixel_info->red=(MagickRealType)
-        pixel[image->channel_map[RedPixelChannel].offset];
-      pixel_info->green=(MagickRealType)
-        pixel[image->channel_map[GreenPixelChannel].offset];
-      pixel_info->blue=(MagickRealType)
-        pixel[image->channel_map[BluePixelChannel].offset];
-      if (image->channel_map[BlackPixelChannel].traits != UndefinedPixelTrait)
-        pixel_info->black=(MagickRealType)
-          pixel[image->channel_map[BlackPixelChannel].offset];
-      if (image->channel_map[AlphaPixelChannel].traits != UndefinedPixelTrait)
+      if (pixel != (Quantum *) NULL)
         {
-          pixel_info->alpha=(MagickRealType)
-            pixel[image->channel_map[AlphaPixelChannel].offset];
-          pixel_info->alpha_trait=BlendPixelTrait;
-        }
-      if (image->channel_map[IndexPixelChannel].traits != UndefinedPixelTrait)
-        pixel_info->index=(MagickRealType)
-      pixel[image->channel_map[IndexPixelChannel].offset];
+          pixel_info->red=(MagickRealType)
+            pixel[image->channel_map[RedPixelChannel].offset];
+          pixel_info->green=(MagickRealType)
+            pixel[image->channel_map[GreenPixelChannel].offset];
+          pixel_info->blue=(MagickRealType)
+            pixel[image->channel_map[BluePixelChannel].offset];
+          if (image->channel_map[BlackPixelChannel].traits != UndefinedPixelTrait)
+            pixel_info->black=(MagickRealType)
+              pixel[image->channel_map[BlackPixelChannel].offset];
+          if (image->channel_map[AlphaPixelChannel].traits != UndefinedPixelTrait)
+            {
+              pixel_info->alpha=(MagickRealType)
+                pixel[image->channel_map[AlphaPixelChannel].offset];
+              pixel_info->alpha_trait=BlendPixelTrait;
+            }
+          if (image->channel_map[IndexPixelChannel].traits != UndefinedPixelTrait)
+            pixel_info->index=(MagickRealType)
+          pixel[image->channel_map[IndexPixelChannel].offset];
+      }
     }
 }
 


### PR DESCRIPTION
we need to put second "if" inside first "if" to avoid possible null pointer dereference