### PR TITLE
Pass image's type instead of colorspace to IsGrayImageType

### DIFF
--- a/MagickCore/attribute.c
+++ b/MagickCore/attribute.c
@@ -2160,7 +2160,7 @@ MagickExport MagickBooleanType SetImageType(Image *image,const ImageType type,
   {
     case BilevelType:
     {
-      if (IsGrayImageType(image->colorspace) == MagickFalse)
+      if (IsGrayImageType(image->type) == MagickFalse)
         status=TransformImageColorspace(image,GRAYColorspace,exception);
       (void) NormalizeImage(image,exception);
       (void) BilevelImage(image,(double) QuantumRange/2.0,exception);
@@ -2174,14 +2174,14 @@ MagickExport MagickBooleanType SetImageType(Image *image,const ImageType type,
     }
     case GrayscaleType:
     {
-      if (IsGrayImageType(image->colorspace) == MagickFalse)
+      if (IsGrayImageType(image->type) == MagickFalse)
         status=TransformImageColorspace(image,GRAYColorspace,exception);
       image->alpha_trait=UndefinedPixelTrait;
       break;
     }
     case GrayscaleAlphaType:
     {
-      if (IsGrayImageType(image->colorspace) == MagickFalse)
+      if (IsGrayImageType(image->type) == MagickFalse)
         status=TransformImageColorspace(image,GRAYColorspace,exception);
       if (image->alpha_trait == UndefinedPixelTrait)
         (void) SetImageAlphaChannel(image,OpaqueAlphaChannel,exception);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

`SetImageType` supplies the `image`'s `colorspace` as `ImageType` to `IsGrayImageType` in an attempt to decide whether or not to call `TransformImageColorspace`.

Reference commit: c1ca2476540dd2f55ac108a190a75ff83a207a9c

### Implication

For example, give an image of type `ColorSeparationType`, its type remains unchanged after being set to `GrayscaleType`, as `CMYKColorspace` and `GrayscaleType` share the same value.

### How to reproduce

The behavior detailed above is reproducible using Python bindings with the [Wand](https://docs.wand-py.org/en/latest/) package. Here are the steps:

1. Have Python installed, preferably with a virtual environment activated
2. Install Wand: `pip install Wand`
   - Please check https://docs.wand-py.org/en/latest/guide/install.html for more details
3. Run the following script:

```python
from wand.image import IMAGE_TYPES
from wand.image import Image

(
    UNDEFINED_TYPE,
    BILEVEL_TYPE,
    GRAYSCALE_TYPE,
    GRAYSCALEALPHA_TYPE,
    PALETTE_TYPE,
    PALETTEALPHA_TYPE,
    TRUECOLOR_TYPE,
    TRUECOLORALPHA_TYPE,
    COLORSEPARATION_TYPE,
    COLORSEPARATIONALPHA_TYPE,
    OPTIMIZE_TYPE,
    PALETTEBILEVELALPHA_TYPE,
) = IMAGE_TYPES

green_image = Image().blank(179, 359, "green")
# Assert green_image's initial type
assert green_image.type == TRUECOLOR_TYPE
# Set its type to GrayscaleType
green_image.type = GRAYSCALE_TYPE
# Assert its new type, should be GrayscaleType
assert green_image.type == GRAYSCALE_TYPE
print("So far, so good!")

red_image = Image().blank(179, 359, "red")
# Assert red_image's initial type
assert red_image.type == TRUECOLOR_TYPE
# Set its type to ColorSeparationType
red_image.type = COLORSEPARATION_TYPE
# Assert its new type
assert red_image.type == COLORSEPARATION_TYPE
# Set its type to GrayscaleType
red_image.type = GRAYSCALE_TYPE
# Assert its new type, should be GrayscaleType
assert red_image.type == GRAYSCALE_TYPE, f"type remains {red_image.type}"
print("Yup, all good!")
```

The expected output would be:

```
So far, so good!
Yup, all good!
```

But instead, the output is:

```
So far, so good!
Traceback (most recent call last):
  File "<stdin>", line 38, in <module>
AssertionError: type remains colorseparation
```

### Proposed fix

The proposed fix is either what's suggested in this PR, or the following:

```diff
diff --git a/MagickCore/attribute.c b/MagickCore/attribute.c
index e124f38a6..534121f63 100644
--- a/MagickCore/attribute.c
+++ b/MagickCore/attribute.c
@@ -2160,7 +2160,7 @@ MagickExport MagickBooleanType SetImageType(Image *image,const ImageType type,
   {
     case BilevelType:
     {
-      if (IsGrayImageType(image->colorspace) == MagickFalse)
+      if (IsGrayColorspace(image->colorspace) == MagickFalse)
         status=TransformImageColorspace(image,GRAYColorspace,exception);
       (void) NormalizeImage(image,exception);
       (void) BilevelImage(image,(double) QuantumRange/2.0,exception);
@@ -2174,14 +2174,14 @@ MagickExport MagickBooleanType SetImageType(Image *image,const ImageType type,
     }
     case GrayscaleType:
     {
-      if (IsGrayImageType(image->colorspace) == MagickFalse)
+      if (IsGrayColorspace(image->colorspace) == MagickFalse)
         status=TransformImageColorspace(image,GRAYColorspace,exception);
       image->alpha_trait=UndefinedPixelTrait;
       break;
     }
     case GrayscaleAlphaType:
     {
-      if (IsGrayImageType(image->colorspace) == MagickFalse)
+      if (IsGrayColorspace(image->colorspace) == MagickFalse)
         status=TransformImageColorspace(image,GRAYColorspace,exception);
       if (image->alpha_trait == UndefinedPixelTrait)
         (void) SetImageAlphaChannel(image,OpaqueAlphaChannel,exception);
```

Please, let me know if you'd like me to update the PR with the latter.

Thanks for ImageMagick!
