### PR TITLE
Avoid NULL pointer dereference in coders/wmf.c

### DIFF
--- a/coders/wmf.c
+++ b/coders/wmf.c
@@ -1223,24 +1223,27 @@ static void ipa_draw_polypolygon(wmfAPI * API, wmfPolyPoly_t* polypolygon)
       util_set_brush(API, polypolygon->dc, BrushApplyFill);
 
       DrawPathStart(WmfDrawingWand);
-      for (polygon = 0; polygon < polypolygon->npoly; polygon++)
+      if (polypolygon->pt && polypolygon->count)
         {
-          polyline.dc = polypolygon->dc;
-          polyline.pt = polypolygon->pt[polygon];
-          polyline.count = polypolygon->count[polygon];
-          if ((polyline.count > 2) && polyline.pt)
-            {
-              DrawPathMoveToAbsolute(WmfDrawingWand,
-                                     XC(polyline.pt[0].x),
-                                     YC(polyline.pt[0].y));
-              for (point = 1; point < polyline.count; point++)
-                {
-                  DrawPathLineToAbsolute(WmfDrawingWand,
-                                         XC(polyline.pt[point].x),
-                                         YC(polyline.pt[point].y));
-                }
-              DrawPathClose(WmfDrawingWand);
-            }
+        for (polygon = 0; polygon < polypolygon->npoly; polygon++)
+          {
+            polyline.dc = polypolygon->dc;
+            polyline.pt = polypolygon->pt[polygon];
+            polyline.count = polypolygon->count[polygon];
+            if ((polyline.count > 2) && polyline.pt)
+              {
+                DrawPathMoveToAbsolute(WmfDrawingWand,
+                                       XC(polyline.pt[0].x),
+                                       YC(polyline.pt[0].y));
+                for (point = 1; point < polyline.count; point++)
+                  {
+                    DrawPathLineToAbsolute(WmfDrawingWand,
+                                           XC(polyline.pt[point].x),
+                                           YC(polyline.pt[point].y));
+                  }
+                DrawPathClose(WmfDrawingWand);
+              }
+          }
         }
       DrawPathFinish(WmfDrawingWand);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
Avoid NULL pointer dereference in coders/wmf.c