### PR TITLE
Fix include/strcmp() for cpp fuzzers

### DIFF
--- a/Magick++/fuzz/encoder_fuzzer.cc
+++ b/Magick++/fuzz/encoder_fuzzer.cc
@@ -1,5 +1,5 @@
 #include <cstdint>
-#include <string.h>
+#include <cstring>
 
 #include <Magick++/Blob.h>
 #include <Magick++/Image.h>

--- a/Magick++/fuzz/ping_fuzzer.cc
+++ b/Magick++/fuzz/ping_fuzzer.cc
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <cstring>
 
 #include <Magick++/Blob.h>
 #include <Magick++/Image.h>
@@ -19,7 +20,7 @@
 
 static ssize_t EncoderInitializer(const uint8_t *Data, const size_t Size, Magick::Image &image)
 {
-  if (FUZZ_ENCODER_INITIALIZER == "interlace") {
+  if (strcmp(FUZZ_ENCODER_INITIALIZER, "interlace") == 0) {
     Magick::InterlaceType interlace = (Magick::InterlaceType) *reinterpret_cast<const char *>(Data);
     if (interlace > Magick::PNGInterlace)
       return -1;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Fix include/strcmp() for cpp fuzzers
