### PR TITLE
Fix spelling of "want" in documentation

### DIFF
--- a/www/advanced-unix-installation.html
+++ b/www/advanced-unix-installation.html
@@ -475,7 +475,7 @@ Options used to compile and link:
   <dd class="col-md-8">Remove all files from the system which are (or would be) installed by <code>sudo make install</code> using the current configuration.  Note that this target is imperfect for PerlMagick since Perl no longer supports an <var>uninstall</var> target.</dd>
 </dl>
 
-<p>In most cases you will simply wand to compile ImageMagick with this command:</p>
+<p>In most cases you will simply want to compile ImageMagick with this command:</p>
 
 <pre class="highlight"><code>make
 </code></pre>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Want has been misspelled in the documentation, this corrects that spelling error