### PR TITLE
Define MAGICKCORE_HAVE_SYSCONF on Windows

### DIFF
--- a/MagickCore/nt-base.h
+++ b/MagickCore/nt-base.h
@@ -247,6 +247,7 @@ extern "C" {
 #endif
 #if !defined(sysconf)
 #  define sysconf(name)  NTSystemConfiguration(name)
+#  define MAGICKCORE_HAVE_SYSCONF 1
 #endif
 #if defined(MAGICKCORE_WINDOWS_SUPPORT) && \
   !(defined(_MSC_VER) && (_MSC_VER < 1400)) && \


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Fixes https://github.com/ImageMagick/ImageMagick/issues/3684