### PR TITLE
Restore dds:compression=dxt5 behavior

### DIFF
--- a/coders/dds.c
+++ b/coders/dds.c
@@ -4124,6 +4124,8 @@ static MagickBooleanType WriteDDSImage(const ImageInfo *image_info,
     {
        if (LocaleCompare(option,"dxt1") == 0)
          compression=FOURCC_DXT1;
+       if (LocaleCompare(option,"dxt5") == 0)
+         compression=FOURCC_DXT5;
        if (LocaleCompare(option,"none") == 0)
          pixelFormat=DDPF_RGB;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The `DDS` coder accepts a user-defined `dds:compression` option. This allows users to overwrite compression-methods selected by `image_info->compression` property and/or pixel traits. However the `dxt5` option is omitted from the `dds:compression` checks. This pull-request restores the `dxt5` overwrite for users that require this compression method, but do not have `image->alpha_trait` defined.

### Examples

Before this patch....

```sh
$ magick -size 100x100 plasma: -define dds:compression=dxt5 dds:- | identify -verbose dds:- | grep Compression
#=>  Compression: DXT1
```
After this patch....
```sh
$ magick -size 100x100 plasma: -define dds:compression=dxt5 dds:- | identify -verbose dds:- | grep Compression
#=>  Compression: DXT5
```

### Why

Folks packaging image assets for videogames may have compression-method requirement. It's likely that an image without an alpha channel will still require `DXT5`. From ImageMagick's documentation, defining `dds:compression=dxt5` is the correct way for users to define this behavior.

> Use _-define_ to specify the compression (e.g. <samp>-define dds:compression={dxt1, dxt5, none}</samp>).