### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/MagickCore/cache.c
+++ b/MagickCore/cache.c
@@ -621,7 +621,7 @@ static MagickBooleanType ClonePixelCacheOnDisk(
   quantum=(size_t) MagickMaxBufferExtent;
   if ((fstat(cache_info->file,&file_stats) == 0) && (file_stats.st_size > 0))
     {
-#if defined(MAGICKCORE_HAVE_SENDFILE) && !defined(__APPLE__)
+#if defined(MAGICKCORE_HAVE_SENDFILE) && !defined(__APPLE__) && !defined(__FreeBSD__)
       if (cache_info->length < 0x7ffff000)
         {
           count=sendfile(clone_info->file,cache_info->file,(off_t *) NULL,


### PR DESCRIPTION
FreeBSD implements sendfile(2) with 7 parameters. This function is not
compatible with the one used in MagickCore/cache.c. But it is detected
by the configuration script and MAGICKCORE_HAVE_SENDFILE is still
defined.