### PR TITLE
Allow zero XML elements.

### DIFF
--- a/config/coder.xml
+++ b/config/coder.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE codermap [
-<!ELEMENT codermap (coder)+>
+<!ELEMENT codermap (coder)*>
   <!ATTLIST codermap xmlns CDATA #FIXED ''>
   <!ELEMENT coder EMPTY>
   <!ATTLIST coder xmlns CDATA #FIXED '' magick NMTOKEN #REQUIRED

--- a/config/colors.xml
+++ b/config/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE colormap [
-<!ELEMENT colormap (color)+>
+<!ELEMENT colormap (color)*>
 <!ELEMENT color (#PCDATA)>
 <!ATTLIST color name CDATA "0">
 <!ATTLIST color color CDATA "rgb(0,0,0)">

--- a/config/policy.xml
+++ b/config/policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE policymap [
-  <!ELEMENT policymap (policy)+>
+  <!ELEMENT policymap (policy)*>
   <!ATTLIST policymap xmlns CDATA #FIXED ''>
   <!ELEMENT policy EMPTY>
   <!ATTLIST policy xmlns CDATA #FIXED '' domain NMTOKEN #REQUIRED


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The Document Type Declarations (DTDs) embedded in some XML configuration files make them invalid with their initial contents. The `+` means "one or more elements required", while all the elements are commented out. The change is to '*' which means "zero or more elements".