### PR TITLE
Fix compiler warning with gcc c++ 10.2

### DIFF
--- a/MagickCore/memory_.h
+++ b/MagickCore/memory_.h
@@ -95,7 +95,7 @@ static inline MagickBooleanType HeapOverflowSanityCheckGetSize(
       errno=ENOMEM;
       return(MagickTrue);
     }
-  assert(extent != (size_t *const) NULL);
+  assert(extent != NULL);
   *extent=length;
   return(MagickFalse);
 }


### PR DESCRIPTION
Fix warning -Wignored-qualifiers that is enabled by gcc with -Wextra:

    /usr/include/ImageMagick-6/magick/memory_.h: In function ‘MagickCore::MagickBooleanType MagickCore::HeapOverflowSanityCheckGetSize(size_t, size_t, size_t*)’:
    /usr/include/ImageMagick-6/magick/memory_.h:98:20: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
       98 |   assert(extent != (size_t *const) NULL);
          |                    ^

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The following fragment extracted from MagickCore/memory_.h emits a compiler warning when compiled with g++ -Wextra. Since this header is included in client code it interferes with projects that compile with e.g. -Wextra -Werror.

See the compiler warning on compiler explorer [here](https://godbolt.org/z/3z1n8x)

```
#include <errno.h>
#include <assert.h>
#include <stddef.h>

static inline int HeapOverflowSanityCheckGetSize(
  const size_t count,const size_t quantum,size_t *const extent)
{
  size_t length;

  if ((count == 0) || (quantum == 0))
    return 1;
  length=count*quantum;
  if (quantum != (length/count))
    {
      errno=ENOMEM;
      return 1;
    }
  assert(extent != (size_t *const) NULL);
  *extent=length;
  return 0;
}
```