### PR TITLE
'typo' in houghline comments.

### DIFF
--- a/MagickCore/feature.c
+++ b/MagickCore/feature.c
@@ -1733,17 +1733,17 @@ MagickExport ChannelFeatures *GetImageFeatures(const Image *image,
 %                                                                             %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-%  Use HoughLineImage() in conjunction with any binary edge extracted image (we
-%  recommand Canny) to identify lines in the image.  The algorithm accumulates
-%  counts for every white pixel for every possible orientation (for angles from
-%  0 to 179 in 1 degree increments) and distance from the center of the image to
-%  the corner (in 1 px increments) and stores the counts in an accumulator
-%  matrix of angle vs distance. The size of the accumulator is 180x(diagonal/2).
-%  Next it searches this space for peaks in counts and converts the locations
-%  of the peaks to slope and intercept in the normal x,y input image space. Use
-%  the slope/intercepts to find the endpoints clipped to the bounds of the
-%  image. The lines are then drawn. The counts are a measure of the length of
-%  the lines.
+%  HoughLineImage() can be used in conjunction with any binary edge extracted
+%  image (we recommend Canny) to identify lines in the image. The algorithm
+%  accumulates counts for every white pixel for every possible orientation (for
+%  angles from 0 to 179 in 1 degree increments) and distance from the center of
+%  the image to the corner (in 1 px increments) and stores the counts in an
+%  accumulator matrix of angle vs distance. The size of the accumulator is
+%  180x(diagonal/2). Next it searches this space for peaks in counts and
+%  converts the locations of the peaks to slope and intercept in the normal
+%  x,y input image space. Use  the slope/intercepts to find the endpoints
+%  clipped to the bounds of the image. The lines are then drawn. The counts
+%  are a measure of the length of the lines.
 %
 %  The format of the HoughLineImage method is:
 %

--- a/MagickWand/magick-image.c
+++ b/MagickWand/magick-image.c
@@ -6366,17 +6366,17 @@ WandExport MagickBooleanType MagickHasPreviousImage(MagickWand *wand)
 %                                                                             %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-%  Use MagickHoughLineImage() in conjunction with any binary edge extracted
-%  image (we recommand Canny) to identify lines in the image.  The algorithm
-%  accumulates counts for every white pixel for every possible orientation (for
-%  angles from 0 to 179 in 1 degree increments) and distance from the center of
-%  the image to the corner (in 1 px increments) and stores the counts in an
-%  accumulator matrix of angle vs distance. The size of the accumulator is
-%  180x(diagonal/2). Next it searches this space for peaks in counts and
-%  converts the locations of the peaks to slope and intercept in the normal x,y
-%  input image space. Use the slope/intercepts to find the endpoints clipped to
-%  the bounds of the image. The lines are then drawn. The counts are a measure
-%  of the length of the lines.
+%  MagickHoughLineImage() can be used in conjunction with any binary edge
+%  extracted image (we recommend Canny) to identify lines in the image. The
+%  algorithm accumulates counts for every white pixel for every possible
+%  orientation (for angles from 0 to 179 in 1 degree increments) and distance
+%  from the center of the image to the corner (in 1 px increments) and stores
+%  the counts in an accumulator matrix of angle vs distance. The size of the
+%  accumulator is 180x(diagonal/2). Next it searches this space for peaks in
+%  counts and converts the locations of the peaks to slope and intercept in the
+%  normal x,y input image space. Use the slope/intercepts to find the endpoints
+%  clipped to the bounds of the image. The lines are then drawn. The counts are
+%  a measure of the length of the lines.
 %
 %  The format of the MagickHoughLineImage method is:
 %


### PR DESCRIPTION
### Prerequisites

- [* ] I have written a descriptive pull-request title
- [* ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ *] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Currently the comments for the HoughLineImage function doesn't follow the standard of other functions, and has the word "use" at the start. This appears to be generating bad anchors on the website e.g. https://imagemagick.org/api/magick-image.php#Use%20MagickHoughLineImage

Which doesn't scroll the page to the correct function.

Sorry, I don't know how to regenerate the files www/api/feature.html or www/api/magick-image.html
