### PR TITLE
svg: do not pass background to inkscape with opacity=0

### DIFF
--- a/coders/svg.c
+++ b/coders/svg.c
@@ -310,7 +310,7 @@ static Image *RenderSVGImage(const ImageInfo *image_info,Image *image,
   (void) FormatLocaleString(density,MagickPathExtent,"%.20g",
     ceil(sqrt(image->resolution.x*image->resolution.y)-0.5));
   (void) FormatLocaleString(background,MagickPathExtent,
-    "rgb(%.20g%%,%.20g%%,%.20g%%)",
+    image->background_color.alpha ? "rgb(%.20g%%,%.20g%%,%.20g%%)" : "",
     100.0*QuantumScale*image->background_color.red,
     100.0*QuantumScale*image->background_color.green,
     100.0*QuantumScale*image->background_color.blue);


### PR DESCRIPTION
If 0 opacity is passed to Inkscape at the same time as a background
color, the background color wins, and the opacity is actually set to
100%. Fix this by passing the empty string as a background color for
opacity=0.