### PR TITLE
Make exported for MagickBilateralBlurImage be same as in C file.

### DIFF
--- a/MagickWand/magick-image.h
+++ b/MagickWand/magick-image.h
@@ -93,7 +93,7 @@ extern WandExport MagickBooleanType
   MagickAutoLevelImage(MagickWand *),
   MagickAutoOrientImage(MagickWand *),
   MagickAutoThresholdImage(MagickWand *,const AutoThresholdMethod),
-  MagickBilateralImage(MagickWand *,const double,const double,const double,
+  MagickBilateralBlurImage(MagickWand *,const double,const double,const double,
     const double),
   MagickBlackThresholdImage(MagickWand *,const PixelWand *),
   MagickBlueShiftImage(MagickWand *,const double),


### PR DESCRIPTION
### Prerequisites

- [ *] I have written a descriptive pull-request title
- [ *] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ *] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The word 'blur' appears to be missing in header, so MagickBilateralImage instead of MagickBilateralBlurImage.
