### PR TITLE
Ensure that data_index is within the bounds

### DIFF
--- a/coders/jp2.c
+++ b/coders/jp2.c
@@ -472,10 +472,21 @@ static Image *ReadJP2Image(const ImageInfo *image_info,ExceptionInfo *exception)
           pixel,
           scale;
 
+        ssize_t data_index = y/jp2_image->comps[i].dy*
+                             image->columns/jp2_image->comps[i].dx+
+                             x/jp2_image->comps[i].dx;
+        if(data_index < 0 ||
+           data_index >= (jp2_image->comps[i].h * jp2_image->comps[i].w))
+        {
+          opj_destroy_codec(jp2_codec);
+          opj_image_destroy(jp2_image);
+          ThrowReaderException(CoderError,
+                               "IrregularChannelGeometryNotSupported")
+        }
         scale=QuantumRange/(double) ((1UL << jp2_image->comps[i].prec)-1);
-        pixel=scale*(jp2_image->comps[i].data[y/jp2_image->comps[i].dy*
-          image->columns/jp2_image->comps[i].dx+x/jp2_image->comps[i].dx]+
-          (jp2_image->comps[i].sgnd ? 1UL << (jp2_image->comps[i].prec-1) : 0));
+        pixel=scale*(jp2_image->comps[i].data[data_index] +
+              (jp2_image->comps[i].sgnd ?
+               1UL << (jp2_image->comps[i].prec-1) : 0));
         switch (i)
         {
            case 0:


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This change ensure that the data index is within the bounds and discards the image if the access would be out-of-bounds.
