### PR TITLE
Add note to MagickCLAHEImage to avoid confusion.

### DIFF
--- a/MagickWand/magick-image.c
+++ b/MagickWand/magick-image.c
@@ -1430,7 +1430,9 @@ WandExport MagickBooleanType MagickChopImage(MagickWand *wand,
 %
 %    o height: the height of the tile divisions to use in vertical direction.
 %
-%    o number_bins: number of bins for histogram ("dynamic range").
+%    o number_bins: number of bins for histogram ("dynamic range"). Although
+%      parameter is currently a double, it is cast to size_t internally. Param
+%      will be changed to size_t type in ImageMagick 7.2.0 / 8.0.
 %
 %    o clip_limit: contrast limit for localised changes in contrast. A limit
 %      less than 1 results in standard non-contrast limited AHE.


### PR DESCRIPTION
### Prerequisites

- [x ] I have written a descriptive pull-request title
- [x ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Just adding a note to the doc for MagickCLAHEImage to make it clearer why a double is passed in, when ints are used.

Fixes #4429