### PR TITLE
DDS: fixed a bug that produced artefacts in images

### DIFF
--- a/coders/dds.c
+++ b/coders/dds.c
@@ -2004,12 +2004,12 @@ static void ReadEndpoints(BC7Colors *endpoints,const unsigned char *block,
     endpoints->r[i] <<= (8 - color_bits);
     endpoints->g[i] <<= (8 - color_bits);
     endpoints->b[i] <<= (8 - color_bits);
-    endpoints->a[i] <<= (8 - color_bits);
+    endpoints->a[i] <<= (8 - alpha_bits);
 
     endpoints->r[i]=endpoints->r[i] | (endpoints->r[i] >> color_bits);
     endpoints->g[i]=endpoints->g[i] | (endpoints->g[i] >> color_bits);
     endpoints->b[i]=endpoints->b[i] | (endpoints->b[i] >> color_bits);
-    endpoints->a[i]=endpoints->a[i] | (endpoints->a[i] >> color_bits);
+    endpoints->a[i]=endpoints->a[i] | (endpoints->a[i] >> alpha_bits);
   }
 
   if (has_alpha == MagickFalse)


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Fixed a bug that produced artefacts in dds images. The bug was introduced when variable alpha_bits was mistakely renamed to color_bits in commit ImageMagick/ImageMagick@6d56ce1.

<!-- Thanks for contributing to ImageMagick! -->
