### PR TITLE
Fix -deconstruct replacement

### DIFF
--- a/MagickWand/operation.c
+++ b/MagickWand/operation.c
@@ -4102,8 +4102,8 @@ WandPrivate MagickBooleanType CLIListOperatorImages(MagickCLI *cli_wand,
     {
       if (LocaleCompare("deconstruct",option+1) == 0)
         {
-          CLIWandWarnReplaced("-layer CompareAny");
-          (void) CLIListOperatorImages(cli_wand,"-layer","CompareAny",NULL);
+          CLIWandWarnReplaced("-layers CompareAny");
+          (void) CLIListOperatorImages(cli_wand,"-layers","CompareAny",NULL);
           break;
         }
       if (LocaleCompare("delete",option+1) == 0)


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Fix -deconstruct replacement
Change from -layer to -layers, as the former is unrecognized and the latter is consistent with www/porting.html#L575.
