### PR TITLE
Fix compiler errors for the cli_operators and cli_process examples

### DIFF
--- a/api_examples/cli_operators.c
+++ b/api_examples/cli_operators.c
@@ -34,14 +34,14 @@ int main(int argc, char **argv)
 
   cli_wand = AcquireMagickCLI((ImageInfo *) NULL,(ExceptionInfo *) NULL);
 
-  CLISettingOptionInfo    (cli_wand, "-size", "100x100");
-  CLISpecialOperator      (cli_wand, "-read", "xc:red");
-  CLISpecialOperator      (cli_wand, "(", NULL);
-  CLISpecialOperator      (cli_wand, "-read", "rose:");
-  CLISimpleOperatorImages (cli_wand, "-rotate", "-90", NULL);
-  CLISpecialOperator      (cli_wand, ")", NULL);
-  CLIListOperatorImages   (cli_wand, "+append", NULL, NULL);
-  CLIListOperatorImages   (cli_wand, "-write", "show:", NULL);
+  CLIOption (cli_wand, "-size", "100x100");
+  CLIOption (cli_wand, "-read", "xc:red");
+  CLIOption (cli_wand, "(", NULL);
+  CLIOption (cli_wand, "-read", "rose:");
+  CLIOption (cli_wand, "-rotate", "-90", NULL);
+  CLIOption (cli_wand, ")", NULL);
+  CLIOption (cli_wand, "+append", NULL, NULL);
+  CLIOption (cli_wand, "-write", "show:", NULL);
 
   /* Note use of 'True' to report all exceptions - including fatals */
   if ( CLICatchException(cli_wand,MagickTrue) != MagickFalse )

--- a/api_examples/cli_process.c
+++ b/api_examples/cli_process.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
   MagickCoreGenesis(argv[0],MagickFalse);
   cli_wand = AcquireMagickCLI((ImageInfo *) NULL,(ExceptionInfo *) NULL);
 
-  ProcessCommandOptions(cli_wand, arg_count, args, 0, MagickCommandOptionFlags);
+  ProcessCommandOptions(cli_wand, arg_count, args, 0);
 
   /* Note use of 'True' to report all exceptions - including non-fatals */
   if ( CLICatchException(cli_wand,MagickTrue) != MagickFalse )


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->

`cli_operators.c` could not compile because the original operators are either no longer public or present.
`cli_process.c` could not compile because the signature of `ProcessCommandOptions` has changed.
Fixed the above issues.