### PR TITLE
fix line through z-index issue

### DIFF
--- a/MagickCore/annotate.c
+++ b/MagickCore/annotate.c
@@ -526,19 +526,17 @@ MagickExport MagickBooleanType AnnotateImage(Image *image,
         (void) DrawImage(image,annotate_info,exception);
         break;
       }
-      case LineThroughDecoration:
-      {
-        annotate_info->affine.ty-=(draw_info->affine.sy*(height+
-          metrics.underline_position+metrics.descent*2)/2.0);
-        (void) CloneString(&annotate_info->primitive,primitive);
-        (void) DrawImage(image,annotate_info,exception);
-      }
-      default:
-        break;
     }
     status=RenderType(image,annotate,&offset,&metrics,exception);
     if (status == MagickFalse)
       break;
+
+    if (annotate->decorate == LineThroughDecoration) {
+        annotate_info->affine.ty-=(draw_info->affine.sy*(height+
+          metrics.underline_position+metrics.descent*2)/2.0);
+        (void) CloneString(&annotate_info->primitive,primitive);
+        (void) DrawImage(image,annotate_info,exception);
+    }
   }
   /*
     Relinquish resources.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Related 

- The issue happend from https://github.com/ImageMagick/ImageMagick/pull/1619

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->

When I sent a PR(https://github.com/ImageMagick/ImageMagick/pull/1619), I cleaned up the branch of text decorations, But At recent, I realized the separated design must be happened to control the layer drawing priority.

The following will show the details, 3 decorations required priorities.

Name | Priority
-----|-----------
Underline | `NORMAL`
LineThrough | `LOW`
Overline | `NORMAL`

However, It was as following


Name | Priority
-----|-----------
Underline | `NORMAL`
LineThrough | `NORMAL` <- This can be problem
Overline | `NORMAL`

#### Test Commandline

**LineThrough**

```bash
convert -size 320x120 xc:lightblue \
          -draw "fill tomato  circle 250,30 310,30 \
                 fill limegreen  circle 55,75 15,80 \
                 font Candice  font-size 72  decorate LineThrough \
                 fill dodgerblue  stroke navy  stroke-width 2 \
                 translate 10,110 rotate -15 text 0,0 ' Anthony '" \
          draw_line_through.gif
```

**Underline**

```bash
convert -size 320x120 xc:lightblue \
          -draw "fill tomato  circle 250,30 310,30 \
                 fill limegreen  circle 55,75 15,80 \
                 font Candice  font-size 72  decorate UnderLine \
                 fill dodgerblue  stroke navy  stroke-width 2 \
                 translate 10,110 rotate -15 text 0,0 ' Anthony '" \
          draw_underline.gif
```

#### AS-WAS

**LineThrough**

![draw_line_through](https://user-images.githubusercontent.com/7090315/60818659-0d064280-a1d9-11e9-9d14-3c61d1f9082b.gif)

**Underline**

![draw_underline](https://user-images.githubusercontent.com/7090315/60818688-18596e00-a1d9-11e9-91de-21010df389e8.gif)


#### TO-BE

**LineThrough**

![draw_line_through_new](https://user-images.githubusercontent.com/7090315/60818697-20191280-a1d9-11e9-9e09-552547356334.gif)

**Underline**

> No differences

![draw_underline_new](https://user-images.githubusercontent.com/7090315/60818715-2909e400-a1d9-11e9-8743-56d69e27bf15.gif)
