### PR TITLE
coders/pnm: Handle write failures

### DIFF
--- a/MagickCore/blob-private.h
+++ b/MagickCore/blob-private.h
@@ -124,6 +124,144 @@ extern MagickExport ssize_t
   WriteBlobMSBSignedShort(Image *,const signed short),
   WriteBlobString(Image *,const char *);
 
+#define CheckWriteBlob(img, len, dat) \
+{   \
+  ssize_t __ret_size = WriteBlob(img, (len), dat); \
+  if (__ret_size != (ssize_t)(len)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+
+#define CheckWriteBlobByte(img, sz) \
+{ \
+  if (WriteBlobByte(img, sz) != sizeof(unsigned char)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobFloat(img, sz) \
+{ \
+  if (WriteBlobFloat(img, sz) != sizeof(float)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobLong(img, sz) \
+{ \
+  if (WriteBlobLong(img, sz) != sizeof(unsigned int)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobLongLong(img, sz) \
+{ \
+  if (WriteBlobLongLong(img, sz) != sizeof(MagickSizeType)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobShort(img, sz) \
+{ \
+  if (WriteBlobShort(img, sz) != sizeof(unsigned short)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobSignedLong(img, sz) \
+{ \
+  if (WriteBlobSignedLong(img, sz) != sizeof(signed int)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobLSBLong(img, sz) \
+{ \
+  if (WriteBlobLSBLong(img, sz) != sizeof(unsigned int)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobLSBShort(img, sz) \
+{ \
+  if (WriteBlobLSBShort(img, sz) != sizeof(unsigned short)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobLSBSignedLong(img, sz) \
+{ \
+  if (WriteBlobLSBSignedLong(img, sz) != sizeof(signed int)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobLSBSignedShort(img, sz) \
+{ \
+  if (WriteBlobLSBSignedShort(img, sz) != sizeof(signed short)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobMSBLong(img, sz) \
+{ \
+  if (WriteBlobMSBLong(img, sz) != sizeof(unsigned int)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobMSBShort(img, sz) \
+{ \
+  if (WriteBlobMSBShort(img, sz) != sizeof(unsigned short)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobMSBSignedShort(img, sz) \
+{ \
+  if (WriteBlobMSBSignedShort(img, sz) != sizeof(signed short)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+#define CheckWriteBlobString(img, str) \
+{ \
+  if (WriteBlobString(img, str) != strlen(str)) { \
+    perror("WriteBlob failed"); \
+    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    status = MagickFalse; \
+    break; \
+  } \
+}
+
 extern MagickExport unsigned int
   ReadBlobLong(Image *),
   ReadBlobLSBLong(Image *),

--- a/MagickCore/blob-private.h
+++ b/MagickCore/blob-private.h
@@ -128,8 +128,7 @@ extern MagickExport ssize_t
 {   \
   ssize_t __ret_size = WriteBlob(img, (len), dat); \
   if (__ret_size != (ssize_t)(len)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -138,8 +137,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobByte(img, sz) \
 { \
   if (WriteBlobByte(img, sz) != sizeof(unsigned char)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -147,8 +145,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobFloat(img, sz) \
 { \
   if (WriteBlobFloat(img, sz) != sizeof(float)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -156,8 +153,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobLong(img, sz) \
 { \
   if (WriteBlobLong(img, sz) != sizeof(unsigned int)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -165,8 +161,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobLongLong(img, sz) \
 { \
   if (WriteBlobLongLong(img, sz) != sizeof(MagickSizeType)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -174,8 +169,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobShort(img, sz) \
 { \
   if (WriteBlobShort(img, sz) != sizeof(unsigned short)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -183,8 +177,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobSignedLong(img, sz) \
 { \
   if (WriteBlobSignedLong(img, sz) != sizeof(signed int)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -192,8 +185,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobLSBLong(img, sz) \
 { \
   if (WriteBlobLSBLong(img, sz) != sizeof(unsigned int)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -201,8 +193,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobLSBShort(img, sz) \
 { \
   if (WriteBlobLSBShort(img, sz) != sizeof(unsigned short)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -210,8 +201,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobLSBSignedLong(img, sz) \
 { \
   if (WriteBlobLSBSignedLong(img, sz) != sizeof(signed int)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -219,8 +209,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobLSBSignedShort(img, sz) \
 { \
   if (WriteBlobLSBSignedShort(img, sz) != sizeof(signed short)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -228,8 +217,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobMSBLong(img, sz) \
 { \
   if (WriteBlobMSBLong(img, sz) != sizeof(unsigned int)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -237,8 +225,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobMSBShort(img, sz) \
 { \
   if (WriteBlobMSBShort(img, sz) != sizeof(unsigned short)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -246,8 +233,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobMSBSignedShort(img, sz) \
 { \
   if (WriteBlobMSBSignedShort(img, sz) != sizeof(signed short)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \
@@ -255,8 +241,7 @@ extern MagickExport ssize_t
 #define CheckWriteBlobString(img, str) \
 { \
   if (WriteBlobString(img, str) != strlen(str)) { \
-    perror("WriteBlob failed"); \
-    fprintf(stderr, "WriteBlob* failed in %s at %d\n", __FILE__, __LINE__); \
+    ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
     status = MagickFalse; \
     break; \
   } \

--- a/coders/bmp.c
+++ b/coders/bmp.c
@@ -2266,37 +2266,37 @@ static MagickBooleanType WriteBMPImage(const ImageInfo *image_info,Image *image,
           profile_size_pad=4-(profile_size%4);
         bmp_info.file_size+=profile_size+profile_size_pad;
       }
-    (void) WriteBlob(image,2,(unsigned char *) "BM");
-    (void) WriteBlobLSBLong(image,bmp_info.file_size);
-    (void) WriteBlobLSBLong(image,bmp_info.ba_offset);  /* always 0 */
-    (void) WriteBlobLSBLong(image,bmp_info.offset_bits);
+    CheckWriteBlob(image,2,(unsigned char *) "BM");
+    CheckWriteBlobLSBLong(image,bmp_info.file_size);
+    CheckWriteBlobLSBLong(image,bmp_info.ba_offset);  /* always 0 */
+    CheckWriteBlobLSBLong(image,bmp_info.offset_bits);
     if (type == 2)
       {
         /*
           Write 12-byte version 2 bitmap header.
         */
-        (void) WriteBlobLSBLong(image,bmp_info.size);
-        (void) WriteBlobLSBSignedShort(image,(signed short) bmp_info.width);
-        (void) WriteBlobLSBSignedShort(image,(signed short) bmp_info.height);
-        (void) WriteBlobLSBShort(image,bmp_info.planes);
-        (void) WriteBlobLSBShort(image,bmp_info.bits_per_pixel);
+        CheckWriteBlobLSBLong(image,bmp_info.size);
+        CheckWriteBlobLSBSignedShort(image,(signed short) bmp_info.width);
+        CheckWriteBlobLSBSignedShort(image,(signed short) bmp_info.height);
+        CheckWriteBlobLSBShort(image,bmp_info.planes);
+        CheckWriteBlobLSBShort(image,bmp_info.bits_per_pixel);
       }
     else
       {
         /*
           Write 40-byte version 3+ bitmap header.
         */
-        (void) WriteBlobLSBLong(image,bmp_info.size);
-        (void) WriteBlobLSBSignedLong(image,(signed int) bmp_info.width);
-        (void) WriteBlobLSBSignedLong(image,(signed int) bmp_info.height);
-        (void) WriteBlobLSBShort(image,bmp_info.planes);
-        (void) WriteBlobLSBShort(image,bmp_info.bits_per_pixel);
-        (void) WriteBlobLSBLong(image,bmp_info.compression);
-        (void) WriteBlobLSBLong(image,bmp_info.image_size);
-        (void) WriteBlobLSBLong(image,bmp_info.x_pixels);
-        (void) WriteBlobLSBLong(image,bmp_info.y_pixels);
-        (void) WriteBlobLSBLong(image,bmp_info.number_colors);
-        (void) WriteBlobLSBLong(image,bmp_info.colors_important);
+        CheckWriteBlobLSBLong(image,bmp_info.size);
+        CheckWriteBlobLSBSignedLong(image,(signed int) bmp_info.width);
+        CheckWriteBlobLSBSignedLong(image,(signed int) bmp_info.height);
+        CheckWriteBlobLSBShort(image,bmp_info.planes);
+        CheckWriteBlobLSBShort(image,bmp_info.bits_per_pixel);
+        CheckWriteBlobLSBLong(image,bmp_info.compression);
+        CheckWriteBlobLSBLong(image,bmp_info.image_size);
+        CheckWriteBlobLSBLong(image,bmp_info.x_pixels);
+        CheckWriteBlobLSBLong(image,bmp_info.y_pixels);
+        CheckWriteBlobLSBLong(image,bmp_info.number_colors);
+        CheckWriteBlobLSBLong(image,bmp_info.colors_important);
       }
     if ((type > 3) && ((image->alpha_trait != UndefinedPixelTrait) ||
         (have_color_info != MagickFalse)))
@@ -2304,14 +2304,15 @@ static MagickBooleanType WriteBMPImage(const ImageInfo *image_info,Image *image,
         /*
           Write the rest of the 108-byte BMP Version 4 header.
         */
-        (void) WriteBlobLSBLong(image,bmp_info.red_mask);
-        (void) WriteBlobLSBLong(image,bmp_info.green_mask);
-        (void) WriteBlobLSBLong(image,bmp_info.blue_mask);
-        (void) WriteBlobLSBLong(image,bmp_info.alpha_mask);
-        if (profile != (StringInfo *) NULL)
-          (void) WriteBlobLSBLong(image,0x4D424544U);  /* PROFILE_EMBEDDED */
-        else
-          (void) WriteBlobLSBLong(image,0x73524742U);  /* sRGB */
+        CheckWriteBlobLSBLong(image,bmp_info.red_mask);
+        CheckWriteBlobLSBLong(image,bmp_info.green_mask);
+        CheckWriteBlobLSBLong(image,bmp_info.blue_mask);
+        CheckWriteBlobLSBLong(image,bmp_info.alpha_mask);
+        if (profile != (StringInfo *) NULL) {
+          CheckWriteBlobLSBLong(image,0x4D424544U); /* PROFILE_EMBEDDED */
+        } else {
+          CheckWriteBlobLSBLong(image,0x73524742U);  /* sRGB */
+        }
         
         // bounds check, assign .0 if invalid value
         if (isgreater(image->chromaticity.red_primary.x, 1.0) ||
@@ -2342,32 +2343,32 @@ static MagickBooleanType WriteBMPImage(const ImageInfo *image_info,Image *image,
             !isgreater(bmp_info.gamma_scale.z, 0.0))
           bmp_info.gamma_scale.z = 0.0;
 
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (image->chromaticity.red_primary.x*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (image->chromaticity.red_primary.y*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           ((1.000f-(image->chromaticity.red_primary.x+
           image->chromaticity.red_primary.y))*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (image->chromaticity.green_primary.x*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (image->chromaticity.green_primary.y*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           ((1.000f-(image->chromaticity.green_primary.x+
           image->chromaticity.green_primary.y))*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (image->chromaticity.blue_primary.x*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (image->chromaticity.blue_primary.y*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           ((1.000f-(image->chromaticity.blue_primary.x+
           image->chromaticity.blue_primary.y))*0x40000000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (bmp_info.gamma_scale.x*0x10000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (bmp_info.gamma_scale.y*0x10000));
-        (void) WriteBlobLSBLong(image,(unsigned int)
+        CheckWriteBlobLSBLong(image,(unsigned int)
           (bmp_info.gamma_scale.z*0x10000));
         if ((image->rendering_intent != UndefinedIntent) ||
             (profile != (StringInfo *) NULL))
@@ -2403,11 +2404,11 @@ static MagickBooleanType WriteBMPImage(const ImageInfo *image_info,Image *image,
                 break;
               }
             }
-            (void) WriteBlobLSBLong(image,(unsigned int) intent);
-            (void) WriteBlobLSBLong(image,(unsigned int) profile_data);
-            (void) WriteBlobLSBLong(image,(unsigned int)
+            CheckWriteBlobLSBLong(image,(unsigned int) intent);
+            CheckWriteBlobLSBLong(image,(unsigned int) profile_data);
+            CheckWriteBlobLSBLong(image,(unsigned int)
               (profile_size+profile_size_pad));
-            (void) WriteBlobLSBLong(image,0x00);  /* reserved */
+            CheckWriteBlobLSBLong(image,0x00);  /* reserved */
           }
       }
     if (image->storage_class == PseudoClass)
@@ -2445,26 +2446,27 @@ static MagickBooleanType WriteBMPImage(const ImageInfo *image_info,Image *image,
           if (type > 2)
             *q++=(unsigned char) 0x00;
         }
-        if (type <= 2)
-          (void) WriteBlob(image,(size_t) (3*(1L << bmp_info.bits_per_pixel)),
+        if (type <= 2) {
+          CheckWriteBlob(image,(size_t) (3*(1L << bmp_info.bits_per_pixel)),
             bmp_colormap);
-        else
-          (void) WriteBlob(image,(size_t) (4*(1L << bmp_info.bits_per_pixel)),
+        } else {
+          CheckWriteBlob(image,(size_t) (4*(1L << bmp_info.bits_per_pixel)),
             bmp_colormap);
+        }
         bmp_colormap=(unsigned char *) RelinquishMagickMemory(bmp_colormap);
       }
     if (image->debug != MagickFalse)
       (void) LogMagickEvent(CoderEvent,GetMagickModule(),
         "  Pixels:  %u bytes",bmp_info.image_size);
-    (void) WriteBlob(image,(size_t) bmp_info.image_size,pixels);
+    CheckWriteBlob(image,(size_t) bmp_info.image_size,pixels);
     if (profile != (StringInfo *) NULL)
       {
         if (image->debug != MagickFalse)
           (void) LogMagickEvent(CoderEvent,GetMagickModule(),
                                 "  Profile:  %g bytes",(double) profile_size+profile_size_pad);
-        (void) WriteBlob(image,(size_t) profile_size,GetStringInfoDatum(profile));
+        CheckWriteBlob(image,(size_t) profile_size,GetStringInfoDatum(profile));
         if (profile_size_pad > 0)  /* padding for 4 bytes multiple */
-          (void) WriteBlob(image,(size_t) profile_size_pad,"\0\0\0");
+          CheckWriteBlob(image,(size_t) profile_size_pad,"\0\0\0");
       }
     pixel_info=RelinquishVirtualMemory(pixel_info);
     if (GetNextImageInList(image) == (Image *) NULL)
@@ -2475,5 +2477,5 @@ static MagickBooleanType WriteBMPImage(const ImageInfo *image_info,Image *image,
       break;
   } while (image_info->adjoin != MagickFalse);
   (void) CloseBlob(image);
-  return(MagickTrue);
+  return(status);
 }

--- a/coders/pnm.c
+++ b/coders/pnm.c
@@ -2480,5 +2480,5 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
       break;
   } while (image_info->adjoin != MagickFalse);
   (void) CloseBlob(image);
-  return(MagickTrue);
+  return(status);
 }

--- a/coders/pnm.c
+++ b/coders/pnm.c
@@ -2085,6 +2085,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
       {
         register unsigned char
           *pixels;
+        ssize_t written = 0;
 
         /*
           Convert image to a PNM image.
@@ -2094,7 +2095,12 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
           image->depth=32;
         (void) FormatLocaleString(buffer,MagickPathExtent,"%.20g\n",(double)
           ((MagickOffsetType) GetQuantumRange(image->depth)));
-        (void) WriteBlobString(image,buffer);
+        written = WriteBlobString(image,buffer);
+        if (written != strlen(buffer)) {
+            perror("WriteBlob failed");
+            status = MagickFalse;
+            break;
+        }
         quantum_info=AcquireQuantumInfo(image_info,image);
         if (quantum_info == (QuantumInfo *) NULL)
           ThrowWriterException(ResourceLimitError,"MemoryAllocationFailed");
@@ -2170,8 +2176,11 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
             }
           }
           count=WriteBlob(image,extent,pixels);
-          if (count != (ssize_t) extent)
+          if (count != (ssize_t) extent) {
+            perror("WriteBlob failed!");
+            status = MagickFalse;
             break;
+          }
           if (image->previous == (Image *) NULL)
             {
               status=SetImageProgress(image,SaveImageTag,(MagickOffsetType) y,

--- a/coders/pnm.c
+++ b/coders/pnm.c
@@ -1641,7 +1641,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
       }
     }
     (void) FormatLocaleString(buffer,MagickPathExtent,"P%c\n",format);
-    (void) WriteBlobString(image,buffer);
+    CheckWriteBlobString(image,buffer);
     value=GetImageProperty(image,"comment",exception);
     if (value != (const char *) NULL)
       {
@@ -1651,20 +1651,20 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
         /*
           Write comments to file.
         */
-        (void) WriteBlobByte(image,'#');
+        CheckWriteBlobByte(image,'#');
         for (p=value; *p != '\0'; p++)
         {
-          (void) WriteBlobByte(image,(unsigned char) *p);
+          CheckWriteBlobByte(image,(unsigned char) *p);
           if ((*p == '\n') || (*p == '\r'))
-            (void) WriteBlobByte(image,'#');
+            CheckWriteBlobByte(image,'#');
         }
-        (void) WriteBlobByte(image,'\n');
+        CheckWriteBlobByte(image,'\n');
       }
     if (format != '7')
       {
         (void) FormatLocaleString(buffer,MagickPathExtent,"%.20g %.20g\n",
           (double) image->columns,(double) image->rows);
-        (void) WriteBlobString(image,buffer);
+        CheckWriteBlobString(image,buffer);
       }
     else
       {
@@ -1677,7 +1677,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
         (void) FormatLocaleString(buffer,MagickPathExtent,
           "WIDTH %.20g\nHEIGHT %.20g\n",(double) image->columns,(double)
           image->rows);
-        (void) WriteBlobString(image,buffer);
+        CheckWriteBlobString(image,buffer);
         quantum_type=GetQuantumType(image,exception);
         switch (quantum_type)
         {
@@ -1717,10 +1717,10 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
         (void) FormatLocaleString(buffer,MagickPathExtent,
           "DEPTH %.20g\nMAXVAL %.20g\n",(double) packet_size,(double)
           ((MagickOffsetType) GetQuantumRange(image->depth)));
-        (void) WriteBlobString(image,buffer);
+        CheckWriteBlobString(image,buffer);
         (void) FormatLocaleString(buffer,MagickPathExtent,
           "TUPLTYPE %s\nENDHDR\n",type);
-        (void) WriteBlobString(image,buffer);
+        CheckWriteBlobString(image,buffer);
       }
     /*
       Convert runextent encoded to PNM raster pixels.
@@ -1755,14 +1755,14 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
             if ((q-pixels+2) >= (ssize_t) sizeof(pixels))
               {
                 *q++='\n';
-                (void) WriteBlob(image,q-pixels,pixels);
+                CheckWriteBlob(image,q-pixels,pixels);
                 q=pixels;
               }
             *q++=' ';
             p+=GetPixelChannels(image);
           }
           *q++='\n';
-          (void) WriteBlob(image,q-pixels,pixels);
+          CheckWriteBlob(image,q-pixels,pixels);
           q=pixels;
           if (image->previous == (Image *) NULL)
             {
@@ -1775,7 +1775,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
         if (q != pixels)
           {
             *q++='\n';
-            (void) WriteBlob(image,q-pixels,pixels);
+            CheckWriteBlob(image,q-pixels,pixels);
           }
         break;
       }
@@ -1787,13 +1787,15 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
         /*
           Convert image to a PGM image.
         */
-        if (image->depth <= 8)
-          (void) WriteBlobString(image,"255\n");
-        else
-          if (image->depth <= 16)
-            (void) WriteBlobString(image,"65535\n");
-          else
-            (void) WriteBlobString(image,"4294967295\n");
+        if (image->depth <= 8) {
+          CheckWriteBlobString(image,"255\n");
+        } else {
+          if (image->depth <= 16) {
+            CheckWriteBlobString(image,"65535\n");
+          } else {
+            CheckWriteBlobString(image,"4294967295\n");
+          }
+        }
         q=pixels;
         for (y=0; y < (ssize_t) image->rows; y++)
         {
@@ -1823,7 +1825,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
             if ((q-pixels+extent+1) >= sizeof(pixels))
               {
                 *q++='\n';
-                (void) WriteBlob(image,q-pixels,pixels);
+                CheckWriteBlob(image,q-pixels,pixels);
                 q=pixels;
               }
             (void) memcpy((char *) q,buffer,extent);
@@ -1831,7 +1833,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
             p+=GetPixelChannels(image);
           }
           *q++='\n';
-          (void) WriteBlob(image,q-pixels,pixels);
+          CheckWriteBlob(image,q-pixels,pixels);
           q=pixels;
           if (image->previous == (Image *) NULL)
             {
@@ -1844,7 +1846,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
         if (q != pixels)
           {
             *q++='\n';
-            (void) WriteBlob(image,q-pixels,pixels);
+            CheckWriteBlob(image,q-pixels,pixels);
           }
         break;
       }
@@ -1857,13 +1859,15 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
           Convert image to a PNM image.
         */
         (void) TransformImageColorspace(image,sRGBColorspace,exception);
-        if (image->depth <= 8)
-          (void) WriteBlobString(image,"255\n");
-        else
-          if (image->depth <= 16)
-            (void) WriteBlobString(image,"65535\n");
-          else
-            (void) WriteBlobString(image,"4294967295\n");
+        if (image->depth <= 8) {
+          CheckWriteBlobString(image,"255\n");
+        } else {
+          if (image->depth <= 16) {
+            CheckWriteBlobString(image,"65535\n");
+          } else {
+            CheckWriteBlobString(image,"4294967295\n");
+          }
+        }
         q=pixels;
         for (y=0; y < (ssize_t) image->rows; y++)
         {
@@ -1898,7 +1902,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
             if ((q-pixels+extent+2) >= sizeof(pixels))
               {
                 *q++='\n';
-                (void) WriteBlob(image,q-pixels,pixels);
+                CheckWriteBlob(image,q-pixels,pixels);
                 q=pixels;
               }
             (void) memcpy((char *) q,buffer,extent);
@@ -1906,7 +1910,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
             p+=GetPixelChannels(image);
           }
           *q++='\n';
-          (void) WriteBlob(image,q-pixels,pixels);
+          CheckWriteBlob(image,q-pixels,pixels);
           q=pixels;
           if (image->previous == (Image *) NULL)
             {
@@ -1919,7 +1923,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
         if (q != pixels)
           {
             *q++='\n';
-            (void) WriteBlob(image,q-pixels,pixels);
+            CheckWriteBlob(image,q-pixels,pixels);
           }
         break;
       }
@@ -1975,7 +1979,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
           image->depth=32;
         (void) FormatLocaleString(buffer,MagickPathExtent,"%.20g\n",(double)
           ((MagickOffsetType) GetQuantumRange(image->depth)));
-        (void) WriteBlobString(image,buffer);
+        CheckWriteBlobString(image,buffer);
         quantum_info=AcquireQuantumInfo(image_info,image);
         if (quantum_info == (QuantumInfo *) NULL)
           ThrowWriterException(ResourceLimitError,"MemoryAllocationFailed");
@@ -2068,8 +2072,11 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
             }
           }
           count=WriteBlob(image,extent,pixels);
-          if (count != (ssize_t) extent)
+          if (count != (ssize_t) extent) {
+            perror("WriteBlob failed");
+            status = MagickFalse;
             break;
+          }
           if (image->previous == (Image *) NULL)
             {
               status=SetImageProgress(image,SaveImageTag,(MagickOffsetType) y,
@@ -2085,7 +2092,6 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
       {
         register unsigned char
           *pixels;
-        ssize_t written = 0;
 
         /*
           Convert image to a PNM image.
@@ -2095,12 +2101,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
           image->depth=32;
         (void) FormatLocaleString(buffer,MagickPathExtent,"%.20g\n",(double)
           ((MagickOffsetType) GetQuantumRange(image->depth)));
-        written = WriteBlobString(image,buffer);
-        if (written != strlen(buffer)) {
-            perror("WriteBlob failed");
-            status = MagickFalse;
-            break;
-        }
+        CheckWriteBlobString(image,buffer);
         quantum_info=AcquireQuantumInfo(image_info,image);
         if (quantum_info == (QuantumInfo *) NULL)
           ThrowWriterException(ResourceLimitError,"MemoryAllocationFailed");
@@ -2177,7 +2178,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
           }
           count=WriteBlob(image,extent,pixels);
           if (count != (ssize_t) extent) {
-            perror("WriteBlob failed!");
+            perror("WriteBlob failed");
             status = MagickFalse;
             break;
           }
@@ -2447,7 +2448,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
         register unsigned char
           *pixels;
 
-        (void) WriteBlobString(image,image->endian == LSBEndian ? "-1.0\n" :
+        CheckWriteBlobString(image,image->endian == LSBEndian ? "-1.0\n" :
           "1.0\n");
         image->depth=32;
         quantum_type=format == 'f' ? GrayQuantum : RGBQuantum;
@@ -2468,7 +2469,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
             break;
           extent=ExportQuantumPixels(image,(CacheView *) NULL,quantum_info,
             quantum_type,pixels,exception);
-          (void) WriteBlob(image,extent,pixels);
+          CheckWriteBlob(image,extent,pixels);
           if (image->previous == (Image *) NULL)
             {
               status=SetImageProgress(image,SaveImageTag,(MagickOffsetType) y,

--- a/coders/pnm.c
+++ b/coders/pnm.c
@@ -2073,7 +2073,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
           }
           count=WriteBlob(image,extent,pixels);
           if (count != (ssize_t) extent) {
-            perror("WriteBlob failed");
+            ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
             status = MagickFalse;
             break;
           }
@@ -2178,7 +2178,7 @@ static MagickBooleanType WritePNMImage(const ImageInfo *image_info,Image *image,
           }
           count=WriteBlob(image,extent,pixels);
           if (count != (ssize_t) extent) {
-            perror("WriteBlob failed");
+            ThrowFileException(exception,FileOpenError,"UnableToWriteFile", image->filename); \
             status = MagickFalse;
             break;
           }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

When using `convert`, coders/pnm fails to detect is the disk is full, and instead return exit code `0`. The `Write*` calls throughout the file do not check the actual amount of bytes that are written, leading to silent truncation errors. Additionally, the actual return line at the end of the function also unconditionally returns true, even if it has just detected that the processing went wrong.

Further description, including how to reproduce, can be found in the commit messages, but here's a quick summary:

```
    Evident by this sequence:

        $ ls -lsh /tmp/0009-1-small.png
        20M -rw-r--r-- 1 merlijn merlijn 20M May 25 23:59 /tmp/0009-1-small.png
        $ sudo mkdir /mnt/test
        $ sudo mount -t tmpfs none -o size=1G /mnt/test/
        $ df -h /mnt/test/
        Filesystem      Size  Used Avail Use% Mounted on
        none            5.0M     0  5.0M   0% /mnt/test
        $ convert /tmp/0009-1-small.png /mnt/test/0009.pnm
        $ echo $?
        0
        $ ls -lsh /mnt/test/0009.pnm
        5.0M -rw-r--r-- 1 merlijn merlijn 5.0M May 31 11:42 /mnt/test/0009.pnm

    Failure is evident with strace:

        write(5, "\373\372\367\373\371\367\372\370\365\372\370\364\372\370\364\372\371\366\372\367\363\363\355\346\351\344\327\370\363\356\372\370"..., 8192) = -1 ENOSPC (No space left on device)
```

Please let me know if you are OK with this assessment and approach and I will fix up the rest of `coders/pnm.c` in this pull request, and briefly scan some of the others coders as well.