### PR TITLE
Honour SOURCE_DATE_EPOCH

### DIFF
--- a/MagickCore/string.c
+++ b/MagickCore/string.c
@@ -1156,6 +1156,81 @@ MagickExport ssize_t FormatMagickSize(const MagickSizeType size,
   return(count);
 }
 
+/* CurrentTime()
+   returns the source time from SOURCE_DATE_EPOCH environment variable (if set),
+   or current time.
+
+   code from https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal#C
+*/
+
+MagickExport time_t CurrentTime()
+{
+  struct tm *build_time;
+  time_t now;
+  unsigned long long epoch;
+  char *endptr;
+  char *source_date_epoch=getenv("SOURCE_DATE_EPOCH");
+  if (source_date_epoch) {
+    errno = 0;
+    epoch = strtoull(source_date_epoch, &endptr, 10);
+    if ((errno == ERANGE && (epoch == ULLONG_MAX || epoch == 0))
+        || (errno != 0 && epoch == 0)) {
+      fprintf(stderr, "Environment variable $SOURCE_DATE_EPOCH: strtoull: %s\n", strerror(errno));
+      exit(EXIT_FAILURE);
+    }
+    if (endptr == source_date_epoch) {
+      fprintf(stderr, "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n", endptr);
+      exit(EXIT_FAILURE);
+    }
+    if (*endptr != '\0') {
+      fprintf(stderr, "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n", endptr);
+      exit(EXIT_FAILURE);
+    }
+    if (epoch > ULONG_MAX) {
+      fprintf(stderr, "Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to: %lu but was found to be: %llu \n", ULONG_MAX, epoch);
+      exit(EXIT_FAILURE);
+    }
+    now = epoch;
+  } else {
+    now = time(NULL);
+  }
+  return(now);
+}
+
+/* LocalOrGMTime computes the local or GM time from s, and stores it to t.
+   If the SOURCE_DATE_EPOCH environment variable is set, GM time is used,
+   otherwise local time is used.
+ */
+MagickExport void LocalOrGMTime(time_t *s,struct tm *t) {
+  if(getenv("SOURCE_DATE_EPOCH") != NULL) {
+#if defined(MAGICKCORE_HAVE_GMTIME_R)
+    (void) gmtime_r(s,t);
+#else
+    {
+      struct tm
+        *my_time;
+
+      my_time=gmtime(t);
+      if (my_time != (struct tm *) NULL)
+        (void) memcpy(t,my_time,sizeof(*t));
+    }
+#endif
+  } else {
+#if defined(MAGICKCORE_HAVE_LOCALTIME_R)
+    (void) localtime_r(s,t);
+#else
+    {
+      struct tm
+        *my_time;
+
+      my_time=localtime(t);
+      if (my_time != (struct tm *) NULL)
+        (void) memcpy(t,my_time,sizeof(*t));
+    }
+#endif
+  }
+}
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -1225,14 +1300,21 @@ MagickExport ssize_t FormatMagickTime(const time_t time,const size_t length,
       (void) memcpy(&gm_time,my_time,sizeof(gm_time));
   }
 #endif
-  timezone=(time_t) ((local_time.tm_min-gm_time.tm_min)/60+
-    local_time.tm_hour-gm_time.tm_hour+24*((local_time.tm_year-
-    gm_time.tm_year) != 0 ? (local_time.tm_year-gm_time.tm_year) :
-    (local_time.tm_yday-gm_time.tm_yday)));
-  count=FormatLocaleString(timestamp,length,
-    "%04d-%02d-%02dT%02d:%02d:%02d%+03ld:00",local_time.tm_year+1900,
-    local_time.tm_mon+1,local_time.tm_mday,local_time.tm_hour,
-    local_time.tm_min,local_time.tm_sec,(long) timezone);
+  if(getenv("SOURCE_DATE_EPOCH")) {
+    count=FormatLocaleString(timestamp,length,
+     "%04d-%02d-%02dT%02d:%02d:%02d%+03ld:00",gm_time.tm_year+1900,
+     gm_time.tm_mon+1,gm_time.tm_mday,gm_time.tm_hour,
+     gm_time.tm_min,gm_time.tm_sec,0);
+  } else {
+    timezone=(time_t) ((local_time.tm_min-gm_time.tm_min)/60+
+                       local_time.tm_hour-gm_time.tm_hour+24*((local_time.tm_year-
+                       gm_time.tm_year) != 0 ? (local_time.tm_year-gm_time.tm_year) :
+                       (local_time.tm_yday-gm_time.tm_yday)));
+    count=FormatLocaleString(timestamp,length,
+     "%04d-%02d-%02dT%02d:%02d:%02d%+03ld:00",local_time.tm_year+1900,
+     local_time.tm_mon+1,local_time.tm_mday,local_time.tm_hour,
+     local_time.tm_min,local_time.tm_sec,(long) timezone);
+  }
   return(count);
 }
 

--- a/MagickCore/string_.h
+++ b/MagickCore/string_.h
@@ -86,6 +86,9 @@ extern MagickExport ssize_t
     const size_t,char *),
   FormatMagickTime(const time_t,const size_t,char *);
 
+extern MagickExport time_t
+  CurrentTime();
+
 extern MagickExport StringInfo
   *AcquireStringInfo(const size_t),
   *BlobToStringInfo(const void *,const size_t),
@@ -109,7 +112,8 @@ extern MagickExport void
   SetStringInfoLength(StringInfo *,const size_t),
   SetStringInfoName(StringInfo *,const char *),
   SetStringInfoPath(StringInfo *,const char *),
-  StripString(char *);
+  StripString(char *),
+  LocalOrGMTime(time_t *,struct tm *);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }

--- a/coders/cin.c
+++ b/coders/cin.c
@@ -990,14 +990,14 @@ static MagickBooleanType WriteCINImage(const ImageInfo *image_info,Image *image,
       sizeof(cin.file.filename));
   offset+=WriteBlob(image,sizeof(cin.file.filename),(unsigned char *)
     cin.file.filename);
-  seconds=time((time_t *) NULL);
-#if defined(MAGICKCORE_HAVE_LOCALTIME_R)
-  (void) localtime_r(&seconds,&local_time);
-#else
-  (void) memcpy(&local_time,localtime(&seconds),sizeof(local_time));
-#endif
+  seconds=CurrentTime();
+  (void) LocalOrGMTime(&seconds,&local_time);
   (void) memset(timestamp,0,sizeof(timestamp));
-  (void) strftime(timestamp,MagickPathExtent,"%Y:%m:%d:%H:%M:%S%Z",&local_time);
+  if(getenv("SOURCE_DATE_EPOCH")) {
+    (void) strftime(timestamp,MaxTextExtent,"%Y:%m:%d:%H:%M:%SUTC",&local_time);
+  } else {
+    (void) strftime(timestamp,MaxTextExtent,"%Y:%m:%d:%H:%M:%S%Z",&local_time);
+  }
   (void) memset(cin.file.create_date,0,sizeof(cin.file.create_date));
   (void) CopyMagickString(cin.file.create_date,timestamp,11);
   offset+=WriteBlob(image,sizeof(cin.file.create_date),(unsigned char *)
@@ -1093,9 +1093,6 @@ static MagickBooleanType WriteCINImage(const ImageInfo *image_info,Image *image,
       sizeof(cin.origination.filename));
   offset+=WriteBlob(image,sizeof(cin.origination.filename),(unsigned char *)
     cin.origination.filename);
-  seconds=time((time_t *) NULL);
-  (void) memset(timestamp,0,sizeof(timestamp));
-  (void) strftime(timestamp,MagickPathExtent,"%Y:%m:%d:%H:%M:%S%Z",&local_time);
   (void) memset(cin.origination.create_date,0,
     sizeof(cin.origination.create_date));
   (void) CopyMagickString(cin.origination.create_date,timestamp,11);

--- a/coders/dpx.c
+++ b/coders/dpx.c
@@ -1590,7 +1590,7 @@ static MagickBooleanType WriteDPXImage(const ImageInfo *image_info,Image *image,
     (void) strncpy(dpx.file.filename,value,sizeof(dpx.file.filename)-1);
   offset+=WriteBlob(image,sizeof(dpx.file.filename),(unsigned char *)
     dpx.file.filename);
-  seconds=time((time_t *) NULL);
+  seconds=CurrentTime();
   (void) FormatMagickTime(seconds,sizeof(dpx.file.timestamp),
     dpx.file.timestamp);
   offset+=WriteBlob(image,sizeof(dpx.file.timestamp),(unsigned char *)

--- a/coders/mat.c
+++ b/coders/mat.c
@@ -1600,12 +1600,8 @@ static MagickBooleanType WriteMATImage(const ImageInfo *image_info,Image *image,
     return(MagickFalse);
   image->depth=8;
 
-  current_time=time((time_t *) NULL);
-#if defined(MAGICKCORE_HAVE_LOCALTIME_R)
-  (void) localtime_r(&current_time,&local_time);
-#else
-  (void) memcpy(&local_time,localtime(&current_time),sizeof(local_time));
-#endif
+  current_time=CurrentTime();
+  (void) LocalOrGMTime(&current_time,&local_time);
   (void) memset(MATLAB_HDR,' ',MagickMin(sizeof(MATLAB_HDR),124));
   FormatLocaleString(MATLAB_HDR,sizeof(MATLAB_HDR),
     "MATLAB 5.0 MAT-file, Platform: %s, Created on: %s %s %2d %2d:%2d:%2d %d",

--- a/coders/pdb.c
+++ b/coders/pdb.c
@@ -811,7 +811,7 @@ static MagickBooleanType WritePDBImage(const ImageInfo *image_info,Image *image,
     sizeof(pdb_info.name));
   pdb_info.attributes=0;
   pdb_info.version=0;
-  pdb_info.create_time=time(NULL);
+  pdb_info.create_time=CurrentTime();
   pdb_info.modify_time=pdb_info.create_time;
   pdb_info.archive_time=0;
   pdb_info.modify_number=0;

--- a/coders/pdf.c
+++ b/coders/pdf.c
@@ -1450,7 +1450,7 @@ RestoreMSCWarning
       value=GetImageProperty(image,"date:create",exception);
       if (value != (const char *) NULL)
         (void) CopyMagickString(create_date,value,MagickPathExtent);
-      (void) FormatMagickTime(time((time_t *) NULL),MagickPathExtent,timestamp);
+      (void) FormatMagickTime(CurrentTime(),MagickPathExtent,timestamp);
       url=(char *) MagickAuthoritativeURL;
       escape=EscapeParenthesis(basename);
       i=FormatLocaleString(xmp_profile,MagickPathExtent,XMPProfile,
@@ -2982,12 +2982,8 @@ RestoreMSCWarning
         }
     }
   (void) WriteBlobString(image,buffer);
-  seconds=time((time_t *) NULL);
-#if defined(MAGICKCORE_HAVE_LOCALTIME_R)
-  (void) localtime_r(&seconds,&local_time);
-#else
-  (void) memcpy(&local_time,localtime(&seconds),sizeof(local_time));
-#endif
+  seconds=CurrentTime();
+  (void) LocalOrGMTime(&seconds,&local_time);
   (void) FormatLocaleString(date,MagickPathExtent,"D:%04d%02d%02d%02d%02d%02d",
     local_time.tm_year+1900,local_time.tm_mon+1,local_time.tm_mday,
     local_time.tm_hour,local_time.tm_min,local_time.tm_sec);

--- a/coders/png.c
+++ b/coders/png.c
@@ -8366,10 +8366,15 @@ static void write_tIME_chunk(Image *image,png_struct *ping,png_info *info,
   ptime.minute = minute;
   ptime.second = second;
 
+  if(getenv("SOURCE_DATE_EPOCH")) {
+    time_t ttime = CurrentTime();
+    png_convert_from_time_t(&ptime,ttime);
+  }
   LogMagickEvent(CoderEvent,GetMagickModule(),
       "      png_set_tIME: y=%d, m=%d, d=%d, h=%d, m=%d, s=%d, ah=%d, am=%d",
       ptime.year, ptime.month, ptime.day, ptime.hour, ptime.minute,
       ptime.second, addhours, addminutes);
+
   png_set_tIME(ping,info,&ptime);
 }
 #endif

--- a/coders/ps.c
+++ b/coders/ps.c
@@ -1669,7 +1669,7 @@ static MagickBooleanType WritePSImage(const ImageInfo *image_info,Image *image,
         (void) FormatLocaleString(buffer,MagickPathExtent,"%%%%Title: (%s)\n",
           image->filename);
         (void) WriteBlobString(image,buffer);
-        timer=time((time_t *) NULL);
+        timer=CurrentTime();
         (void) FormatMagickTime(timer,MagickPathExtent,date);
         (void) FormatLocaleString(buffer,MagickPathExtent,
           "%%%%CreationDate: (%s)\n",date);

--- a/coders/ps2.c
+++ b/coders/ps2.c
@@ -569,7 +569,7 @@ static MagickBooleanType WritePS2Image(const ImageInfo *image_info,Image *image,
         (void) FormatLocaleString(buffer,MagickPathExtent,"%%%%Title: (%s)\n",
           image->filename);
         (void) WriteBlobString(image,buffer);
-        timer=time((time_t *) NULL);
+        timer=CurrentTime();
         (void) FormatMagickTime(timer,MagickPathExtent,date);
         (void) FormatLocaleString(buffer,MagickPathExtent,
           "%%%%CreationDate: (%s)\n",date);

--- a/coders/ps3.c
+++ b/coders/ps3.c
@@ -1018,7 +1018,7 @@ static MagickBooleanType WritePS3Image(const ImageInfo *image_info,Image *image,
         (void) FormatLocaleString(buffer,MagickPathExtent,"%%%%Title: %s\n",
           image->filename);
         (void) WriteBlobString(image,buffer);
-        timer=time((time_t *) NULL);
+	timer=CurrentTime();
         (void) FormatMagickTime(timer,MagickPathExtent,date);
         (void) FormatLocaleString(buffer,MagickPathExtent,
           "%%%%CreationDate: %s\n",date);


### PR DESCRIPTION
Honour the SOURCE_DATE_EPOCH environment variable when writing
to some files: PS, PDF, PNG, CIN, DPX, MAT, PDB, setting the timestamp
to the provided value and using GM time instead of local time.

From: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=819914

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
