### PR TITLE
Typo in magick color threshold image

### DIFF
--- a/MagickWand/magick-image.c
+++ b/MagickWand/magick-image.c
@@ -6762,7 +6762,7 @@ WandExport MagickBooleanType MagickInverseFourierTransformImage(
 %  MagickKmeansImage() applies k-means color reduction to an image. This is a
 %  colorspace clustering or segmentation technique.
 %
-%  The format of the MagickKuwaharaImage method is:
+%  The format of the MagickKmeansImage method is:
 %
 %      MagickBooleanType MagickKmeansImage(MagickWand *wand,
 %        const size_t number_colors, const size_t max_iterations,

--- a/MagickWand/magick-image.c
+++ b/MagickWand/magick-image.c
@@ -1858,18 +1858,18 @@ WandExport MagickBooleanType MagickColorMatrixImage(MagickWand *wand,
 %  MagickColorThresholdImage() forces all pixels in the color range to white
 %  otherwise black.
 %
-%  The format of the MagickWhiteThresholdImage method is:
+%  The format of the MagickColorThresholdImage method is:
 %
-%      MagickBooleanType MagickWhiteThresholdImage(MagickWand *wand,
+%      MagickBooleanType MagickColorThresholdImage(MagickWand *wand,
 %        const PixelWand *start_color,const PixelWand *stop_color)
 %
 %  A description of each parameter follows:
 %
 %    o wand: the magick wand.
 %
-%    o start-color: the start color pixel wand.
+%    o start_color: the start color pixel wand.
 %
-%    o stop-color: the stop color pixel wand.
+%    o stop_color: the stop color pixel wand.
 %
 */
 WandExport MagickBooleanType MagickColorThresholdImage(MagickWand *wand,


### PR DESCRIPTION
### Prerequisites

- [* ] I have written a descriptive pull-request title
- [*] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [*] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Fixes a few typos in the comments that show up on the docs site.