### PR TITLE
Pass negative interline_spacing to pango

### DIFF
--- a/coders/pango.c
+++ b/coders/pango.c
@@ -373,7 +373,7 @@ static Image *ReadPANGOImage(const ImageInfo *image_info,
           error->message,"`%s'",image_info->filename);
       pango_layout_set_markup(layout,caption,-1);
     }
-  if (draw_info->interline_spacing > 0)
+  if (draw_info->interline_spacing != 0)
     pango_layout_set_spacing(layout,ScalePangoValue(
       draw_info->interline_spacing,image->resolution.x));
   pango_layout_context_changed(layout);


### PR DESCRIPTION
Allow interline-spacing values of less than 0 to pass through to Pango, that line spacing can be narrowed.

### Prerequisites

- [✓] I have written a descriptive pull-request title
- [✓] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [✓] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
