### PR TITLE
Remove comment about a non-existing parameter

### DIFF
--- a/MagickCore/coder.c
+++ b/MagickCore/coder.c
@@ -112,12 +112,9 @@ static MagickBooleanType
 %
 %  The format of the AcquireCoderCache coder is:
 %
-%      SplayTreeInfo *AcquireCoderCache(const char *filename,
-%        ExceptionInfo *exception)
+%      SplayTreeInfo *AcquireCoderCache(ExceptionInfo *exception)
 %
 %  A description of each parameter follows:
-%
-%    o filename: the font file name.
 %
 %    o exception: return any errors or warnings in this structure.
 %


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

`AcquireCoderCache` is documented to accept `filename`, but it doesn't.

<!-- Thanks for contributing to ImageMagick! -->
