### PR TITLE
Added jxl_threads lib to JPEG XL configuration, so make won't fail wi…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2419,7 +2419,7 @@ if test "$with_jxl" != 'no'; then
           AC_MSG_RESULT([no -- some components failed test])
           have_jxl='no (failed tests)'
       else
-          JXL_LIBS='-ljxl'
+          JXL_LIBS='-ljxl -ljxl_threads'
           LIBS="$JXL_LIBS $LIBS"
           AC_DEFINE([JXL_DELEGATE],[1],[Define if you have jpeg-xl library])
           AC_MSG_RESULT([yes])


### PR DESCRIPTION
…th "undefined reference to `JxlThreadParallelRunner'"

### Prerequisites

- [*] I have written a descriptive pull-request title
- [*] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [*] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

When I was trying to build the latest IM with jpeg-xl delegate v 0.3.7 then I got an error during make:

```
/usr/bin/ld: MagickCore/.libs/libMagickCore-7.Q16HDRI.so: undefined reference to `JxlThreadParallelRunner'
/usr/bin/ld: MagickCore/.libs/libMagickCore-7.Q16HDRI.so: undefined reference to `JxlThreadParallelRunnerDestroy'
/usr/bin/ld: MagickCore/.libs/libMagickCore-7.Q16HDRI.so: undefined reference to `JxlThreadParallelRunnerCreate'
```