### PR TITLE
Font location has changed apparently.

### DIFF
--- a/configure
+++ b/configure
@@ -35622,7 +35622,7 @@ urw_base35_font_dir=''
 if test "${with_urw_base35_font_dir}" != 'default'; then
   urw_base35_font_dir="${with_urw_base35_font_dir}/"
 else
-  for font_dir in "${prefix}/share/urw-base35/fonts/" '/usr/share/fonts/urw-base35/'; do
+  for font_dir in "${prefix}/share/urw-base35/fonts/" '/usr/share/fonts/urw-base35/' '/usr/share/fonts/type1/urw-base35/'; do
     if test -f "${font_dir}StandardSymbolsPS.t1"; then
       urw_base35_font_dir="${font_dir}"
       break 1


### PR DESCRIPTION
### Prerequisites

- [✓] I have written a descriptive pull-request title
- [✓ ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [✓] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Not sure why, but the installation directory for urw-base35 fonts has changed, and the default configure was no longer finding it on ubuntu:18.04
