### PR TITLE
RFC: stabilize ABI on s390x by tieing MagickFloatType to double

### DIFF
--- a/MagickCore/magick-type.h
+++ b/MagickCore/magick-type.h
@@ -40,6 +40,7 @@ extern "C" {
 #  define MagickULLConstant(c)  ((MagickSizeType) (c ## ULL))
 #endif
 
+#if !defined(__s390__)
 #if MAGICKCORE_SIZEOF_FLOAT_T == 0
 typedef float MagickFloatType;
 #elif (MAGICKCORE_SIZEOF_FLOAT_T == MAGICKCORE_SIZEOF_FLOAT)
@@ -50,6 +51,9 @@ typedef double MagickFloatType;
 typedef double MagickFloatType;
 #else
 #error Your MagickFloatType type is neither a float, nor a double, nor a long double
+#endif
+#else
+typedef double MagickFloatType;
 #endif
 #if MAGICKCORE_SIZEOF_DOUBLE_T == 0
 typedef double MagickDoubleType;


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

tl;dr: On s390x, `float_t` is defined as `double` for no good reason, yet with unexpected and unnecessary impact on performance in some scenarios. For cleaning that up, `float_t` will have to become `float` on s390x. That would break the ABI of ImageMagick for HDRI=1 on s390x for existing binaries. To avoid that breakage, I propose to set `MagickFloatType` to always be double on s390x so that the API/ABI for HDRI=1 remains as it is today, independent of a change in `float_t`.

What do you think about that approach? Any alternatives I may have missed?

### Background

`float_t` is meant to represent the range and precision that `float` expressions are evaluated in internally. While the s390x architecture very well supports operations on single-precision `float` and gcc by default uses these single-precision operations for that purpose, on s390x `float_t` has historically been defined as `double`. The reason is that the port of glibc for s390x picked up the then-default of setting `float_t` to double.

That combination of gcc's default behavior and `float_t` being `double` contradicts the C standard. To rectify that, gcc _mimics_ behavior according to the standard by evaluating in `double` when called in standard-compliant mode (e.g., `std=c99`): it explicitly converts the values of `float` variables to `double` in registers, performs calculations in double precision, and then rounds and truncates them back to `float` -- at the cost of overhead for the conversions.

To avoid that overhead and be compliant with the C standard (and common sense), we are discussing plans to change `float_t` to `float` and s390 to match gcc's default behavior.

### Impact on ImageMagick

ImageMagick captures the `sizeof(float_t)` at compile-time of the library in `magick-baseconfig.h`. Headers then define `MagickFloatType` to match. For 8-bit and 16-bit depths and HDRI=1, that `MagickFloatType` is used as the type for pixels's color channels (i.e., `Quantum`).

Changes to `float_t` thus would result in a different ABI. Once ImageMagick is rebuilt with HDRI=1 and an updated gcc/glibc, Quantum would then become 32-bit float. Existing binaries and libraries would expect 64-bit double and thus cease to work with newly built version of the library.

To avoid anyone having a bad day from that incompatibility, we could make the ABI on s390x independent of `float_t` and turn MagickFloatType to always remain `double`.

<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
