### PR TITLE
utilities: Enable support for unicode paths in mingw

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -259,6 +259,7 @@ check_PROGRAMS = $(am__EXEEXT_2) $(am__EXEEXT_4)
 @WIN32_NATIVE_BUILD_TRUE@am__append_1 = -lws2_32
 @MAGICKCORE_ZERO_CONFIGURATION_SUPPORT_TRUE@am__append_2 = MagickCore/threshold-map.h
 @MAGICKCORE_ZERO_CONFIGURATION_SUPPORT_TRUE@am__append_3 = MagickCore/threshold-map.h
+@WIN32_NATIVE_BUILD_TRUE@@WITH_UTILITIES_TRUE@am__append_4 = -municode
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ac_func_fseeko.m4 \
@@ -6006,7 +6007,8 @@ filters_analyze_la_LIBADD = $(MAGICKCORE_LIBS) $(MATH_LIBS)
 @WITH_UTILITIES_TRUE@  $(UTILITIES_XML_XFAIL_TESTS)
 
 @WITH_UTILITIES_TRUE@utilities_magick_LDADD = $(MAGICKCORE_LIBS) $(MAGICKWAND_LIBS)
-@WITH_UTILITIES_TRUE@utilities_magick_LDFLAGS = $(LDFLAGS)
+@WITH_UTILITIES_TRUE@utilities_magick_LDFLAGS = $(LDFLAGS) \
+@WITH_UTILITIES_TRUE@	$(am__append_4)
 @WITH_UTILITIES_TRUE@utilities_magick_SOURCES = utilities/magick.c
 @WITH_UTILITIES_TRUE@nodist_EXTRA_utilities_magick_SOURCES = dummy.cxx
 @WITH_UTILITIES_FALSE@UTILITIES_MANS = 

--- a/utilities/Makefile.am
+++ b/utilities/Makefile.am
@@ -24,6 +24,11 @@ UTILITIES_XFAIL_TESTS = \
 
 utilities_magick_LDADD    = $(MAGICKCORE_LIBS) $(MAGICKWAND_LIBS)
 utilities_magick_LDFLAGS  = $(LDFLAGS)
+
+if WIN32_NATIVE_BUILD
+utilities_magick_LDFLAGS += -municode
+endif
+
 utilities_magick_SOURCES  = utilities/magick.c
 nodist_EXTRA_utilities_magick_SOURCES = dummy.cxx
 

--- a/utilities/magick.c
+++ b/utilities/magick.c
@@ -176,7 +176,7 @@ static int MagickMain(int argc,char **argv)
   return(exit_code);
 }
 
-#if !defined(MAGICKCORE_WINDOWS_SUPPORT) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if !defined(MAGICKCORE_WINDOWS_SUPPORT) || defined(__CYGWIN__)
 int main(int argc,char **argv)
 {
   return(MagickMain(argc,argv));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This fixes magick.exe with unicode file name. Otherwise the command fails as following:

```
$ magick identify páramo.png
identify: unable to open image 'páramo.png': No such file or directory @ error/blob.c/OpenBlob/3570.
```