### PR TITLE
Fix grammar in AUTHORS.txt

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,4 +1,4 @@
-These active developers and have made source code contributions to the
+These active developers have made source code contributions to the
 ImageMagick project in the last few years:
 
 Cristy


### PR DESCRIPTION
The file had an erroneous "and" in the first sentence.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The first line in AUTHORS.txt had an erroneous "and". 

<!-- Thanks for contributing to ImageMagick! -->
