### PR TITLE
Update libjxl to use a .pc

### DIFF
--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -622,7 +622,7 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
     }
   memset(&format,0,sizeof(format));
   JXLSetFormat(image,&format);
-  memset(&basic_info,0,sizeof(basic_info));
+  JxlEncoderInitBasicInfo(&basic_info);
   basic_info.xsize=(uint32_t) image->columns;
   basic_info.ysize=(uint32_t) image->rows;
   basic_info.bits_per_sample=8;

--- a/configure
+++ b/configure
@@ -816,9 +816,10 @@ LCMS_DELEGATE_FALSE
 LCMS_DELEGATE_TRUE
 LCMS2_LIBS
 LCMS2_CFLAGS
-JXL_LIBS
 JXL_DELEGATE_FALSE
 JXL_DELEGATE_TRUE
+JXL_LIBS
+JXL_CFLAGS
 JPEG_LIBS
 JPEG_DELEGATE_FALSE
 JPEG_DELEGATE_TRUE
@@ -1280,6 +1281,8 @@ GVC_CFLAGS
 GVC_LIBS
 HEIF_CFLAGS
 HEIF_LIBS
+JXL_CFLAGS
+JXL_LIBS
 LCMS2_CFLAGS
 LCMS2_LIBS
 LIBOPENJP2_CFLAGS
@@ -2122,6 +2125,8 @@ Some influential environment variables:
   GVC_LIBS    linker flags for GVC, overriding pkg-config
   HEIF_CFLAGS C compiler flags for HEIF, overriding pkg-config
   HEIF_LIBS   linker flags for HEIF, overriding pkg-config
+  JXL_CFLAGS  C compiler flags for JXL, overriding pkg-config
+  JXL_LIBS    linker flags for JXL, overriding pkg-config
   LCMS2_CFLAGS
               C compiler flags for LCMS2, overriding pkg-config
   LCMS2_LIBS  linker flags for LCMS2, overriding pkg-config
@@ -30700,153 +30705,95 @@ else
 fi
 
 
-if test "$with_jxl" != 'yes'; then
-    DISTCHECK_CONFIG_FLAGS="${DISTCHECK_CONFIG_FLAGS} --with-jxl=$with_jxl "
-fi
-if test "$enable_static" = 'yes'; then
-    if test "$with_utilities" = 'yes'; then
-        with_jxl='no'
-    fi
-fi
-
 # Check for the JPEG-XL library.
 have_jxl='no'
+JXL_CFLAGS=''
 JXL_LIBS=''
+JXL_PKG=''
 if test "$with_jxl" != 'no'; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: -------------------------------------------------------------" >&5
 $as_echo "-------------------------------------------------------------" >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for jpeg-xl" >&5
-$as_echo_n "checking for jpeg-xl... " >&6; }
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libjxl >= 0.6 libjxl_threads" >&5
+$as_echo_n "checking for libjxl >= 0.6 libjxl_threads... " >&6; }
+
+if test -n "$JXL_CFLAGS"; then
+    pkg_cv_JXL_CFLAGS="$JXL_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libjxl >= 0.6 libjxl_threads\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libjxl >= 0.6 libjxl_threads") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_JXL_CFLAGS=`$PKG_CONFIG --cflags "libjxl >= 0.6 libjxl_threads" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$JXL_LIBS"; then
+    pkg_cv_JXL_LIBS="$JXL_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libjxl >= 0.6 libjxl_threads\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libjxl >= 0.6 libjxl_threads") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_JXL_LIBS=`$PKG_CONFIG --libs "libjxl >= 0.6 libjxl_threads" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        JXL_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libjxl >= 0.6 libjxl_threads" 2>&1`
+        else
+	        JXL_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libjxl >= 0.6 libjxl_threads" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$JXL_PKG_ERRORS" >&5
+
+	have_jxl=no
+elif test $pkg_failed = untried; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+	have_jxl=no
+else
+	JXL_CFLAGS=$pkg_cv_JXL_CFLAGS
+	JXL_LIBS=$pkg_cv_JXL_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	have_jxl=yes
+fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: " >&5
 $as_echo "" >&6; }
-  failed=0
-  passed=0
-  ac_fn_c_check_header_mongrel "$LINENO" "jxl/decode.h" "ac_cv_header_jxl_decode_h" "$ac_includes_default"
-if test "x$ac_cv_header_jxl_decode_h" = xyes; then :
-  passed=`expr $passed + 1`
-else
-  failed=`expr $failed + 1`
 fi
 
-
-  ac_fn_c_check_header_mongrel "$LINENO" "jxl/encode.h" "ac_cv_header_jxl_encode_h" "$ac_includes_default"
-if test "x$ac_cv_header_jxl_encode_h" = xyes; then :
-  passed=`expr $passed + 1`
-else
-  failed=`expr $failed + 1`
-fi
-
-
-  # This check should be changed once we have a .pc file for the JPEG-XL library.
-  if test "$enable_static" != 'yes'; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for JxlDecoderCreate in -ljxl" >&5
-$as_echo_n "checking for JxlDecoderCreate in -ljxl... " >&6; }
-if ${ac_cv_lib_jxl_JxlDecoderCreate+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-ljxl  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char JxlDecoderCreate ();
-int
-main ()
-{
-return JxlDecoderCreate ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_jxl_JxlDecoderCreate=yes
-else
-  ac_cv_lib_jxl_JxlDecoderCreate=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_jxl_JxlDecoderCreate" >&5
-$as_echo "$ac_cv_lib_jxl_JxlDecoderCreate" >&6; }
-if test "x$ac_cv_lib_jxl_JxlDecoderCreate" = xyes; then :
-  passed=`expr $passed + 1`
-else
-  failed=`expr $failed + 1`
-fi
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for JxlEncoderSetBasicInfo in -ljxl" >&5
-$as_echo_n "checking for JxlEncoderSetBasicInfo in -ljxl... " >&6; }
-if ${ac_cv_lib_jxl_JxlEncoderSetBasicInfo+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-ljxl  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char JxlEncoderSetBasicInfo ();
-int
-main ()
-{
-return JxlEncoderSetBasicInfo ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_jxl_JxlEncoderSetBasicInfo=yes
-else
-  ac_cv_lib_jxl_JxlEncoderSetBasicInfo=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_jxl_JxlEncoderSetBasicInfo" >&5
-$as_echo "$ac_cv_lib_jxl_JxlEncoderSetBasicInfo" >&6; }
-if test "x$ac_cv_lib_jxl_JxlEncoderSetBasicInfo" = xyes; then :
-  passed=`expr $passed + 1`
-else
-  failed=`expr $failed + 1`
-fi
-
-  fi
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if jpeg-xl package is complete" >&5
-$as_echo_n "checking if jpeg-xl package is complete... " >&6; }
-  if test $passed -gt 0; then
-      if test $failed -gt 0; then
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: no -- some components failed test" >&5
-$as_echo "no -- some components failed test" >&6; }
-          have_jxl='no (failed tests)'
-      else
-          JXL_LIBS='-ljxl -ljxl_threads'
-          LIBS="$JXL_LIBS $LIBS"
+if test "$have_jxl" = 'yes'; then
 
 $as_echo "#define JXL_DELEGATE 1" >>confdefs.h
 
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-          have_jxl='yes'
-      fi
-  else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-  fi
 fi
+
  if test "$have_jxl" = 'yes'; then
   JXL_DELEGATE_TRUE=
   JXL_DELEGATE_FALSE='#'
@@ -30854,6 +30801,7 @@ else
   JXL_DELEGATE_TRUE='#'
   JXL_DELEGATE_FALSE=
 fi
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2375,49 +2375,23 @@ AC_ARG_WITH([jxl],
     [with_jxl=$withval],
     [with_jxl='no'])
 
-if test "$with_jxl" != 'yes'; then
-    DISTCHECK_CONFIG_FLAGS="${DISTCHECK_CONFIG_FLAGS} --with-jxl=$with_jxl "
-fi
-if test "$enable_static" = 'yes'; then
-    if test "$with_utilities" = 'yes'; then
-        with_jxl='no'
-    fi
-fi
-
 # Check for the JPEG-XL library.
 have_jxl='no'
+JXL_CFLAGS=''
 JXL_LIBS=''
+JXL_PKG=''
 if test "$with_jxl" != 'no'; then
   AC_MSG_RESULT([-------------------------------------------------------------])
-  AC_MSG_CHECKING([for jpeg-xl])
+  PKG_CHECK_MODULES([JXL],[libjxl >= 0.6 libjxl_threads],[have_jxl=yes],[have_jxl=no])
   AC_MSG_RESULT([])
-  failed=0
-  passed=0
-  AC_CHECK_HEADER([jxl/decode.h],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`])
-  AC_CHECK_HEADER([jxl/encode.h],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`])
-  # This check should be changed once we have a .pc file for the JPEG-XL library.
-  if test "$enable_static" != 'yes'; then
-    AC_CHECK_LIB([jxl],[JxlDecoderCreate],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`],[])
-    AC_CHECK_LIB([jxl],[JxlEncoderSetBasicInfo],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`],[])
-  fi
-
-  AC_MSG_CHECKING([if jpeg-xl package is complete])
-  if test $passed -gt 0; then
-      if test $failed -gt 0; then
-          AC_MSG_RESULT([no -- some components failed test])
-          have_jxl='no (failed tests)'
-      else
-          JXL_LIBS='-ljxl -ljxl_threads'
-          LIBS="$JXL_LIBS $LIBS"
-          AC_DEFINE([JXL_DELEGATE],[1],[Define if you have jpeg-xl library])
-          AC_MSG_RESULT([yes])
-          have_jxl='yes'
-      fi
-  else
-      AC_MSG_RESULT([no])
-  fi
 fi
+
+if test "$have_jxl" = 'yes'; then
+  AC_DEFINE([JXL_DELEGATE],[1],[Define if you have jpeg-xl library])
+fi
+
 AM_CONDITIONAL([JXL_DELEGATE],[test "$have_jxl" = 'yes'])
+AC_SUBST([JXL_CFLAGS])
 AC_SUBST([JXL_LIBS])
 
 dnl ===========================================================================


### PR DESCRIPTION
### Description

Starting with libjxl v0.6 we can build static or shared libs when using
libjxl, so the check for `enable_static` is not needed anymore.

Also, it is possible to just use the .pc file from libjxl.

When encoding, not all the basic_info fields were set to valid values
when using memset(). This patch uses `JxlEncoderInitBasicInfo` to
initialize them instead of memset().