### PR TITLE
Fix AVIF support reporting

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -633,8 +633,10 @@ ModuleExport size_t RegisterHEICImage(void)
 #if LIBHEIF_NUMERIC_VERSION > 0x01060200
   entry=AcquireMagickInfo("HEIC","AVIF","AV1 Image File Format");
 #if defined(MAGICKCORE_HEIC_DELEGATE)
-  entry->decoder=(DecodeImageHandler *) ReadHEICImage;
-  entry->encoder=(EncodeImageHandler *) WriteHEICImage;
+  if (heif_have_decoder_for_format(heif_compression_AV1))
+    entry->decoder=(DecodeImageHandler *) ReadHEICImage;
+  if (heif_have_encoder_for_format(heif_compression_AV1))
+    entry->encoder=(EncodeImageHandler *) WriteHEICImage;
 #endif
   entry->magick=(IsImageFormatHandler *) IsHEIC;
   entry->mime_type=ConstantString("image/x-heic");


### PR DESCRIPTION
# Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

As in #1432 and #2551 libheif may not be built with AVIF support but `magick -list format` always reports that reading and writing is supported. This pull request will actually check that libheif supports AVIF.

Previously running `magick input.jpeg output.avif` did give a somewhat nice "Unsupported file-type" message but this pull request will silently output a JPEG. This seems to be consistent with behavior of unknown file extensions but hopefully doesn't cause additional confusion.