### PR TITLE
Fix rubber banding artifacts in the XSelectWindow function. #1460 

### DIFF
--- a/MagickCore/xwindow.c
+++ b/MagickCore/xwindow.c
@@ -9315,6 +9315,7 @@ static Window XSelectWindow(Display *display,RectangleInfo *crop_info)
   target_window=(Window) NULL;
   x_offset=0;
   y_offset=0;
+  (void) XGrabServer(display);
   do
   {
     if ((crop_info->width*crop_info->height) >= MinimumCropArea)
@@ -9383,6 +9384,7 @@ static Window XSelectWindow(Display *display,RectangleInfo *crop_info)
         break;
     }
   } while ((target_window == (Window) NULL) || (presses > 0));
+  (void) XUngrabServer(display);
   (void) XUngrabPointer(display,CurrentTime);
   (void) XFreeCursor(display,target_cursor);
   (void) XFreeGC(display,annotate_context);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This patch fixed #1460 . The problem was caused by the fact that applications redraw regions in which selection happen, so rubber banding doesn't work. A simple fix is to grab the X server before doing the selection. To quote the *Xlib Programming Manual*:

> XGrabServer() and XUngrabServer() are used when a  program requires total control of the screen, so that output requests from other programs are queued but not displayed. One application of grabbing is to draw temporary moving objects on the screen, such as the outline of a window being moved. This is called rubber−banding. 