### PR TITLE
Fix animated webp encode

### DIFF
--- a/coders/webp.c
+++ b/coders/webp.c
@@ -870,18 +870,18 @@ static MagickBooleanType WriteAnimatedWEBPImage(const ImageInfo *image_info,
       ThrowWriterException(ResourceLimitError,"UnableToEncodeImageFile");
 
     WriteSingleWEBPImage(image_info, image, &picture, current, exception);
+    WebPAnimEncoderAdd(enc,&picture,(int) frame_timestamp,configure);
 
     effective_delta = image->delay*1000/image->ticks_per_second;
     if (effective_delta < 10)
       effective_delta = 100; /* Consistent with gif2webp */
     frame_timestamp+=effective_delta;
 
-    WebPAnimEncoderAdd(enc,&picture,(int) frame_timestamp,configure);
-
     image = GetNextImageInList(image);
     current->next=(PictureMemory *) calloc(sizeof(*head), 1);
     current = current->next;
   }
+  WebPAnimEncoderAdd(enc,NULL,(int) frame_timestamp,configure);
   webp_data.bytes=writer_info->mem;
   webp_data.size=writer_info->size;
   WebPAnimEncoderAssemble(enc, &webp_data);
@@ -1051,8 +1051,7 @@ static MagickBooleanType WriteWEBPImage(const ImageInfo *image_info,
 #if defined(MAGICKCORE_WEBPMUX_DELEGATE)
   if ((image_info->adjoin != MagickFalse) &&
       (GetPreviousImageInList(image) == (Image *) NULL) &&
-      (GetNextImageInList(image) != (Image *) NULL) &&
-      (image->iterations != 1))
+      (GetNextImageInList(image) != (Image *) NULL))
     WriteAnimatedWEBPImage(image_info,image,&configure,&writer_info,exception);
 #endif
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

Hi, I'm use ImageMagick created a online image process service that is a powerful library, but i found some issues when i use ImageMagick convert gif to animated webp.

### Incorrect frame time

For test this issue, i create a test gif that has 3 frame.
* frame 1 delay 500ms
* frame 2 delay 2s
* frame 3 delay 500ms 
![test-gif](https://user-images.githubusercontent.com/4957677/95574417-7e2d4900-0a5f-11eb-9396-00b472a7dbaf.gif)

After use convert tool to convert to webp, image frame time became strange.
```
convert test-gif.gif test-webp.webp
```
![test-webp.webp](https://storage.googleapis.com/gcp-asia-east2-storage-test-01.tomwei7.com/test-webp.webp)

I think that because `WebPAnimEncoderAdd ` parameter `timestamp_ms ` is a frame start point not end. 

[webpanimencoderadd](https://developers.google.com/speed/webp/docs/container-api#webpanimencoderadd)
> timestamp_ms -- (in) timestamp of this frame in milliseconds. Duration of a frame would be calculated as "timestamp of next frame - timestamp of this frame". Hence, timestamps should be in non-decreasing order.

And we should call `WebPAnimEncoderAdd` use NULL frame at last.

> The last call to WebPAnimEncoderAdd should be with frame = NULL, which indicates that no more frames are to be added. This call is also used to determine the duration of the last frame.

### Lost animation when gif iterations not set.

For test this issue, i create a test gif that not iterations set.

![test-gif-loop-1](https://user-images.githubusercontent.com/4957677/95575996-47a4fd80-0a62-11eb-998e-844b80939b83.gif)

After convert to webp that lost animation.
![test-gif-loop-1-webp](https://storage.googleapis.com/gcp-asia-east2-storage-test-01.tomwei7.com/test-gif-loop-1.webp)

I simple remove `image->iterations != 1` from `if` condition  because we already checked that image has multi-frame so that's enough.