### PR TITLE
cleanup identical conditions

### DIFF
--- a/MagickCore/nt-base.c
+++ b/MagickCore/nt-base.c
@@ -1405,22 +1405,19 @@ MagickPrivate int NTGhostscriptEXE(char *path,int length)
       if (ghost_semaphore == (SemaphoreInfo *) NULL)
         ActivateSemaphoreInfo(&ghost_semaphore);
       LockSemaphoreInfo(ghost_semaphore);
-      if (*program == '\0')
+      if (NTGhostscriptGetString("GS_DLL",&is_64_bit_version,program,
+          sizeof(program)) == FALSE)
         {
-          if (NTGhostscriptGetString("GS_DLL",&is_64_bit_version,program,
-              sizeof(program)) == FALSE)
-            {
-              UnlockSemaphoreInfo(ghost_semaphore);
-              return(FALSE);
-            }
-          p=strrchr(program,'\\');
-          if (p != (char *) NULL)
-            {
-              p++;
-              *p='\0';
-              (void) ConcatenateMagickString(program,is_64_bit_version ?
-                "gswin64c.exe" : "gswin32c.exe",sizeof(program));
-            }
+          UnlockSemaphoreInfo(ghost_semaphore);
+          return(FALSE);
+        }
+      p=strrchr(program,'\\');
+      if (p != (char *) NULL)
+        {
+          p++;
+          *p='\0';
+          (void) ConcatenateMagickString(program,is_64_bit_version ?
+            "gswin64c.exe" : "gswin32c.exe",sizeof(program));
         }
       UnlockSemaphoreInfo(ghost_semaphore);
     }

--- a/MagickCore/prepress.c
+++ b/MagickCore/prepress.c
@@ -141,8 +141,7 @@ MagickExport double GetImageTotalInkDensity(Image *image,
         #pragma omp critical (MagickCore_GetImageTotalInkDensity)
 #endif
         {
-          if (density > total_ink_density)
-            total_ink_density=density;
+          total_ink_density=density;
         }
       p+=GetPixelChannels(image);
     }

--- a/MagickCore/quantize.c
+++ b/MagickCore/quantize.c
@@ -3384,17 +3384,14 @@ static MagickBooleanType SetGrayscaleImage(Image *image,
 #if defined(MAGICKCORE_OPENMP_SUPPORT)
               #pragma omp critical (MagickCore_SetGrayscaleImage)
 #endif
-              if (colormap_index[intensity] < 0)
-                {
-                  colormap_index[intensity]=(ssize_t) image->colors;
-                  image->colormap[image->colors].red=(double)
-                    GetPixelRed(image,q);
-                  image->colormap[image->colors].green=(double)
-                    GetPixelGreen(image,q);
-                  image->colormap[image->colors].blue=(double)
-                    GetPixelBlue(image,q);
-                  image->colors++;
-               }
+              colormap_index[intensity]=(ssize_t) image->colors;
+              image->colormap[image->colors].red=(double)
+                GetPixelRed(image,q);
+              image->colormap[image->colors].green=(double)
+                GetPixelGreen(image,q);
+              image->colormap[image->colors].blue=(double)
+                GetPixelBlue(image,q);
+              image->colors++;
             }
           SetPixelIndex(image,(Quantum) colormap_index[intensity],q);
           q+=GetPixelChannels(image);

--- a/MagickCore/xml-tree.c
+++ b/MagickCore/xml-tree.c
@@ -451,8 +451,7 @@ static char **DestroyXMLTreeAttributes(char **attributes)
     /*
       Destroy attribute tag and value.
     */
-    if (attributes[i] != (char *) NULL)
-      attributes[i]=DestroyString(attributes[i]);
+    attributes[i]=DestroyString(attributes[i]);
     if (attributes[i+1] != (char *) NULL)
       attributes[i+1]=DestroyString(attributes[i+1]);
   }
@@ -527,8 +526,7 @@ static void DestroyXMLTreeRoot(XMLTreeInfo *xml_info)
       attributes[0]=DestroyString(attributes[0]);
     for (j=1; attributes[j] != (char *) NULL; j+=3)
     {
-      if (attributes[j] != (char *) NULL)
-        attributes[j]=DestroyString(attributes[j]);
+      attributes[j]=DestroyString(attributes[j]);
       if (attributes[j+1] != (char *) NULL)
         attributes[j+1]=DestroyString(attributes[j+1]);
       if (attributes[j+2] != (char *) NULL)

--- a/coders/dds.c
+++ b/coders/dds.c
@@ -1175,16 +1175,13 @@ static void CompressClusterFit(const size_t count,
               #pragma omp critical (DDS_CompressClusterFit)
 #endif
               {
-                if (error < bestError)
-                  {
-                    VectorCopy43(a,start);
-                    VectorCopy43(b,end);
-                    bestError = error;
-                    besti = i;
-                    bestj = j;
-                    bestk = k;
-                    bestIteration = iterationIndex;
-                  }
+                VectorCopy43(a,start);
+                VectorCopy43(b,end);
+                bestError = error;
+                besti = i;
+                bestj = j;
+                bestk = k;
+                bestIteration = iterationIndex;
               }
             }
 


### PR DESCRIPTION
[MagickCore/nt-base.c:1403] -> [MagickCore/nt-base.c:1408]: (warning) Identical inner 'if' condition is always true.
[MagickCore/prepress.c:139] -> [MagickCore/prepress.c:144]: (warning) Identical inner 'if' condition is always true.
[MagickCore/quantize.c:3382] -> [MagickCore/quantize.c:3387]: (warning) Identical inner 'if' condition is always true.
[MagickCore/xml-tree.c:449] -> [MagickCore/xml-tree.c:454]: (warning) Identical inner 'if' condition is always true.
[MagickCore/xml-tree.c:528] -> [MagickCore/xml-tree.c:530]: (warning) Identical inner 'if' condition is always true.
[coders/dds.c:1172] -> [coders/dds.c:1178]: (warning) Identical inner 'if' condition is always true.