### PR TITLE
 Fixed a bug in multi-value of jp2:quality

### DIFF
--- a/coders/jp2.c
+++ b/coders/jp2.c
@@ -862,6 +862,7 @@ static MagickBooleanType WriteJP2Image(const ImageInfo *image_info,Image *image,
     {
       parameters->tcp_distoratio[0]=(double) image_info->quality;
       parameters->cp_fixed_quality=OPJ_TRUE;
+      parameters->cp_disto_alloc=0;
     }
   if (image_info->extract != (char *) NULL)
     {
@@ -910,6 +911,7 @@ static MagickBooleanType WriteJP2Image(const ImageInfo *image_info,Image *image,
       }
       parameters->tcp_numlayers=i+1;
       parameters->cp_fixed_quality=OPJ_TRUE;
+      parameters->cp_disto_alloc=0;
     }
   option=GetImageOption(image_info,"jp2:progression-order");
   if (option != (const char *) NULL)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

BUG: cp_disto_alloc is not set back to 0 by only setting cp_fixed_quality=1 when specifying -define jp2:quality (and -quality)

reference) https://github.com/ImageMagick/ImageMagick/issues/1873

OpenJPEG seems to use cp_disto_alloc and cp_fixed_alloc exclusively.

If both flags are set, even if ImageMagick set values of jp2:quality to the tcp_distoratio array, OpenJPEG will check tcp_rates in descending order with 0 initialization, and an error will occur.

- https://github.com/uclouvain/openjpeg/blob/v2.3.1/src/lib/openjp2/j2k.c#L6874

#### Test

```
% convert rose: -define jp2:quality=10,20,30 rose.jp2
% identify  rose.jp2
rose.jp2 JP2 70x46 70x46+0+0 8-bit sRGB 0.000u 0:00.000
%
```

- Error occurs correctly

```
$ convert rose: -define jp2:quality=30,20,10 rose.jp2
convert: tcp_distoratio[1]=20.000000 should be strictly greater than tcp_distoratio[0]=30.000000
 `OpenJP2' @ warning/jp2.c/JP2WarningHandler/237.
convert: tcp_distoratio[2]=10.000000 should be strictly greater than tcp_distoratio[1]=20.000000
 `OpenJP2' @ warning/jp2.c/JP2WarningHandler/237.
%
```

- regression

```
% convert rose: -quality 10 rose.jp2
% identify  rose.jp2
rose.jp2 JP2 70x46 70x46+0+0 8-bit sRGB 0.000u 0:00.000
%
```

<!-- Thanks for contributing to ImageMagick! -->
