### PR TITLE
Removed a seamingly useless write in color.cpp

### DIFF
--- a/Magick++/lib/Color.cpp
+++ b/Magick++/lib/Color.cpp
@@ -261,8 +261,6 @@ Magick::Color::operator std::string() const
 
   pixel.colorspace=(_pixelType == RGBPixel || _pixelType == RGBAPixel) ?
     sRGBColorspace : CMYKColorspace;
-  pixel.alpha_trait=(_pixelType == RGBAPixel || _pixelType == CMYKAPixel) ?
-    BlendPixelTrait : UndefinedPixelTrait;
   pixel.depth=MAGICKCORE_QUANTUM_DEPTH;
   pixel.alpha=_pixel->alpha;
   pixel.alpha_trait=_pixel->alpha_trait;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The write in line 264 seems to be overwritten by line 268 so i removed it.
