### PR TITLE
fix division by zero in WriteJP2Image() in coders/jp2.c

### DIFF
--- a/coders/jp2.c
+++ b/coders/jp2.c
@@ -1056,8 +1056,8 @@ static MagickBooleanType WriteJP2Image(const ImageInfo *image_info,Image *image,
 
         scale=(double) (((size_t) 1UL << jp2_image->comps[i].prec)-1)/
           QuantumRange;
-        q=jp2_image->comps[i].data+(y/jp2_image->comps[i].dy*
-          image->columns/jp2_image->comps[i].dx+x/jp2_image->comps[i].dx);
+        q=jp2_image->comps[i].data+(y*PerceptibleReciprocal(jp2_image->comps[i].dy)*
+          image->columns*PerceptibleReciprocal(jp2_image->comps[i].dx)+x*PerceptibleReciprocal(jp2_image->comps[i].dx));
         switch (i)
         {
           case 0:


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
