### PR TITLE
Fix associated alpha handling

### DIFF
--- a/MagickCore/quantum-import.c
+++ b/MagickCore/quantum-import.c
@@ -4260,7 +4260,7 @@ MagickExport size_t ImportQuantumPixels(const Image *image,
         q+=GetPixelChannels(image);
       }
     }
-  if (quantum_info->alpha_type == DisassociatedQuantumAlpha)
+  if (quantum_info->alpha_type == AssociatedQuantumAlpha)
     {
       double
         gamma,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

We've been seeing odd behaviour with TIFF-files with associated alpha, the files are showing inverse alpha as if it was disassociated alpha. It looks like this was introduced with PR to fix disassociated alpha in https://github.com/ImageMagick/ImageMagick/pull/1349

It seems like the naming was swapped and this was fixed, but the quantum-import.c file also was doing translations based on the wrong name. I've adjusted this and now it works for our associated alpha files and the disassociated testfile in the original PR that introduced the issue for us.
