### PR TITLE
Remove quotes from around MAGICKCORE_QUANTUM_DEPTH_OBSOLETE_IN_H.

### DIFF
--- a/configure
+++ b/configure
@@ -1128,6 +1128,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -1349,6 +1350,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1601,6 +1603,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1738,7 +1749,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1891,6 +1902,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -4575,7 +4587,7 @@ MAGICK_PATCHLEVEL_VERSION=35
 
 MAGICK_VERSION=7.0.10-35
 
-MAGICK_GIT_REVISION=17712:2b4b9a757:20201014
+MAGICK_GIT_REVISION=17730:3ea0f81e9:20201021
 
 
 # Substitute library versioning
@@ -22268,7 +22280,7 @@ esac
 QUANTUM_DEPTH="$with_quantum_depth"
 
 cat >>confdefs.h <<_ACEOF
-#define QUANTUM_DEPTH_OBSOLETE_IN_H "$QUANTUM_DEPTH"
+#define QUANTUM_DEPTH_OBSOLETE_IN_H $QUANTUM_DEPTH
 _ACEOF
 
 MAGICK_PCFLAGS="$MAGICK_PCFLAGS -DMAGICKCORE_QUANTUM_DEPTH=$QUANTUM_DEPTH"

--- a/configure.ac
+++ b/configure.ac
@@ -831,7 +831,7 @@ case "${with_quantum_depth}" in
     * ) AC_MSG_ERROR("Pixel quantum depth must have value of 8, 16, 32, or 64") ;;
 esac
 QUANTUM_DEPTH="$with_quantum_depth"
-AC_DEFINE_UNQUOTED([QUANTUM_DEPTH_OBSOLETE_IN_H],["$QUANTUM_DEPTH"],[Number of bits in a pixel Quantum (8/16/32/64)])
+AC_DEFINE_UNQUOTED([QUANTUM_DEPTH_OBSOLETE_IN_H],[$QUANTUM_DEPTH],[Number of bits in a pixel Quantum (8/16/32/64)])
 AC_SUBST([QUANTUM_DEPTH])dnl
 MAGICK_PCFLAGS="$MAGICK_PCFLAGS -DMAGICKCORE_QUANTUM_DEPTH=$QUANTUM_DEPTH"
 CFLAGS="$CFLAGS -DMAGICKCORE_QUANTUM_DEPTH=$QUANTUM_DEPTH"


### PR DESCRIPTION
### Prerequisites

- [ x] I have written a descriptive pull-request title
- [ x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
When compiling transcode in Gentoo, having MAGICKCORE_QUANTUM_DEPTH_OBSOLETE_IN_H use a quoted value cause a compile error.  This can be reproduced by just including the MagickWand/MagickWand.h include file.

From looking at the commit introducing the issue, it appears I should run autoconf to regenerate configure.  If this is unwanted in the pull request please let me know and I'll remove that.
