### PR TITLE
Fixed magnify confusing colorspaces other than linear-RGB.

### DIFF
--- a/MagickCore/resize.c
+++ b/MagickCore/resize.c
@@ -48,6 +48,8 @@
 #include "MagickCore/channel.h"
 #include "MagickCore/color.h"
 #include "MagickCore/color-private.h"
+#include "MagickCore/colorspace.h"
+#include "MagickCore/colorspace-private.h"
 #include "MagickCore/distort.h"
 #include "MagickCore/draw.h"
 #include "MagickCore/exception.h"
@@ -2987,7 +2989,8 @@ MagickExport Image *MagnifyImage(const Image *image,ExceptionInfo *exception)
   rectangle.width=image->columns;
   rectangle.height=image->rows;
   (void) CopyImagePixels(source_image,image,&rectangle,&offset,exception);
-  (void) SetImageColorspace(source_image,RGBColorspace,exception);
+  if (IssRGBCompatibleColorspace(source_image->colorspace) == MagickFalse)
+    (void) TransformImageColorspace(source_image,sRGBColorspace,exception);
   magnify_image=CloneImage(source_image,magnification*source_image->columns,
     magnification*source_image->rows,MagickTrue,exception);
   if (magnify_image == (Image *) NULL)


### PR DESCRIPTION
Fixed magnify confusing colorspaces other than linear-RGB.

- Changed SetImageColorspace to TransformImageColorspace.
- Workspace colors changed from linear-RGB to sRGB

In most cases, the -magnify option lightens the colors.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Since ImageMagick 7.0.8-54, the -magnify option brightens colors in most cases.
There is a bug that reinterprets the input image RGB values as Linear-RGB.

```
% ~/ImageMagick/7.1.0-48/bin/magick -size 64x64 xc:green4 -draw "fill none stroke orange circle 32 32 32 8"  circle.png
% ~/ImageMagick/7.0.8-53/bin/magick circle.png -magnify  magnify-7.0.8-53.png
% ~/ImageMagick/7.0.8-54/bin/magick circle.png -magnify  magnify-7.0.8-54.png
% ~/ImageMagick/7.1.0-48/bin/magick circle.png -magnify  magnify-7.1.0-48.png
```

| circle.png | magnify-7.0.8-53.png | magnify-7.0.8-54.png | magnify-7.1.0-48.png |
|---|---|---|---|
| ![circle](https://user-images.githubusercontent.com/26040/190670522-ae924b22-a0de-4827-85b4-3cde71c2138f.png) | ![magnify-7 0 8-53](https://user-images.githubusercontent.com/26040/190670552-263275b3-1797-4295-88f3-b9fb4398ae3a.png) | ![magnify-7 0 8-54](https://user-images.githubusercontent.com/26040/190670570-0c13e59a-475f-411a-8b2a-65d5e78f23a5.png) | ![magnify-7 1 0-48](https://user-images.githubusercontent.com/26040/190670592-f79bfda7-36de-4817-a58b-f2dbd231aa12.png) | 

The input image RGB values is treated as LinearRGB without colorspace conversion.
Also, I think the committer probably set RGBColorspace as normal RGB, so I changed it to sRGBColorspace.
