### PR TITLE
Fix heic exif extraction bug where we are seeing 4 unwanted bytes before EXIF magic number

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -290,7 +290,15 @@ static Image *ReadHEICImage(const ImageInfo *image_info,
               StringInfo
                 *profile;
 
-              profile=BlobToStringInfo(exif_buffer,exif_size);
+              //Refering to JpegEncoder::Encode in libheif's encoder_jpeg.cc
+              //https://github.com/strukturag/libheif/blob/master/examples/encoder_jpeg.cc
+              //in the call to jpeg_write_marker, we need to manually remove
+              //the first 4 bytes returned by heif_image_handle_get_metadata
+              //JFIF APP1 marker should point to the EXIF magic number
+              //0x45 0x78 0x69 0x66/"Exif"
+              //If this is not done, some EXIF reader can't read the EXIF metadata
+              profile=BlobToStringInfo(exif_buffer+4,exif_size-4);
+              
               if (profile != (StringInfo*) NULL)
                 {
                   SetImageProfile(image,"exif",profile,exception);


### PR DESCRIPTION
### Prerequisites

- [ x ] I have written a descriptive pull-request title
- [ x ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ x ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
This code change would fix: https://github.com/ImageMagick/ImageMagick/issues/1266
              Refering to JpegEncoder::Encode in libheif's encoder_jpeg.cc
              https://github.com/strukturag/libheif/blob/master/examples/encoder_jpeg.cc
              in the call to jpeg_write_marker, we need to manually remove
              the first 4 bytes returned by heif_image_handle_get_metadata
              JFIF APP1 marker should point to the EXIF magic number
              0x45 0x78 0x69 0x66/"Exif"
              If this is not done, some EXIF readers can't read the EXIF metadata

<!-- Thanks for contributing to ImageMagick! -->
