### PR TITLE
Fix the format string

### DIFF
--- a/MagickCore/quantize.c
+++ b/MagickCore/quantize.c
@@ -2699,7 +2699,7 @@ MagickExport MagickBooleanType KmeansImage(Image *image,
       distortion+=kmeans_pixels[0][i].distortion;
     }
     if (verbose != MagickFalse)
-      (void) (void) FormatLocaleFile(stderr,"distortion[%ld]: %g %g\n",n,
+      (void) (void) FormatLocaleFile(stderr,"distortion[%zd]: %g %g\n",n,
         distortion,fabs(distortion-previous_distortion));
     if (fabs(distortion-previous_distortion) <= max_distortion)
       break;


### PR DESCRIPTION
Clang complaint about this. The right format string for ssize_t seems to be %zd.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
