### PR TITLE
Add support for FITS images with NaN values

### DIFF
--- a/coders/fits.c
+++ b/coders/fits.c
@@ -196,7 +196,7 @@ static MagickOffsetType GetFITSPixelExtrema(Image *image,
   number_pixels=(MagickSizeType) image->columns*image->rows;
   *minima=DBL_MAX;
   *maxima=DBL_MIN;
-  for (i=1; i < (MagickOffsetType) number_pixels; i++)
+  for (i=0; i < (MagickOffsetType) number_pixels; i++)
   {
     pixel=GetFITSPixel(image,bits_per_pixel);
     if (pixel < *minima)

--- a/coders/fits.c
+++ b/coders/fits.c
@@ -145,9 +145,6 @@ static MagickBooleanType IsFITS(const unsigned char *magick,const size_t length)
 
 static inline double GetFITSPixel(Image *image,int bits_per_pixel)
 {
-  double
-    pixel;
-
   switch (image->depth >> 3)
   {
     case 1:
@@ -168,13 +165,8 @@ static inline double GetFITSPixel(Image *image,int bits_per_pixel)
     default:
       break;
   }
-
-  pixel=(ReadBlobDouble(image));
-  if (IsNaN(pixel))
-    pixel=0;
-  return pixel;
+  return(ReadBlobDouble(image));
 }
-
 
 static MagickOffsetType GetFITSPixelExtrema(Image *image,
   const int bits_per_pixel,double *minima,double *maxima)

--- a/coders/fits.c
+++ b/coders/fits.c
@@ -145,35 +145,36 @@ static MagickBooleanType IsFITS(const unsigned char *magick,const size_t length)
 
 static inline double GetFITSPixel(Image *image,int bits_per_pixel)
 {
-  double pixel = 0;
+  double
+    pixel;
+
   switch (image->depth >> 3)
   {
     case 1:
-      pixel=((double) ReadBlobByte(image));
+      return((double) ReadBlobByte(image));
     case 2:
-      pixel=((double) ((short) ReadBlobShort(image)));
+      return((double) ((short) ReadBlobShort(image)));
     case 4:
     {
       if (bits_per_pixel > 0)
-        pixel=((double) ReadBlobSignedLong(image));
-      pixel=((double) ReadBlobFloat(image));
+        return((double) ReadBlobSignedLong(image));
+      return((double) ReadBlobFloat(image));
     }
     case 8:
     {
       if (bits_per_pixel > 0)
-        pixel=((double) ((MagickOffsetType) ReadBlobLongLong(image)));
+        return((double) ((MagickOffsetType) ReadBlobLongLong(image)));
     }
     default:
       break;
   }
+
   pixel=(ReadBlobDouble(image));
-
-  // Override any undefined pixels to black.
-  if (isnan(pixel))
-      pixel=0;
-
+  if (IsNaN(pixel))
+    pixel=0;
   return pixel;
 }
+
 
 static MagickOffsetType GetFITSPixelExtrema(Image *image,
   const int bits_per_pixel,double *minima,double *maxima)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
When the first pixel of a FITS image is NaN, the minima/maxima for the image ends up being set to NaN and the resulting image that's rendered is all black.

This change updates the initial minima/maxima to be DBL_MAX and DBL_MIN respectively instead of using the 1st pixel value. This allows the min/max search to work correctly, and the image is then displayed correctly.

I also added a change to override any NaN values to 0 for extra safety, since I'm not sure how the rest of ImageMagick handles NaN values.
