### PR TITLE
Allow interlaced GIFs to be written

### DIFF
--- a/coders/gif.c
+++ b/coders/gif.c
@@ -1606,9 +1606,6 @@ static MagickBooleanType WriteGIFImage(const ImageInfo *image_info,Image *image,
   /*
     Write images to file.
   */
-  if ((write_info->adjoin != MagickFalse) &&
-      (GetNextImageInList(image) != (Image *) NULL))
-    write_info->interlace=NoInterlace;
   scene=0;
   one=1;
   imageListLength=GetImageListLength(image);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

Proposed fix for #2560. Removes the silent overwrite of the GIF interlace output option.

<!-- Thanks for contributing to ImageMagick! -->
