### PR TITLE
Fix stripes in output when resizing with OpenCL acceleration enabled

### DIFF
--- a/MagickCore/accelerate.c
+++ b/MagickCore/accelerate.c
@@ -3980,8 +3980,6 @@ static MagickBooleanType resizeHorizontalFilter(MagickCLDevice device,
     support;
 
   int
-    cacheRangeStart,
-    cacheRangeEnd,
     numCachedPixels,
     resizeFilterType,
     resizeWindowType;
@@ -4038,10 +4036,7 @@ DisableMSCWarning(4127)
 RestoreMSCWarning
   {
     /* calculate the local memory size needed per workgroup */
-    cacheRangeStart=(int) (((0 + 0.5)/xFactor+MagickEpsilon)-support+0.5);
-    cacheRangeEnd=(int) ((((pixelPerWorkgroup-1) + 0.5)/xFactor+
-      MagickEpsilon)+support+0.5);
-    numCachedPixels=cacheRangeEnd-cacheRangeStart+1;
+    numCachedPixels=(int) ceil((pixelPerWorkgroup-1)/xFactor+2*support);
     imageCacheLocalMemorySize=numCachedPixels*sizeof(CLQuantum)*
       number_channels;
     totalLocalMemorySize=imageCacheLocalMemorySize;
@@ -4164,8 +4159,6 @@ static MagickBooleanType resizeVerticalFilter(MagickCLDevice device,
     support;
 
   int
-    cacheRangeStart,
-    cacheRangeEnd,
     numCachedPixels,
     resizeFilterType,
     resizeWindowType;
@@ -4222,10 +4215,7 @@ DisableMSCWarning(4127)
 RestoreMSCWarning
   {
     /* calculate the local memory size needed per workgroup */
-    cacheRangeStart=(int) (((0 + 0.5)/yFactor+MagickEpsilon)-support+0.5);
-    cacheRangeEnd=(int) ((((pixelPerWorkgroup-1) + 0.5)/yFactor+
-      MagickEpsilon)+support+0.5);
-    numCachedPixels=cacheRangeEnd-cacheRangeStart+1;
+    numCachedPixels=(int)ceil((pixelPerWorkgroup-1)/yFactor+2*support);
     imageCacheLocalMemorySize=numCachedPixels*sizeof(CLQuantum)*
       number_channels;
     totalLocalMemorySize=imageCacheLocalMemorySize;


### PR DESCRIPTION
### Description

This patch is a possible fix for issue https://github.com/ImageMagick/ImageMagick/issues/2165.

For certain combinations of input and output size, the output contains horizontal and/or vertical stripes. These are always on the last line of a block of 32 pixels.

This patch updates the calculation of the amount of source pixels that needs to be cached to calculate the output values. This has to account for the worst case — the exact amount needed varies per block because it depends on the exact alignment of source and destination pixels (and the filter support size).

I don’t fully understand how exactly the pixel grids and filter kernels are lined up. But I have not seen any cases that break so far with this patch.

If you want to test a series of sizes on the Windows command line you can do this with a command like this:

```bat
set MAGICK_OCL_DEVICE=ON
FOR /L %a in (32, 1, 199) do magick.exe -size 200x200 gradient: -filter Lanczos -resize x%a test-%a.png
```

(n.b. in a .cmd file you have to write `%%a` instead of `%a`)
