### PR TITLE
png.c: Remove the extra space character in "%8lu "

### DIFF
--- a/coders/png.c
+++ b/coders/png.c
@@ -8273,7 +8273,7 @@ Magick_png_write_raw_profile(const ImageInfo *image_info,png_struct *ping,
    dp+=description_length;
    *dp++='\n';
    (void) FormatLocaleString(dp,allocated_length-
-     (png_size_t) (dp-text[0].text),"%8lu ",(unsigned long) length);
+     (png_size_t) (dp-text[0].text),"%8lu",(unsigned long) length);
    dp+=8;
 
    for (i=0; i < (ssize_t) length; i++)


### PR DESCRIPTION
The space character in "%8lu " is written and then immediately overwritten with `\n`.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
