### PR TITLE
[suggestion] configure --with-openjp2 to switch library path

### DIFF
--- a/configure
+++ b/configure
@@ -4566,7 +4566,7 @@ MAGICK_PATCHLEVEL_VERSION=3
 
 MAGICK_VERSION=7.0.10-3
 
-MAGICK_GIT_REVISION=17089:263fc2ce1:20200322
+MAGICK_GIT_REVISION=17090:4b25060:20200324
 
 
 # Substitute library versioning
@@ -31410,7 +31410,7 @@ have_openjp2='no'
 LIBOPENJP2_CFLAGS=""
 LIBOPENJP2_LIBS=""
 LIBOPENJP2_PKG=""
-if test "x$with_openjp2" = "xyes"; then
+if test "$with_openjp2" != 'no'; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: -------------------------------------------------------------" >&5
 $as_echo "-------------------------------------------------------------" >&6; }
 

--- a/configure.ac
+++ b/configure.ac
@@ -2413,7 +2413,7 @@ have_openjp2='no'
 LIBOPENJP2_CFLAGS=""
 LIBOPENJP2_LIBS=""
 LIBOPENJP2_PKG=""
-if test "x$with_openjp2" = "xyes"; then
+if test "$with_openjp2" != 'no'; then
   AC_MSG_RESULT([-------------------------------------------------------------])
   PKG_CHECK_MODULES(LIBOPENJP2,[libopenjp2 >= 2.1.0], have_openjp2=yes, have_openjp2=no)
   AC_MSG_RESULT([])


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

configure --with-jpeg can switch library path.
but configure --with-openjp2 can't switch library path.

ref) https://github.com/ImageMagick/ImageMagick/issues/1869

I made it possible to switch openjp2 library by imitating --with-jpeg.

However, many --with-* can't switch library path, include openjp2.
As mentioned in issues/1869, --with-jpeg like switching is a minority.

If the current policy to switch library path is to use the settings in pkg-config,
please refuse this PR.

####  test

*  switch library path

```
./configure --with-openjp2=/Users/yoya/openjpeg/2.3.0/  # library path

  OpenJP2           --with-openjp2=/Users/yoya/openjpeg/2.3.0/		yes
```

* pkg-config is used

```
./configure

  OpenJP2           --with-openjp2=yes		yes
```

```
./configure --with-openjp2=

  OpenJP2           --with-openjp2=		yes
```

```
./configure --with-openjp2=yes

  OpenJP2           --with-openjp2=yes		yes
```

```
./configure --with-openjp2=/Users/yoya/openjpeg/  # no library path

  OpenJP2           --with-openjp2=/Users/yoya/openjpeg		yes
```

```
./configure --with-openjp2=foo  # no exist path

  OpenJP2           --with-openjp2=foo		yes
```

* disable openjp2

```
./configure --with-openjp2=no

  OpenJP2           --with-openjp2=no		no
```

<!-- Thanks for contributing to ImageMagick! -->
