### PR TITLE
The effect of modulate:colorspace LCH is different for palette and true color images.

### DIFF
--- a/MagickCore/enhance.c
+++ b/MagickCore/enhance.c
@@ -3872,13 +3872,13 @@ MagickExport MagickBooleanType ModulateImage(Image *image,const char *modulate,
             &red,&green,&blue);
           break;
         }
+        case LCHColorspace:
         case LCHabColorspace:
         {
           ModulateLCHab(percent_brightness,percent_saturation,percent_hue,
             illuminant,&red,&green,&blue);
           break;
         }
-        case LCHColorspace:
         case LCHuvColorspace:
         {
           ModulateLCHuv(percent_brightness,percent_saturation,percent_hue,

--- a/MagickCore/enhance.c
+++ b/MagickCore/enhance.c
@@ -3853,6 +3853,12 @@ MagickExport MagickBooleanType ModulateImage(Image *image,const char *modulate,
             &red,&green,&blue);
           break;
         }
+        case HSIColorspace:
+        {
+          ModulateHSI(percent_hue,percent_saturation,percent_brightness,
+            &red,&green,&blue);
+          break;
+        }
         case HSLColorspace:
         default:
         {

--- a/www/command-line-options.html
+++ b/www/command-line-options.html
@@ -5281,7 +5281,7 @@ saturation by 10% and leave the hue unchanged, use <a
 href="command-line-options.html#modulate">-modulate 120,90</a>.</p>
 
 <p>Use <a href="command-line-options.html#set">-set</a> attribute of '<samp>option:modulate:colorspace</samp>' to specify which colorspace to
-modulate.  Choose from <samp>HCL</samp>, <samp>HCLp</samp>, <samp>HSB</samp>, <samp>HSI</samp>, <samp>HSL</samp> (the default), <samp>HSV</samp>, <samp>HWB</samp>, or <samp>LCH</samp> (LCHuv).  For example,</p>
+modulate.  Choose from <samp>HCL</samp>, <samp>HCLp</samp>, <samp>HSB</samp>, <samp>HSI</samp>, <samp>HSL</samp> (the default), <samp>HSV</samp>, <samp>HWB</samp>, or <samp>LCH</samp> (LCHab).  For example,</p>
 
 <pre class="bg-light text-dark mx-4"><samp>magick image.png -set option:modulate:colorspace hsb -modulate 120,90 modulate.png
 </samp></pre>


### PR DESCRIPTION
The effect of modulate:colorspace LCH is different for palette and true color images.

- Palette image -modulate LCH as LCHab.   ( OK )
  - ImageMagick LCH colorscape alias to LCHab since v6.8.5-5
- Truecolor image -modulate LCH as LCHuv. ( NG )
  - Documented behavior. but old.

-define modulate:colorspace=LCH -modulate, Truecolor image also , the actual colorspace should changed from LCHuv to LCHab.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

```
% magick -version
Version: ImageMagick 7.1.0-40 beta Q16-HDRI x86_64 20210 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI Modules OpenMP(5.0)
Delegates (built-in): bzlib fontconfig freetype gslib heic jng jp2 jpeg lcms lqr ltdl lzma openexr png ps raw tiff webp xml zlib
Compiler: gcc (4.2)
```

```
% magick rose: -type palette -define modulate:colorspace=LCH -modulate 100,100,200 palette.png
% magick rose: -type truecolor -define modulate:colorspace=LCH -modulate 100,100,200 truecolor.png
% magick rose: -define modulate:colorspace=LCHab -modulate 100,100,200 LCHab.png
% magick rose: -define modulate:colorspace=LCHuv -modulate 100,100,200 LCHuv.png
```

| palette.png  | truecolor.png | LCHab.png | LCHuv.png |
|---|---|---|---|
| ![palette](https://user-images.githubusercontent.com/26040/185893363-8bc42427-47d1-4082-8b45-8a4d7dcffcf0.png) | ![truecolor](https://user-images.githubusercontent.com/26040/185893385-beb6c0c3-666b-40d0-af87-bb327e861141.png) | ![LCHab](https://user-images.githubusercontent.com/26040/185893936-c3a6087d-e169-4d8e-bd8b-a417fc6f2907.png) | ![LCHuv](https://user-images.githubusercontent.com/26040/185893952-c06ee6f1-f694-4e26-9087-a6ccbac89b37.png) |

Perhaps the colorspace LCH is not fully alias to LCHab

My inference of historical background

- In 6.8.0-0, LCH colorspace added . (Implemented as LCHab)
- In 6.8.5-0, LCHab/LCHuv added, LCH as alias for LCHuv
-  (Oops. LCH is broken)
- In 6.8.5-5, LCH as alias for LCHab. almost LCH using implementations rewritten.
- (Forgot to change a part of -modulate code)
