### PR TITLE
Need to leave 6 trailing X characters for mkstemp()

### DIFF
--- a/MagickCore/resource.c
+++ b/MagickCore/resource.c
@@ -598,7 +598,7 @@ MagickExport int AcquireUniqueFileResource(char *path)
       Get temporary pathname.
     */
     (void) GetPathTemplate(path);
-    key=GetRandomKey(random_info,strlen(MagickPathTemplate));
+    key=GetRandomKey(random_info,strlen(MagickPathTemplate)-6);
     p=path+strlen(path)-strlen(MagickPathTemplate);
     datum=GetStringInfoDatum(key);
     for (j=0; j < (ssize_t) GetStringInfoLength(key); j++)


### PR DESCRIPTION
When calling `mkstemp()`, the last 6 characters of the path template should be left unchanged, as `XXXXXX`, and not replaced with random data.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Before 12c8912ce991075477d049db8768962ca72e7384, `MagickPathTemplate` was `XXXXXXXXXXXX` - 12 `X` characters - and the first 6 characters were replaced with random data via `GetRandomKey(..., 6);`

Following that commit, the template size has increased and now all of the Xs are being replaced with random data before mkstemp() is called. mkstemp _requires_ that the last 6 characters of the template are `XXXXXX` and passing a template which does not match this causes different behaviour on different operating systems.

In the case of OmniOS, where this problem was spotted, it caused test failures and crashing processes.

There is more cleanup work that could be done here for the non-mkstemp cases as there is no longer any point overwriting the first section of the template again with different random data, but this PR just fixes the new bug.

Problem spotted by @hadfl while upgrading ImageMagick in https://github.com/omniosorg/omnios-extra