### PR TITLE
Make integer types consistent -- on 32-bit MagickOffsetType is still 64-bits wide, but ssize_t isn't

### DIFF
--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -1130,7 +1130,7 @@ static ssize_t TIFFReadCustomStream(unsigned char *data,const size_t count,
   size_t
     total;
 
-  ssize_t
+  MagickOffsetType
     remaining;
 
   if (count == 0)


### PR DESCRIPTION
Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18166

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
