### PR TITLE
[OSS-Fuzz] Build fuzzers faster and resolve compiler warnings

### DIFF
--- a/Magick++/fuzz/build_fuzzers.sh
+++ b/Magick++/fuzz/build_fuzzers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-MAGICK_COMPILER_FLAGS="$MAGICK_COMPILER_FLAGS -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16"
+MAGICK_COMPILER_FLAGS="$MAGICK_COMPILER_FLAGS -fuse-ld=lld -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16"
 
 $MAGICK_COMPILER $MAGICK_COMPILER_FLAGS -std=c++11 -I$MAGICK_INCLUDE "$MAGICK_SRC/encoder_list.cc" \
     -o "$MAGICK_SRC/encoder_list" $MAGICK_LIBS_NO_FUZZ
@@ -40,7 +40,7 @@ for item in $("$MAGICK_SRC/encoder_list"); do
          $encoder_flags $MAGICK_LIBS
 
     echo -e "[libfuzzer]\nclose_fd_mask=3" > "$MAGICK_OUTPUT/encoder_${encoder,,}_fuzzer.options"
-    
+
     if [ -f "$MAGICK_SRC/dictionaries/${encoder,,}.dict" ]; then
         cp "$MAGICK_SRC/dictionaries/${encoder,,}.dict" "$MAGICK_OUTPUT/ping_${encoder,,}_fuzzer.dict"
         cp "$MAGICK_SRC/dictionaries/${encoder,,}.dict" "$MAGICK_OUTPUT/encoder_${encoder,,}_fuzzer.dict"

--- a/Magick++/fuzz/encoder_fuzzer.cc
+++ b/Magick++/fuzz/encoder_fuzzer.cc
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <string.h>
 
 #include <Magick++/Blob.h>
 #include <Magick++/Image.h>
@@ -19,14 +20,14 @@
 
 static ssize_t EncoderInitializer(const uint8_t *Data, const size_t Size, Magick::Image &image)
 {
-  if (FUZZ_ENCODER_INITIALIZER == "interlace") {
+  if (strcmp(FUZZ_ENCODER_INITIALIZER, "interlace") == 0) {
     Magick::InterlaceType interlace = (Magick::InterlaceType) *reinterpret_cast<const char *>(Data);
     if (interlace > Magick::PNGInterlace)
       return -1;
     image.interlaceType(interlace);
     return 1;
   }
-  if (FUZZ_ENCODER_INITIALIZER == "png") {
+  if (strcmp(FUZZ_ENCODER_INITIALIZER, "png") == 0) {
     image.defineValue("png", "ignore-crc", "1");
   }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
This updates the fuzzers to use `lld` in OSS-Fuzz for much faster linking speed and resolves a compiler warning related to an improper string comparison in C.