### PR TITLE
recommend new rust binding lib

### DIFF
--- a/www/api.html
+++ b/www/api.html
@@ -185,7 +185,7 @@
 
   <dt><a id="rust"></a>Rust</dt>
 
-<dd><a href="https://github.com/influenza/wand-of-rust">RustWand</a> is a MagickWand bindings for the Rust language.</dd>
+<dd><a href="https://github.com/nlfiedler/magick-rust">magick-rust</a> is a MagickWand bindings for the Rust language.</dd>
 
 <dt><a id="tcl"></a>Tcl/Tk</dt>
 

--- a/www/develop.html
+++ b/www/develop.html
@@ -201,7 +201,7 @@
 
   <dt class="col-md-4"><a class="anchor" id="rust"></a>Rust</dt>
 
-<dd class="col-md-8"><a href="https://github.com/influenza/wand-of-rust">RustWand</a> is a MagickWand bindings for the Rust language.</dd>
+<dd class="col-md-8"><a href="https://github.com/nlfiedler/magick-rust"> magick-rust </a> is a MagickWand bindings for the Rust language.</dd>
 
 <dt class="col-md-4"><a class="anchor" id="tcl"></a>Tcl/Tk</dt>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
[wand-of-rust](https://github.com/influenza/wand-of-rust/commits/master) has been inactive for 6 years, and I'm using [magick-rust](https://github.com/nlfiedler/magick-rust) in my product, I think we should recommend this on ImageMagick website.

<!-- Thanks for contributing to ImageMagick! -->
