### PR TITLE
Update comment about available ImageTypes

### DIFF
--- a/Magick++/lib/Magick++/Image.h
+++ b/Magick++/lib/Magick++/Image.h
@@ -516,9 +516,11 @@ namespace Magick
 
     // Image representation type (also see type operation)
     //   Available types:
-    //    Bilevel        Grayscale       GrayscaleMatte
-    //    Palette        PaletteMatte    TrueColor
-    //    TrueColorMatte ColorSeparation ColorSeparationMatte
+    //    Bilevel         PaletteBilevelAlpha
+    //    Grayscale       GrayscaleAlpha
+    //    Palette         PaletteAlpha
+    //    TrueColor       TrueColorAlpha
+    //    ColorSeparation ColorSeparationAlpha
     void type(const ImageType type_);
     ImageType type(void) const;
 


### PR DESCRIPTION
Some types listed in the comment above the type set function did not match the names in the enum. I left OptimizeType and UndefinedType out from the list, hope that's correct.