### PR TITLE
PNG-Encoder: Fix missing exception inheritance.

### DIFF
--- a/coders/png.c
+++ b/coders/png.c
@@ -3430,6 +3430,7 @@ static Image *ReadOnePNGImage(MngInfo *mng_info,
   if (status == MagickFalse)
     {
       png_destroy_read_struct(&ping,&ping_info,&end_info);
+      InheritException(exception, &image->exception);
 #ifdef IMPNG_SETJMP_NOT_THREAD_SAFE
       UnlockSemaphoreInfo(ping_semaphore);
 #endif


### PR DESCRIPTION
a call to InheritException was missing, leading to cryptic error
messages in case of cache exhaustion. now the cache exhaustion
error gets propagated to the user properly

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
We need to use InheritException in the same fashion we do in JPG or TIFF, in order to have beautiful error messages at the user-side. 
