### PR TITLE
Attempt to fix types in webp decoder to protect against overflow

### DIFF
--- a/coders/webp.c
+++ b/coders/webp.c
@@ -177,7 +177,7 @@ static MagickBooleanType IsWEBPImageLossless(const unsigned char *stream,
 #define CHUNK_HEADER_SIZE  8
 #define MAX_CHUNK_PAYLOAD  (~0U-CHUNK_HEADER_SIZE-1)
 
-  ssize_t
+  size_t
     offset;
 
   /*
@@ -191,7 +191,7 @@ static MagickBooleanType IsWEBPImageLossless(const unsigned char *stream,
     Read extended header.
   */
   offset=RIFF_HEADER_SIZE+TAG_SIZE+CHUNK_SIZE_BYTES+VP8X_CHUNK_SIZE;
-  while ((offset+TAG_SIZE+4) <= (ssize_t) (length-TAG_SIZE))
+  while ((offset+TAG_SIZE+4) <= (length-TAG_SIZE))
   {
     uint32_t
       chunk_size,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
There's no reason for `offset` to be negative, the value can never actually be negative as far as I can tell, except in the case of an overflow.