### PR TITLE
Remove unused EXPLICIT_TEMPLATE_INSTANTIATION

### DIFF
--- a/Magick++/lib/Drawable.cpp
+++ b/Magick++/lib/Drawable.cpp
@@ -2491,12 +2491,3 @@ Magick::VPathBase* Magick::PathMovetoRel::copy() const
 {
   return new PathMovetoRel(*this);
 }
-
-#if defined(EXPLICIT_TEMPLATE_INSTANTIATION)
-// template class std::vector<Magick::Coordinate>;
-// template class std::vector<const Magick::Drawable>;
-// template class std::vector<const Magick::PathArcArgs>;
-// template class std::vector<const Magick::PathCurvetoArgs>;
-// template class std::vector<const Magick::PathQuadraticCurvetoArgs>;
-// template class std::vector<const Magick::VPath>;
-#endif


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The code is commented out. In addition, `std::vector<const T>` is
undefined in C++ because `std::allocator<const T>` is undefined
([allocator.requirements.general] says that T is any cv-unqualified
object type). libstdc++ seems to never allow `std::vector<const T>`
(https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48101).
