### PR TITLE
MagickCore/layer.c: resolve null pointer dereference

### DIFF
--- a/MagickCore/layer.c
+++ b/MagickCore/layer.c
@@ -325,7 +325,8 @@ MagickExport Image *CoalesceImages(const Image *image,ExceptionInfo *exception)
       Next image is the dispose image, overlaid with next frame in sequence.
     */
     coalesce_image->next=CloneImage(dispose_image,0,0,MagickTrue,exception);
-    coalesce_image->next->previous=coalesce_image;
+    if (coalesce_image->next != NULL)
+      coalesce_image->next->previous=coalesce_image;
     previous=coalesce_image;
     coalesce_image=GetNextImageInList(coalesce_image);
     (void) CompositeImage(coalesce_image,next,


### PR DESCRIPTION
found by coverity
