### PR TITLE
Fix setting the pixel intensity method with SetImageProperty

### DIFF
--- a/MagickCore/property.c
+++ b/MagickCore/property.c
@@ -4565,7 +4565,7 @@ MagickExport MagickBooleanType SetImageProperty(Image *image,
           ssize_t
             intensity;
 
-          intensity=ParseCommandOption(MagickIntentOptions,MagickFalse,value);
+          intensity=ParseCommandOption(MagickIntensityOptions,MagickFalse,value);
           if (intensity < 0)
             return(MagickFalse);
           image->intensity=(PixelIntensityMethod) intensity;


### PR DESCRIPTION
### Prerequisites
- [x]   I have written a descriptive pull-request title
- [x]   I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x]   I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Hi,
Noticed this while looking into using a different intensity method with `ExportImagePixels`. Currently `SetImageProperty(image,"intensity",...)` is effectively a no-op for [pixel intensity keys](https://github.com/ImageMagick/ImageMagick/blob/main/MagickCore/option.c#L1889), but technically works with [rendering intent keys](https://github.com/ImageMagick/ImageMagick/blob/main/MagickCore/option.c#L1532) (which is a smaller set though).

It's a rather old bug, so I'm not sure if it'd be preferable to just deprecate the "intensity" property and create a new key like "pixelintensity" in the event someone is intentionally or inadvertently relying on this, instead.

Minimal demonstration:
```C
Image *image = AcquireImage(NULL,NULL);
SetImageProperty(image,"intensity","Average",NULL);
assert(image->intensity == AveragePixelIntensityMethod);
```