### PR TITLE
Ensure that memory is initialized

### DIFF
--- a/MagickCore/memory.c
+++ b/MagickCore/memory.c
@@ -338,12 +338,18 @@ MagickExport void *AcquireAlignedMemory(const size_t count,const size_t quantum)
 {
   size_t
     size;
+  void
+    *memory=NULL;
 
   if (HeapOverflowSanityCheckGetSize(count,quantum,&size) != MagickFalse)
     return(NULL);
   if (memory_methods.acquire_aligned_memory_handler != (AcquireAlignedMemoryHandler) NULL)
-    return(memory_methods.acquire_aligned_memory_handler(size,CACHE_LINE_SIZE));
-  return(AcquireAlignedMemory_Actual(size));
+    memory=memory_methods.acquire_aligned_memory_handler(size,CACHE_LINE_SIZE);
+  else
+    memory=AcquireAlignedMemory_Actual(size);
+  if(memory!=NULL)
+    memset(memory,0,size);
+  return(memory);
 }
 
 #if defined(MAGICKCORE_ANONYMOUS_MEMORY_SUPPORT)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Currently, the allocation method relies on the fact that all its callers correctly initialize the memory. This is an error-prone pattern and this patch will address this problem. 