### PR TITLE
TIFF decoder: fix ASsoc/Disassoc setting mismatch

### DIFF
--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -1706,14 +1706,17 @@ RestoreMSCWarning
             image->alpha_trait=BlendPixelTrait;
             if (sample_info[i] == EXTRASAMPLE_ASSOCALPHA)
               {
-                SetQuantumAlphaType(quantum_info,DisassociatedQuantumAlpha);
+                SetQuantumAlphaType(quantum_info,AssociatedQuantumAlpha);
                 (void) SetImageProperty(image,"tiff:alpha","associated",
                   exception);
               }
             else
               if (sample_info[i] == EXTRASAMPLE_UNASSALPHA)
-                (void) SetImageProperty(image,"tiff:alpha","unassociated",
-                  exception);
+                {
+                  SetQuantumAlphaType(quantum_info,DisassociatedQuantumAlpha);
+                  (void) SetImageProperty(image,"tiff:alpha","unassociated",
+                    exception);
+                }
           }
       }
     if (image->alpha_trait != UndefinedPixelTrait)


### PR DESCRIPTION
DisassociatedQuantumAlpha was used in the EXTRASAMPLE_ASSOCALPHA case.
Should have been the opposite.

Spotted on a bug reported to WebP: https://bugs.chromium.org/p/webp/issues/detail?id=401
The sample file test.tiff wouldn't decode correctly.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
