### PR TITLE
simplify boolean expression, found by PVS analyzer

### DIFF
--- a/Magick++/lib/Color.cpp
+++ b/Magick++/lib/Color.cpp
@@ -300,7 +300,7 @@ Magick::Color::PixelType Magick::Color::pixelType() const
 
 void Magick::Color::isValid(bool valid_)
 {
-  if ((valid_ && isValid()) || (!valid_ && !isValid()))
+  if (bool(valid_) == bool(isValid()))
     return;
 
   if (!_pixelOwn)

--- a/Magick++/lib/Image.cpp
+++ b/Magick++/lib/Image.cpp
@@ -311,8 +311,7 @@ void Magick::Image::alpha(const bool alphaFlag_)
   // the image already has a matte channel but a matte channel is not
   // desired, then set the matte channel to opaque.
   GetPPException;
-  if ((alphaFlag_ && !constImage()->alpha_trait) ||
-      (constImage()->alpha_trait && !alphaFlag_))
+  if (bool(alphaFlag_) != bool(constImage()->alpha_trait))
     SetImageAlpha(image(),OpaqueAlpha,exceptionInfo);
   ThrowImageException;
 


### PR DESCRIPTION
Magick++/lib/Color.cpp	303	warn	V728 An excessive check can be simplified. The '(A && B) || (!A && !B)' expression is equivalent to the 'bool(A) == bool(B)' expression.
Magick++/lib/Image.cpp	314	warn	V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression.
