### PR TITLE
MagickCore/property.c: resolve null pointer dereference

### DIFF
--- a/MagickCore/property.c
+++ b/MagickCore/property.c
@@ -2868,7 +2868,7 @@ MagickExport const char *GetMagickProperty(ImageInfo *image_info,
             (void) ConcatenateMagickString(value,"a",MagickPathExtent);
           break;
         }
-      if (LocaleCompare("colors",property) == 0)
+      if ((LocaleCompare("colors",property) == 0) && (image != (Image *) NULL))
         {
           image->colors=GetNumberColors(image,(FILE *) NULL,exception);
           (void) FormatLocaleString(value,MaxTextExtent,"%.20g",(double)


### PR DESCRIPTION
found by coverity