### PR TITLE
GIF encoder: Increased maximum size of a LZW image data block from 254 bytes to 255 bytes

### DIFF
--- a/coders/gif.c
+++ b/coders/gif.c
@@ -554,9 +554,10 @@ static MagickBooleanType EncodeImage(const ImageInfo *image_info,Image *image,
   { \
     /*  \
       Add a character to current packet. \
+      Maximum packet size is 255.
     */ \
     packet[length++]=(unsigned char) (datum & 0xff); \
-    if (length >= 254) \
+    if (length == 255) \
       { \
         (void) WriteBlobByte(image,(unsigned char) length); \
         (void) WriteBlob(image,length,packet); \
@@ -786,9 +787,10 @@ static MagickBooleanType EncodeImage(const ImageInfo *image_info,Image *image,
     {
       /*
         Add a character to current packet.
+        Maximum packet size is 255.
       */
       packet[length++]=(unsigned char) (datum & 0xff);
-      if (length >= 254)
+      if (length == 255)
         {
           (void) WriteBlobByte(image,(unsigned char) length);
           (void) WriteBlob(image,length,packet);


### PR DESCRIPTION
### Prerequisites

- [YES] I have written a descriptive pull-request title
- [YES ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [YES ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The maximum size of an encoded LZW image data block seems currently to be fixed to 254 bytes.
However according to the GIF spec, the maximum block size is 255.
Here an hex excerpt out of an GIF image, encoded by ImageMagick:
`2c 00 00 00 00 58 02 10 03 00 08  fe  00 eb 09 ...`
This is the beginning of a GIF frame.
The last three bytes are already part of the LZW data, 
the byte before that (0xFE = 254) indicates the number of encoded LZW bytes to follow.

Increasing the maximum block size might slightly reduce the file-size under certain conditions.

### References
[https://www.w3.org/Graphics/GIF/spec-gif89a.txt](https://www.w3.org/Graphics/GIF/spec-gif89a.txt)

