### PR TITLE
Correct AVIF creation call

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -942,7 +942,7 @@ static MagickBooleanType WriteHEICImage(const ImageInfo *image_info,
 #if LIBHEIF_NUMERIC_VERSION > 0x01060200
     if (LocaleCompare(image_info->magick,"AVIF") == 0)
       error=heif_context_get_encoder_for_format(heif_context,
-        heif_compression_AVIF,&heif_encoder);
+        heif_compression_AV1,&heif_encoder);
 #endif
     status=IsHeifSuccess(&error,image,exception);
     if (status == MagickFalse)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Typo fix for libheif support #2103 
