### PR TITLE
change from WEBP_DECODER_ABI_VERSION to WEBP_ENCODER_ABI_VERSION, because we need encoder feature switch.

### DIFF
--- a/coders/webp.c
+++ b/coders/webp.c
@@ -481,9 +481,9 @@ ModuleExport size_t RegisterWEBPImage(void)
   entry->decoder=(DecodeImageHandler *) ReadWEBPImage;
   entry->encoder=(EncodeImageHandler *) WriteWEBPImage;
   (void) FormatLocaleString(version,MagickPathExtent,"libwebp %d.%d.%d [%04X]",
-    (WebPGetDecoderVersion() >> 16) & 0xff,
-    (WebPGetDecoderVersion() >> 8) & 0xff,
-    (WebPGetDecoderVersion() >> 0) & 0xff,WEBP_DECODER_ABI_VERSION);
+    (WebPGetEncoderVersion() >> 16) & 0xff,
+    (WebPGetEncoderVersion() >> 8) & 0xff,
+    (WebPGetEncoderVersion() >> 0) & 0xff,WEBP_ENCODER_ABI_VERSION);
 #endif
   entry->mime_type=ConstantString("image/webp");
   entry->flags|=CoderDecoderSeekableStreamFlag;
@@ -546,7 +546,7 @@ ModuleExport void UnregisterWEBPImage(void)
 %
 */
 
-#if WEBP_DECODER_ABI_VERSION >= 0x0100
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
 static int WebPEncodeProgress(int percent,const WebPPicture* picture)
 {
 #define EncodeImageTag  "Encode/Image"
@@ -634,7 +634,7 @@ static MagickBooleanType WriteWEBPImage(const ImageInfo *image_info,
   picture.writer=WebPMemoryWrite;
   picture.custom_ptr=(&writer_info);
 #endif
-#if WEBP_DECODER_ABI_VERSION >= 0x0100
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
   picture.progress_hook=WebPEncodeProgress;
   picture.user_data=(void *) image;
 #endif
@@ -663,7 +663,7 @@ static MagickBooleanType WriteWEBPImage(const ImageInfo *image_info,
         configure.image_hint=WEBP_HINT_PHOTO;
       if (LocaleCompare(value,"picture") == 0)
         configure.image_hint=WEBP_HINT_PICTURE;
-#if WEBP_DECODER_ABI_VERSION >= 0x0200
+#if WEBP_ENCODER_ABI_VERSION >= 0x0200
       if (LocaleCompare(value,"graph") == 0)
         configure.image_hint=WEBP_HINT_GRAPH;
 #endif
@@ -717,7 +717,7 @@ static MagickBooleanType WriteWEBPImage(const ImageInfo *image_info,
   value=GetImageOption(image_info,"webp:partition-limit");
   if (value != (char *) NULL)
     configure.partition_limit=StringToInteger(value);
-#if WEBP_DECODER_ABI_VERSION >= 0x0201
+#if WEBP_ENCODER_ABI_VERSION >= 0x0201
   value=GetImageOption(image_info,"webp:emulate-jpeg-size");
   if (value != (char *) NULL)
     configure.emulate_jpeg_size=(int) ParseCommandOption(MagickBooleanOptions,
@@ -730,7 +730,7 @@ static MagickBooleanType WriteWEBPImage(const ImageInfo *image_info,
   if (value != (char *) NULL)
     configure.thread_level=StringToInteger(value);
 #endif
-#if WEBP_DECODER_ABI_VERSION >= 0x020e
+#if WEBP_ENCODER_ABI_VERSION >= 0x020e
   value=GetImageOption(image_info,"webp:use-sharp-yuv");
   if (value != (char *) NULL)
     configure.use_sharp_yuv=StringToInteger(value);
@@ -828,7 +828,7 @@ static MagickBooleanType WriteWEBPImage(const ImageInfo *image_info,
           message="file too big (> 4GB)";
           break;
         }
-#if WEBP_DECODER_ABI_VERSION >= 0x0100
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
         case VP8_ENC_ERROR_USER_ABORT:
         {
           message="user abort";


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

Currently, "use_sharp_yuv" can not be effective now.

I think that it's propper to using WEBP_ENCODER_ABI_VERSION instead of WEBP_DECODER_ABI_VERSION for #if switching the encode feature.
Also, if we store either of these values as a version of coder, I think that ENCODER, which seems to be more active, more convenient.

- libwebp WEBP_{DE|EN}CODER_ABI_VERSION feature table.
```
       DECODER ENCODER encode.h new feature
0.1.2   0x0001  0x0001
0.1.3  +0x0002 +0x0002
0.1.99 +0x0100 +0x0100 user_data,progress_hook,VP8_ENC_ERROR_USER_ABORT
0.2.0  +0x0200 +0x0200 WEBP_HINT_GRAPH
0.2.1   0x0200  0x0200
0.3.0  +0x0201 +0x0201 emulate_jpeg_size,low_memory,thread_level
0.3.1   0x0201  0x0201
0.4.0  +0x0203 +0x0202
0.4.1   0x0203  0x0202
0.4.2   0x0203  0x0202
0.4.3   0x0203  0x0202
0.4.4   0x0203  0x0202
0.5.0  +0x0208 +0x0209
0.5.1   0x0208  0x0209
0.5.2   0x0208  0x0209
0.6.0   0x0208 +0x020e use_sharp_yuv
0.6.1   0x0208  0x020e
1.0.0   0x0208  0x020e
1.0.1   0x0208  0x020e
1.0.2   0x0208  0x020e
      (+) version up
```

<!-- Thanks for contributing to ImageMagick! -->
