### PR TITLE
initialise ghostscript instances with NULL

### DIFF
--- a/coders/pdf.c
+++ b/coders/pdf.c
@@ -197,7 +197,7 @@ static MagickBooleanType InvokePDFDelegate(const MagickBooleanType verbose,
     *ghost_info;
 
   gs_main_instance
-    *interpreter;
+    *interpreter = NULL;
 
   gsapi_revision_t
     revision;

--- a/coders/ps.c
+++ b/coders/ps.c
@@ -187,7 +187,7 @@ static MagickBooleanType InvokePostscriptDelegate(
     *ghost_info;
 
   gs_main_instance
-    *interpreter;
+    *interpreter = NULL;
 
   gsapi_revision_t
     revision;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Since ghostscript 9.27 pointers passed to `gsapi_new_instance` must be initialized with `NULL`.
See also [upstream patch](http://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=a87c116174ef574465ab12493ef6d0c575bda60d)
