### PR TITLE
Correct HEIC orientation for the ping operation (#1233)

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -306,8 +306,7 @@ static MagickBooleanType ReadHEICImageByID(const ImageInfo *image_info,
   image->depth=8;
   image->columns=(size_t) heif_image_handle_get_width(image_handle);
   image->rows=(size_t) heif_image_handle_get_height(image_handle);
-
-  preserve_orientation = IsStringTrue(GetImageOption(image_info,
+  preserve_orientation=IsStringTrue(GetImageOption(image_info,
     "heic:preserve-orientation"));
 
   if (preserve_orientation == MagickFalse)
@@ -340,7 +339,6 @@ static MagickBooleanType ReadHEICImageByID(const ImageInfo *image_info,
       decode_options=heif_decoding_options_alloc();
       decode_options->ignore_transformations=1;
     }
-  else
   error=heif_decode_image(image_handle,&heif_image,heif_colorspace_YCbCr,
     heif_chroma_420,decode_options);
   if (decode_options != (struct heif_decoding_options *) NULL)


### PR DESCRIPTION
This is a follow-up for commit 41fa21a2eabdeee0202a5f32c081ee968784c265

The fix for https://github.com/ImageMagick/ImageMagick/issues/1232 was
not effective for the "ping" operation, when the library is ought to
return image properties without decoding the pixel data.