### PR TITLE
Minor spelling fixes in MagickWand docs for Image Iterator methods.

### DIFF
--- a/MagickWand/magick-image.c
+++ b/MagickWand/magick-image.c
@@ -367,7 +367,7 @@ WandExport MagickBooleanType MagickAdaptiveThresholdImage(MagickWand *wand,
 %
 %  Use MagickSetLastIterator(), to append new images into an existing wand,
 %  current image will be set to last image so later adds with also be
-%  appened to end of wand.
+%  appended to end of wand.
 %
 %  Use MagickSetFirstIterator() to prepend new images into wand, any more
 %  images added will also be prepended before other images in the wand.
@@ -8815,7 +8815,7 @@ WandExport MagickBooleanType MagickRandomThresholdImage(MagickWand *wand,
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 %  MagickReadImage() reads an image or image sequence.  The images are inserted
-%  jjust before the current image pointer position.
+%  just before the current image pointer position.
 %
 %  Use MagickSetFirstIterator(), to insert new images before all the current
 %  images in the wand, MagickSetLastIterator() to append add to the end,

--- a/MagickWand/magick-wand.c
+++ b/MagickWand/magick-wand.c
@@ -850,7 +850,7 @@ WandExport void MagickResetIterator(MagickWand *wand)
 %  MagickReadImage() will be prepended before any image in the wand.
 %
 %  Also the current image has been set to the first image (if any) in the
-%  Magick Wand.  Using MagickNextImage() will then set teh current image
+%  Magick Wand.  Using MagickNextImage() will then set the current image
 %  to the second image in the list (if present).
 %
 %  This operation is similar to MagickResetIterator() but differs in how


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Quick & minor spelling fixes I ran across over the weekend. All around MagickWand's image iterator methods.