### PR TITLE
Rewrite conditional to avoid the possibility of integer overflow

### DIFF
--- a/coders/webp.c
+++ b/coders/webp.c
@@ -191,7 +191,7 @@ static MagickBooleanType IsWEBPImageLossless(const unsigned char *stream,
     Read extended header.
   */
   offset=RIFF_HEADER_SIZE+TAG_SIZE+CHUNK_SIZE_BYTES+VP8X_CHUNK_SIZE;
-  while ((offset+TAG_SIZE+4) <= (length-TAG_SIZE))
+  while (offset <= (length-TAG_SIZE-TAG_SIZE-4))
   {
     uint32_t
       chunk_size,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

`offset + TAG_SIZE +4` can overflow, however `length` is known to be at least 15, so `length-TAG_SIZE-TAG_SIZE-4` never can underflow.