### PR TITLE
Fix HEIF header include path for MINGW

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -74,7 +74,7 @@
 #include "MagickCore/module.h"
 #include "MagickCore/utility.h"
 #if defined(MAGICKCORE_HEIC_DELEGATE)
-#if defined(MAGICKCORE_WINDOWS_SUPPORT)
+#if defined(MAGICKCORE_WINDOWS_SUPPORT) && !defined(__MINGW32__)
 #include <heif.h>
 #else
 #include <libheif/heif.h>
@@ -86,19 +86,19 @@
   Define declarations.
 */
 #define XmpNamespaceExtent  28
-
+
 /*
   Const declarations.
 */
 static const char
   xmp_namespace[] = "http://ns.adobe.com/xap/1.0/ ";
-
+
 /*
   Forward declarations.
 */
 static MagickBooleanType
   WriteHEICImage(const ImageInfo *,Image *,ExceptionInfo *);
-
+
 /*x
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
MINGW packages install headers into `${includedir}/libheif` just like UNIX.

In fact, [even w/ MSVC they should go into a subdirectory like this](https://github.com/strukturag/libheif/blob/1d36c10ade9b2acfc2dcc4ca8b6176a9789c902c/libheif/CMakeLists.txt#L165) (haven't checked e.g. vcpkg to confirm), so not sure why this check is this still needed?