### PR TITLE
Target specific ABI version in -config scripts

### DIFF
--- a/Magick++/bin/Magick++-config.in
+++ b/Magick++/bin/Magick++-config.in
@@ -41,19 +41,19 @@ while test $# -gt 0; do
       echo '@PACKAGE_VERSION@ Q@QUANTUM_DEPTH@ @MAGICK_HDRI@'
       ;;
     --cflags)
-      @PKG_CONFIG@ --cflags Magick++
+      @PKG_CONFIG@ --cflags Magick++-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --cxxflags)
-      @PKG_CONFIG@ --cflags Magick++
+      @PKG_CONFIG@ --cflags Magick++-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --cppflags)
-      @PKG_CONFIG@ --cflags Magick++
+      @PKG_CONFIG@ --cflags Magick++-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --ldflags)
-      @PKG_CONFIG@ --libs Magick++
+      @PKG_CONFIG@ --libs Magick++-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --libs)
-      @PKG_CONFIG@ --libs Magick++
+      @PKG_CONFIG@ --libs Magick++-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     *)
       echo "${usage}" 1>&2

--- a/MagickCore/MagickCore-config.in
+++ b/MagickCore/MagickCore-config.in
@@ -38,19 +38,19 @@ while test $# -gt 0; do
       echo '@PACKAGE_VERSION@ Q@QUANTUM_DEPTH@ @MAGICK_HDRI@'
       ;;
     --cflags)
-      @PKG_CONFIG@ --cflags MagickCore
+      @PKG_CONFIG@ --cflags MagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --cxxflags)
-      @PKG_CONFIG@ --cflags MagickCore
+      @PKG_CONFIG@ --cflags MagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --cppflags)
-      @PKG_CONFIG@ --cflags MagickCore
+      @PKG_CONFIG@ --cflags MagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --ldflags)
-      @PKG_CONFIG@ --libs MagickCore
+      @PKG_CONFIG@ --libs MagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --libs)
-      @PKG_CONFIG@ --libs MagickCore
+      @PKG_CONFIG@ --libs MagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --coder-path)
       echo "@CODER_PATH@"

--- a/MagickWand/MagickWand-config.in
+++ b/MagickWand/MagickWand-config.in
@@ -38,19 +38,19 @@ while test $# -gt 0; do
       echo '@PACKAGE_VERSION@ Q@QUANTUM_DEPTH@ @MAGICK_HDRI@'
       ;;
     --cflags)
-      @PKG_CONFIG@ --cflags MagickWand
+      @PKG_CONFIG@ --cflags MagickWand-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --cxxflags)
-      @PKG_CONFIG@ --cflags MagickWand
+      @PKG_CONFIG@ --cflags MagickWand-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --cppflags)
-      @PKG_CONFIG@ --cflags MagickWand
+      @PKG_CONFIG@ --cflags MagickWand-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --ldflags)
-      @PKG_CONFIG@ --libs MagickWand
+      @PKG_CONFIG@ --libs MagickWand-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     --libs)
-      @PKG_CONFIG@ --libs MagickWand
+      @PKG_CONFIG@ --libs MagickWand-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@
       ;;
     *)
       echo "${usage}" 1>&2


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Target a specific library ABI when making `pkg-config` data requests using the `-config` scripts, so that multiple scripts installed side-by-side (say, using `configure --program-transform-name`) will each pick up the correct configs.

```sh
# ========== Before ===========================================
$ Magick++-config --cflags --libs
-I/usr/include/ImageMagick-6 -fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 
-lMagick++-6.Q16 -lMagickWand-6.Q16 -lMagickCore-6.Q16 

$ Magick++7-config --cflags --libs
-I/usr/include/ImageMagick-6 -fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 
-lMagick++-6.Q16 -lMagickWand-6.Q16 -lMagickCore-6.Q16 

# ========== After ============================================
$ Magick++-config --cflags --libs
-I/usr/include/ImageMagick-6 -fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 
-lMagick++-6.Q16 -lMagickWand-6.Q16 -lMagickCore-6.Q16 

$ Magick++7-config --cflags --libs
-I/usr/include/ImageMagick-7 -fopenmp -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16 
-lMagick++-7.Q16HDRI -lMagickWand-7.Q16HDRI -lMagickCore-7.Q16HDRI 
```
