### PR TITLE
Fix error dispose with animated webp

### DIFF
--- a/coders/webp.c
+++ b/coders/webp.c
@@ -454,6 +454,8 @@ static int ReadAnimatedWEBPImage(const ImageInfo *image_info,Image *image,
       image->delay=iter.duration/10;
       if (iter.dispose_method == WEBP_MUX_DISPOSE_BACKGROUND)
         image->dispose=BackgroundDispose;
+      else
+        image->dispose=NoneDispose;
       image_count++;
     } while (WebPDemuxNextFrame(&iter));
     WebPDemuxReleaseIterator(&iter);


### PR DESCRIPTION
<!-- Thanks for contributing to ImageMagick! -->
issue with some animated webp dispose info.
[payload.webp.zip](https://github.com/ImageMagick/ImageMagick/files/4946891/f70eef3a703c99a70ec8184e59cda4b841e2918e.webp.zip)
File info:

```bash
> webpmux -info f70eef3a703c99a70ec8184e59cda4b841e2918e.webp
Canvas size: 140 x 140
Features present: animation transparency
Background color : 0xFFFFFFFF  Loop Count : 0
Number of frames: 24
No.: width height alpha x_offset y_offset duration   dispose blend image_size  compression
  1:   140   140   yes        0        0       83 background    no       5438       lossy
  2:   118   131   yes       12        8       83 background    no       5546       lossy
  3:   120   129   yes       12       10       83 background    no       5542       lossy
  4:   124   127   yes       10       12       83 background    no       5590       lossy
  5:   121   131   yes       12        8       83 background    no       5662       lossy
  6:   120   136   yes       12        4       83 background    no       5650       lossy
  7:   117   138   yes       14        2       83 background    no       5646       lossy
  8:   118   136   yes       14        4       83 background    no       5622       lossy
  9:   118   129   yes       14       10       83 background    no       5326       lossy
 10:   118   123   yes       14       16       83 background    no       5324       lossy
 11:   118   117   yes       14       22       83 background    no       5050       lossy
 12:   117   123   yes       14       16       83 background    no       5306       lossy
 13:   116   130   yes       14       10       83       none    no       5402       lossy
 14:    96   109   yes       34        6       83 background    no       4284       lossy
 15:    96   108   yes       34        8       83 background   yes       4320       lossy
 16:    97   109   yes       34       10       83 background   yes       4282       lossy
 17:    99   110   yes       34       12       83 background   yes       4370       lossy
 18:    98   112   yes       34       10       83       none    no       4330       lossy
 19:    98   112   yes       34       10       83       none    no       4354       lossy
 20:    97   114   yes       34        8       83 background    no       4382       lossy
 21:    98   114   yes       32        8       83       none   yes       4490       lossy
 22:    96   113   yes       34        8       83       none    no       4444       lossy
 23:    83   114   yes       46        6       83       none    no       3818       lossy
 24:    81   111   yes       46        8       83       none    no       3778       lossy
```
Using imagemagick to decode, and all frame dispose are background.
My golang test code:
```go
package main

import (
	"fmt"
	"gopkg.in/gographics/imagick.v3/imagick"
	"log"
)

func main() {
	imagick.Initialize()
	defer imagick.Terminate()

	path := "/tmp/f70eef3a703c99a70ec8184e59cda4b841e2918e.webp"

	mw := imagick.NewMagickWand()
	defer mw.Destroy()

	err := mw.ReadImage(path)
	if err != nil {
		log.Fatal(err)
	}

	frameCnt := 1
	mw.SetFirstIterator()
	fmt.Printf("origin width:%d height:%d\n", mw.GetImageWidth(), mw.GetImageHeight())
	fmt.Printf("frame:%d dispose:%d\n", frameCnt, mw.GetImageDispose())

	for mw.NextImage() {
		frameCnt ++
		fmt.Printf("frame:%d dispose:%d\n", frameCnt, mw.GetImageDispose())
	}

	err = mw.WriteImages("/tmp/output.webp", true)
	if err != nil {
		log.Fatal(err)
	}
}
```
output.webp is not expected.