### PR TITLE
fix font decorate position, thickness issue

### DIFF
--- a/MagickCore/annotate.c
+++ b/MagickCore/annotate.c
@@ -224,6 +224,7 @@ MagickExport MagickBooleanType AnnotateImage(Image *image,
 {
   char
     *p,
+    color[MagickPathExtent],
     primitive[MagickPathExtent],
     *text,
     **textlist;
@@ -494,8 +495,15 @@ MagickExport MagickBooleanType AnnotateImage(Image *image,
       }
     annotate_info->affine.tx=offset.x;
     annotate_info->affine.ty=offset.y;
-    (void) FormatLocaleString(primitive,MagickPathExtent,"stroke-width %g "
-      "line 0,0 %g,0",metrics.underline_thickness,metrics.width);
+
+    (void) QueryColorname(image,&annotate_info->fill,AllCompliance,color,exception);
+    (void) FormatLocaleString(primitive,MagickPathExtent,"stroke %s "
+      "stroke-width %g "
+      "line 0,0 %g,0",color,(double) metrics.underline_thickness,(double) metrics.width);
+
+    /*
+      Annotate image with text.
+    */
     if (annotate->decorate == OverlineDecoration)
       {
         annotate_info->affine.ty-=(draw_info->affine.sy*(metrics.ascent+
@@ -503,27 +511,25 @@ MagickExport MagickBooleanType AnnotateImage(Image *image,
         (void) CloneString(&annotate_info->primitive,primitive);
         (void) DrawImage(image,annotate_info,exception);
       }
-    else
-      if (annotate->decorate == UnderlineDecoration)
-        {
-          annotate_info->affine.ty-=(draw_info->affine.sy*
-            metrics.underline_position);
-          (void) CloneString(&annotate_info->primitive,primitive);
-          (void) DrawImage(image,annotate_info,exception);
-        }
-    /*
-      Annotate image with text.
-    */
-    status=RenderType(image,annotate,&offset,&metrics,exception);
-    if (status == MagickFalse)
-      break;
-    if (annotate->decorate == LineThroughDecoration)
+    else if (annotate->decorate == UnderlineDecoration)
       {
-        annotate_info->affine.ty-=(draw_info->affine.sy*(height+
-          metrics.underline_position+metrics.descent)/2.0);
+        annotate_info->affine.ty-=(draw_info->affine.sy*
+          metrics.underline_position);
         (void) CloneString(&annotate_info->primitive,primitive);
         (void) DrawImage(image,annotate_info,exception);
       }
+    else if (annotate->decorate == LineThroughDecoration)
+      {
+        annotate_info->affine.ty=(draw_info->affine.sy*(metrics.ascent
+          +height+metrics.descent)/2.0);
+        (void) CloneString(&annotate_info->primitive,primitive);
+        (void) DrawImage(image,annotate_info,exception);
+      }
+
+    // annotate_info->stroke_width = metrics.underline_thickness;
+    status=RenderType(image,annotate,&offset,&metrics,exception);
+    if (status == MagickFalse)
+      break;
   }
   /*
     Relinquish resources.
@@ -1464,8 +1470,9 @@ static MagickBooleanType RenderFreetype(Image *image,const DrawInfo *draw_info,
   metrics->bounds.y1=metrics->descent;
   metrics->bounds.x2=metrics->ascent+metrics->descent;
   metrics->bounds.y2=metrics->ascent+metrics->descent;
-  metrics->underline_position=face->underline_position/64.0;
-  metrics->underline_thickness=face->underline_thickness/64.0;
+  metrics->underline_position=face->underline_position/64.0*(draw_info->pointsize/12.0);
+  metrics->underline_thickness=face->underline_thickness/64.0*(draw_info->pointsize/12.0);
+
   if ((draw_info->text == (char *) NULL) || (*draw_info->text == '\0'))
     {
       (void) FT_Done_Face(face);

--- a/MagickCore/annotate.c
+++ b/MagickCore/annotate.c
@@ -239,6 +239,9 @@ MagickExport MagickBooleanType AnnotateImage(Image *image,
   MagickBooleanType
     status;
 
+  PixelInfo
+    pixel;
+
   PointInfo
     offset;
 
@@ -496,7 +499,11 @@ MagickExport MagickBooleanType AnnotateImage(Image *image,
     annotate_info->affine.tx=offset.x;
     annotate_info->affine.ty=offset.y;
 
-    (void) QueryColorname(image,&annotate_info->fill,AllCompliance,color,exception);
+    pixel=annotate_info->fill;
+    if (annotate_info->stroke.alpha != TransparentAlpha)
+      pixel = annotate_info->stroke;
+
+    (void) QueryColorname(image,&pixel,AllCompliance,color,exception);
     (void) FormatLocaleString(primitive,MagickPathExtent,"stroke %s "
       "stroke-width %g "
       "line 0,0 %g,0",color,(double) metrics.underline_thickness,(double) metrics.width);

--- a/MagickCore/annotate.c
+++ b/MagickCore/annotate.c
@@ -520,13 +520,12 @@ MagickExport MagickBooleanType AnnotateImage(Image *image,
       }
     else if (annotate->decorate == LineThroughDecoration)
       {
-        annotate_info->affine.ty=(draw_info->affine.sy*(metrics.ascent
-          +height+metrics.descent)/2.0);
+        annotate_info->affine.ty-=(draw_info->affine.sy*(height+
+          metrics.underline_position+metrics.descent*2)/2.0);
         (void) CloneString(&annotate_info->primitive,primitive);
         (void) DrawImage(image,annotate_info,exception);
       }
 
-    // annotate_info->stroke_width = metrics.underline_thickness;
     status=RenderType(image,annotate,&offset,&metrics,exception);
     if (status == MagickFalse)
       break;
@@ -1470,8 +1469,8 @@ static MagickBooleanType RenderFreetype(Image *image,const DrawInfo *draw_info,
   metrics->bounds.y1=metrics->descent;
   metrics->bounds.x2=metrics->ascent+metrics->descent;
   metrics->bounds.y2=metrics->ascent+metrics->descent;
-  metrics->underline_position=face->underline_position/64.0*(draw_info->pointsize/12.0);
-  metrics->underline_thickness=face->underline_thickness/64.0*(draw_info->pointsize/12.0);
+  metrics->underline_position=face->underline_position*(metrics->pixels_per_em.x/face->units_per_EM);
+  metrics->underline_thickness=face->underline_thickness*(metrics->pixels_per_em.x/face->units_per_EM);
 
   if ((draw_info->text == (char *) NULL) || (*draw_info->text == '\0'))
     {


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->

**Effected target source**
`MagickCore/annotate.c`

**See also**
https://imagemagick.org/discourse-server/viewtopic.php?f=1&t=36242

**Main issue**

- ImageMagick latest version (7.0.8-50 Q16 x86_64 2019-06-25) has an issue when the option includes decorate option in the drawing process
- The other famous render program such as Photoshop, They treat decorate perfectly as following

### Photoshop
> CC 19.1.4 20180507.r.325 2018/05/07: 1170750  x64, 320x120, bg:white, pointsize:64
> Font: [NotoSansCJKjp-Medium](https://www.google.com/get/noto/#sans-jpan)

**Underline**

![photoshop_underline](https://user-images.githubusercontent.com/7090315/60382229-1a198800-9a9b-11e9-8cc4-962a06b773a0.png)

**LineThrough**

![photoshop_underline](https://user-images.githubusercontent.com/7090315/60382219-ffdfaa00-9a9a-11e9-8e4e-482700f5b766.png)


### Microsoft Word

> Word for Mac, 16.16.11 (190609), 320x120, bg:white, pointsize:64
> Font: [NotoSansCJKjp-Medium](https://www.google.com/get/noto/#sans-jpan)

**Underline**

![screenshot 2019-06-29 오후 6 22 00](https://user-images.githubusercontent.com/7090315/60382246-5f3dba00-9a9b-11e9-98b8-a96cf6350206.png)

**LineThrough**

![screenshot 2019-06-29 오후 6 22 09](https://user-images.githubusercontent.com/7090315/60382247-62d14100-9a9b-11e9-8128-07bb3f9bf337.png)

### ImageMagick (AS-WAS)

> ImageMagick 7.0.8-50 Q16 x86_64 2019-06-25, 320x120, bg:white, pointsize:64
> Font: [NotoSansCJKjp-Medium](https://www.google.com/get/noto/#sans-jpan)

**Command**

```bash
# underline
convert \
    -debug all -size 320x120 xc:white -draw \
    "fill black font-size 64 font '/Users/user/Downloads/NotoSansCJKjp-hinted/NotoSansCJKjp-Medium.otf' decorate Underline gravity center text 0,0 'test'" underline.gif

# line through
convert \
    -debug all -size 320x120 xc:white -draw \
    "fill black font-size 64 font '/Users/user/Downloads/NotoSansCJKjp-hinted/NotoSansCJKjp-Medium.otf' decorate LineThrough gravity center text 0,0 'test'" linethrough.gif
```

**Underline**

![underline](https://user-images.githubusercontent.com/7090315/60382278-c2c7e780-9a9b-11e9-9ffc-44cbe1619578.gif)

**LineThrough**

![linethrough](https://user-images.githubusercontent.com/7090315/60382281-d1160380-9a9b-11e9-9144-4820f6d15ffb.gif)

### This PR ImageMagick (TO-BE)

> forked from: https://github.com/ImageMagick/ImageMagick/commit/80804f7294aec1cacb624cd1eef55fcf6f7f614a, 320x120, bg:white, pointsize:64
> Font: [NotoSansCJKjp-Medium](https://www.google.com/get/noto/#sans-jpan)

**Command**

```bash
# underline
convert \
    -debug all -size 320x120 xc:white -draw \
    "fill black font-size 64 font '/Users/user/Downloads/NotoSansCJKjp-hinted/NotoSansCJKjp-Medium.otf' decorate Underline gravity center text 0,0 'test'" underline.gif

# line through
convert \
    -debug all -size 320x120 xc:white -draw \
    "fill black font-size 64 font '/Users/user/Downloads/NotoSansCJKjp-hinted/NotoSansCJKjp-Medium.otf' decorate LineThrough gravity center text 0,0 'test'" linethrough.gif
```

**Underline**

![underline](https://user-images.githubusercontent.com/7090315/60382316-4c77b500-9a9c-11e9-8655-a584f131f36d.gif)

**LineThrough**

![linethrough](https://user-images.githubusercontent.com/7090315/60382317-4eda0f00-9a9c-11e9-8e03-4dafdc1de538.gif)

**The result for more scenarios**

**red color + underline**

```bash
convert \
    -debug all -size 320x120 xc:white -draw \
    "fill red font-size 64 font '/Users/user/Downloads/NotoSansCJKjp-hinted/NotoSansCJKjp-Medium.otf' decorate Underline gravity center text 0,0 'test'" underline_red.gif
```

![underline_red](https://user-images.githubusercontent.com/7090315/60382390-71b8f300-9a9d-11e9-9249-40c400f111dc.gif)

**multi line text + blue color + line through**

```bash
convert \ 
    -debug all -size 320x200 xc:white -draw \
    "fill blue font-size 64 font '/Users/user/Downloads/NotoSansCJKjp-hinted/NotoSansCJKjp-Medium.otf' decorate LineThrough gravity center text 0,0 'test
test'" linethrough_blue_multi.gif
```

![linethrough_blue_multi](https://user-images.githubusercontent.com/7090315/60382663-5354f680-9aa1-11e9-8330-5ba75e3d9ba9.gif)

**this PR's draw example**

> reference: https://www.imagemagick.org/Usage/text/#draw

```bash
convert -size 320x120 xc:lightblue \
          -draw "fill tomato  circle 250,30 310,30 \
                 fill limegreen  circle 55,75 15,80 \
                 font Candice  font-size 72  decorate UnderLine \
                 fill dodgerblue  stroke navy  stroke-width 2 \
                 translate 10,110 rotate -15 text 0,0 ' Anthony '" \
          draw_mvg.gif
```

![draw_mvg](https://user-images.githubusercontent.com/7090315/60382886-8c429a80-9aa4-11e9-8974-e663935ae07a.gif)

### Issue Details

There are two kinds of issue in the code

#### 1st: Inaccuracy face underline information 

ImageMagick `annotate.c:L1467-1468` refers [Freetype's FT_Open_Face](https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_open_face) to get face information, And the function will give `underline_thickness`, `underline_position` as following

https://github.com/ImageMagick/ImageMagick/blob/80804f7294aec1cacb624cd1eef55fcf6f7f614a/MagickCore/annotate.c#L1467-L1468

But the problem is, The formula for getting correct `underline_thickness` and `underline_position` We should include `ppem` ratio information instead the number `64`

Because previous version of ImageMagick, They give wrong metric information. Check the below

```bash
# Output from convert command (when i turned on -debug all)
Metrics: text: test; width: 117; height: 95; ascent: 75; descent: -21; max advance: 192; bounds: 1.59375,-1  24.3125,44.7188; origin: 117,0; pixels per em: 64,64; underline position: -2.34375; underline thickness: 0.78125
```
The expected thickness should be at least close to approx. 4px (But the above output prints 0.78125 - too thin)

https://github.com/ImageMagick/ImageMagick/blob/80804f7294aec1cacb624cd1eef55fcf6f7f614a/MagickCore/annotate.c#L522-L523

And when we use `LineThrough` decoration style, The affine ty seems to be wrong.

`height` local variable represents `ascent-descent+(length of text rows-1)*interline_spacing)`,

However, If we want to subtract the accurate half size of height, We should use addition with `descent` (In this case, `height` includes already the `-descent`, We should add `2 x descent` in the formula.

#### 2nd: DrawStrokePolygon function omits branches due to omission of stroke color information.

Mostly, `DrawPolygonPrimitive` function works when the user doesn't give a specific `stroke` option(stroke color option).

But you want to put the `strokewidth` information at the line (or polygon), The option must include specific `stroke` color information.

https://github.com/ImageMagick/ImageMagick/blob/80804f7294aec1cacb624cd1eef55fcf6f7f614a/MagickCore/draw.c#L5550-L5552

In the above code, They check `draw_info->stroke.alpha`

And If the stroke is not defined or `transparent` type, The logic will omit the  `DrawStrokePolygon` function in `draw.c:L5585`.

Sadly `DrawStrokePolygon` is for drawing stroke with specific stroke, If you didn't pass this branch, The stroke will be just less than `1px`.

https://github.com/ImageMagick/ImageMagick/blob/80804f7294aec1cacb624cd1eef55fcf6f7f614a/MagickCore/draw.c#L5585

In `annotate.c:L497-498`, The code tries to define primitive to draw an additional line for decoration, But there is no stroke information, So the stroke alpha will be `transparent` type

And `DrawStrokePolygon` function will be omitted. Because of that, Every decorate stroke cannot be large than `1px`

https://github.com/ImageMagick/ImageMagick/blob/80804f7294aec1cacb624cd1eef55fcf6f7f614a/MagickCore/annotate.c#L497-L498
