### PR TITLE
Ensure that float is valid in ClampToQuantum()

### DIFF
--- a/MagickCore/quantum.h
+++ b/MagickCore/quantum.h
@@ -87,7 +87,7 @@ static inline Quantum ClampToQuantum(const MagickRealType quantum)
 #if defined(MAGICKCORE_HDRI_SUPPORT)
   return((Quantum) quantum);
 #else
-  if (quantum <= 0.0f)
+  if ((IsNaN(quantum) != MagickFalse) || (quantum <= 0.0))
     return((Quantum) 0);
   if (quantum >= (MagickRealType) QuantumRange)
     return(QuantumRange);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Ensure that float is valid in ClampToQuantum(). This is already done in all other functions in this file and should be done in ClampToQuantum() as well.
