### PR TITLE
Correct documentation for return value of MagickImportImagePixels

### DIFF
--- a/MagickWand/magick-image.c
+++ b/MagickWand/magick-image.c
@@ -6584,8 +6584,8 @@ WandExport MagickBooleanType MagickImplodeImage(MagickWand *wand,
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 %  MagickImportImagePixels() accepts pixel datand stores it in the image at the
-%  location you specify.  The method returns MagickFalse on success otherwise
-%  MagickTrue if an error is encountered.  The pixel data can be either char,
+%  location you specify.  The method returns MagickTrue on success otherwise
+%  MagickFalse if an error is encountered.  The pixel data can be either char,
 %  short int, int, ssize_t, float, or double in the order specified by map.
 %
 %  Suppose your want to upload the first scanline of a 640x480 image from


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

MagickImportImagePixels returns true on success and false on failure, just like other MagickWand functions. This change corrects the documentation to be in line with the implementation.

### Question

Do I also have to regenerate the Doxygen or will CI take care of that?
