### PR TITLE
Fix typo in ImageMagick manpage

### DIFF
--- a/utilities/ImageMagick.1
+++ b/utilities/ImageMagick.1
@@ -37,7 +37,7 @@ line.
 .B magick
 
 Read images into memory, and perform operations on those images, and write
-then out to either the same of some other image file format.
+them out to either the same or some other image file format.
 
 The "-script" option can be switch from processing command line options,
 to reading options from a file or pipeline.

--- a/utilities/ImageMagick.1.in
+++ b/utilities/ImageMagick.1.in
@@ -37,7 +37,7 @@ line.
 .B magick
 
 Read images into memory, and perform operations on those images, and write
-then out to either the same of some other image file format.
+them out to either the same or some other image file format.
 
 The "-script" option can be switch from processing command line options,
 to reading options from a file or pipeline.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

I just noticed two typos in this line while reading the man :)
