### PR TITLE
-pointsize also affects fonts

### DIFF
--- a/www/command-line-options.html
+++ b/www/command-line-options.html
@@ -3047,9 +3047,12 @@ rendering text. If the family can be found it is used; if not, a default font
 (e.g., "Arial") or a family known to be similar is substituted (e.g.,
 "Courier" might be used if "System" is requested but not found). Note, the family can be a CSS-style font list.</p>
 
-<p>For other settings that affect fonts, see the options <a
-href="command-line-options.html#font">-font</a>, <a href="command-line-options.html#stretch">-stretch</a>, <a
-href="command-line-options.html#style">-style</a>, and <a href="command-line-options.html#weight">-weight</a>.  </p>
+<p>For other settings that affect fonts, see the options
+<a href="command-line-options.html#font">-font</a>, 
+<a href="command-line-options.html#pointsize">-pointsize</a>,
+<a href="command-line-options.html#stretch">-stretch</a>,
+<a href="command-line-options.html#style">-style</a>,
+and <a href="command-line-options.html#weight">-weight</a>.  </p>
 
 <div style="margin: auto;">
   <h3><a class="anchor" id="features"></a>-features <var>distance</var></h3>


### PR DESCRIPTION
In fact this
```
For other settings that affect fonts, see the options
```
line appears about five times on the page... and should really be a template...
Indeed the options mentioned seem to vary,
Also I am using GitHub.com to edit this large file, so it was only easy to fix the first one...

P.S., **after** submitting this pull request I noticed within `<!-- -->`
```
If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website
```
Well it is too late for that.