### PR TITLE
Add log format special char %i (thread-id) to "human readable" mode

### DIFF
--- a/MagickCore/log.c
+++ b/MagickCore/log.c
@@ -1033,6 +1033,7 @@ static char *TranslateEvent(const char *module,const char *function,
         %e   event
         %f   function
         %g   generation
+        %i   thread id
         %l   line
         %m   module
         %n   log name
@@ -1095,6 +1096,11 @@ static char *TranslateEvent(const char *module,const char *function,
           }
         q+=FormatLocaleString(q,extent,"%.20g",(double) (log_info->generation %
           log_info->generations));
+        break;
+      }
+      case 'i':
+      {
+        q += FormatLocaleString(q, extent, "%.20g", (double) GetMagickThreadSignature());
         break;
       }
       case 'l':


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

Log format specialcharacter "%i" is seems not working in the "human readable" mode.

This is documented here that "%i" is thread id.
https://github.com/ImageMagick/ImageMagick/blob/master/config/log.xml#L59

This works when the format is `"xml"`, but it seems that there is no implementation for "human readable" .
I added to this.

<!-- Thanks for contributing to ImageMagick! -->
