### PR TITLE
Use specific MagickWand ABI version in Magick++.pc

### DIFF
--- a/Magick++/lib/Magick++.pc.in
+++ b/Magick++/lib/Magick++.pc.in
@@ -8,7 +8,7 @@ libname=Magick++-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
 Name: Magick++
 Description: Magick++ - C++ API for ImageMagick (ABI @MAGICK_ABI_SUFFIX@)
 Version: @PACKAGE_VERSION@
-Requires: MagickWand
+Requires: MagickWand-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
 Libs: -L${libdir} -l${libname}
 Libs.private: -L${libdir} -l${libname} @MATH_LIBS@
 Cflags: -I${includearchdir} -I${includedir} @MAGICK_PCFLAGS@


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Just as in #1638 (which modified the `MagickWand.pc` template), `Magick++.pc` should in turn depend on a specific `MagicWand-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@`, to avoid library builds getting mixed together when multiple ABIs are installed.