### PR TITLE
Update contributing guideline reference to ImageMagick6

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,8 +10,7 @@
 
 - Open a new pull request with the patch and follow the instructions from the pull request template.
 - Before submitting, please ensure that your code matches the existing coding patterns and practise as demonstrated in the repository.
-- Once the pull request has been accepted for the master (IM7) branch, please submit another patch for the
-  [ImageMagick-6](https://github.com/ImageMagick/ImageMagick/tree/ImageMagick-6) branch when applicable.
+- Once the pull request has been accepted, please submit another patch to the [ImageMagick6](https://github.com/ImageMagick/ImageMagick6) legacy repository when applicable.
 
 #### **Do you intend to add a new feature?**
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Instead of asking to make a patch to the ImageMagick-6 branch (that doesn't exist in this repo), we ask the contributor to submit a patch to the legacy [ImageMagick6](https://github.com/ImageMagick/ImageMagick6) repo.

I got a bit confused by this part of the contribution guidelines when preparing for making [a small typo PR](https://github.com/ImageMagick/ImageMagick/pull/4091), and thought I could try to improve that as well.
