### PR TITLE
build: fix quoting for autoconf sendfile check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -533,13 +533,12 @@ AC_CACHE_CHECK([Linux compatible sendfile()],ac_cv_have_linux_sendfile,[
     #include <sys/sendfile.h>
   ], [
     sendfile(0, 0, (void *) 0, 0);
-  ], [
+  ])], [
     ac_cv_have_linux_sendfile=yes
   ], [
     ac_cv_have_linux_sendfile=no
   ])])
-])
-if test $ac_cv_have_linux_sendfile = yes; then
+if test "$ac_cv_have_linux_sendfile" = yes; then
   AC_DEFINE([HAVE_LINUX_SENDFILE],[1], [Define if you have Linux-compatible sendfile()])
 fi
 


### PR DESCRIPTION
1. Fix quoting of result variable (for consistency anyway, but
it also fixes a syntax issue below)

Fixes error when running ./configure:
```
checking Linux compatible sendfile()...
./configure: line 10925: test: =: unary operator expected
[...]
```

2. Fix quoting of AC_LANG_PROGRAM/AC_COMPILE_IFELSE arguments

Before (no yes/no/cached would get shown):
```
checking Linux compatible sendfile()...
[...]
```

After:
```
checking Linux compatible sendfile()... yes
```

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Fix quoting in two places of the configure check for sendfile.

<!-- Thanks for contributing to ImageMagick! -->
