### PR TITLE
Use specific version of MagickCore in MagickWand.pc (closes #1637)

### DIFF
--- a/MagickWand/MagickWand.pc.in
+++ b/MagickWand/MagickWand.pc.in
@@ -9,7 +9,7 @@ Name: MagickWand
 Description: MagickWand - C API for ImageMagick (ABI @MAGICK_ABI_SUFFIX@)
 URL: https://github.com/ImageMagick
 Version: @PACKAGE_VERSION@
-Requires: MagickCore
+Requires: MagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
 Cflags: -I${includearchdir} -I${includedir} @MAGICK_PCFLAGS@
 Libs: -L${libdir} -l${libname}
 Libs.private: -L${libdir} -l${libname} @MAGICK_LIBS@ @MATH_LIBS@


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Basically, if you have two versions of ImageMagick installed using the same PREFIX, you can use the version and abi specified pkg-config files to get the right version of MagickCore and MagickWand, but MagickWand internally will use pkg-config's "MagickCore", which refers to the most recently installed version of ImageMagick.

<!-- Thanks for contributing to ImageMagick! -->
