### PR TITLE
msl coder: add support for autoorient

### DIFF
--- a/coders/msl.c
+++ b/coders/msl.c
@@ -1153,6 +1153,30 @@ static void MSLStartElement(void *context,const xmlChar *tag,
           msl_info->image[n]=append_image;
           break;
         }
+      if (LocaleCompare((const char *) tag, "autoorient") == 0)
+        {
+          Image
+            *new_image;
+
+          /*
+            Adjusts an image's orientation
+          */
+          if (msl_info->image[n] == (Image *) NULL)
+            {
+              ThrowMSLException(OptionError,"NoImagesDefined",
+                (const char *) tag);
+              break;
+            }
+
+          new_image=AutoOrientImage(msl_info->image[n],
+              msl_info->image[n]->orientation, exception);
+          if (new_image == (Image *) NULL)
+            break;
+
+          msl_info->image[n]=DestroyImage(msl_info->image[n]);
+          msl_info->image[n]=new_image;
+          break;
+        }
       ThrowMSLException(OptionError,"UnrecognizedElement",(const char *) tag);
       break;
     }

--- a/www/conjure.html
+++ b/www/conjure.html
@@ -315,7 +315,7 @@ msl:font-metrics.origin.y
   </tr>
 
   <tr>
-    <td><strike>autoorient</strike></td>
+    <td>&lt;autoorient&gt;</td>
     <td> </td>
     <td>adjusts an image so that its orientation is suitable for viewing (i.e. top-left orientation)</td>
   </tr>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
This change adds `autoorient` support for the MSL coder and therefore also to the `conjure` program.

The `autoorient` feature was one of the strikeout features.
Thus, this PR enables the usage of automatically adjusting an image's orientation.