### PR TITLE
coders: Enable opening https files in mingw

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -256,9 +256,10 @@ bin_PROGRAMS = $(am__EXEEXT_1)
 TESTS = $(TESTS_TESTS) $(am__EXEEXT_5)
 XFAIL_TESTS = $(am__EXEEXT_6) $(am__EXEEXT_6)
 check_PROGRAMS = $(am__EXEEXT_2) $(am__EXEEXT_4)
-@WIN32_NATIVE_BUILD_TRUE@am__append_1 = -lws2_32
-@MAGICKCORE_ZERO_CONFIGURATION_SUPPORT_TRUE@am__append_2 = MagickCore/threshold-map.h
+@WIN32_NATIVE_BUILD_TRUE@am__append_1 = -lurlmon
+@WIN32_NATIVE_BUILD_TRUE@am__append_2 = -lws2_32
 @MAGICKCORE_ZERO_CONFIGURATION_SUPPORT_TRUE@am__append_3 = MagickCore/threshold-map.h
+@MAGICKCORE_ZERO_CONFIGURATION_SUPPORT_TRUE@am__append_4 = MagickCore/threshold-map.h
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ac_func_fseeko.m4 \
@@ -1827,7 +1828,7 @@ coders_uil_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 @WITH_MODULES_TRUE@am_coders_uil_la_rpath = -rpath $(codersdir)
 coders_url_la_DEPENDENCIES = $(MAGICKCORE_LIBS) $(am__DEPENDENCIES_1) \
 	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) \
-	$(am__DEPENDENCIES_1)
+	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
 am_coders_url_la_OBJECTS = coders/url_la-url.lo
 coders_url_la_OBJECTS = $(am_coders_url_la_OBJECTS)
 coders_url_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
@@ -3546,7 +3547,7 @@ MODULECOMMONCPPFLAGS = $(AM_CPPFLAGS)
 DISTCHECK_CONFIGURE_FLAGS = $(DISTCHECK_CONFIG_FLAGS)
 DISTCLEANFILES = _configs.sed MagickCore/magick-baseconfig.h
 CLEANFILES = $(MAGICKWAND_CLEANFILES) $(MAGICKPP_CLEANFILES) \
-	$(UTILITIES_CLEANFILES) $(TESTS_CLEANFILES) $(am__append_3)
+	$(UTILITIES_CLEANFILES) $(TESTS_CLEANFILES) $(am__append_4)
 
 # Binary scripts
 bin_SCRIPTS = \
@@ -5029,7 +5030,8 @@ coders_uil_la_LIBADD = $(MAGICKCORE_LIBS)
 coders_url_la_SOURCES = coders/url.c
 coders_url_la_CPPFLAGS = $(MAGICK_CODER_CPPFLAGS)
 coders_url_la_LDFLAGS = $(MODULECOMMONFLAGS)
-coders_url_la_LIBADD = $(MAGICKCORE_LIBS) $(XML_LIBS) $(LZMA_LIBS) $(ZLIB_LIBS) $(MATH_LIBS)
+coders_url_la_LIBADD = $(MAGICKCORE_LIBS) $(XML_LIBS) $(LZMA_LIBS) \
+	$(ZLIB_LIBS) $(MATH_LIBS) $(am__append_1)
 
 # UYVY coder module
 coders_uyvy_la_SOURCES = coders/uyvy.c
@@ -5176,11 +5178,11 @@ MAGICKCORE_LIBS = MagickCore/libMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SU
 @WITH_MODULES_FALSE@MagickCore_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_SOURCES = $(MAGICKCORE_BASE_SRCS) $(MAGICKCORE_PLATFORM_SRCS) $(MAGICKCORE_CODER_SRCS) $(MAGICKCORE_FILTER_SRCS)
 @WITH_MODULES_TRUE@MagickCore_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_SOURCES = $(MAGICKCORE_BASE_SRCS) $(MAGICKCORE_PLATFORM_SRCS)
 @WITH_MODULES_FALSE@MagickCore_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_LIBADD =  \
-@WITH_MODULES_FALSE@	$(MAGICK_DEP_LIBS) $(am__append_1)
+@WITH_MODULES_FALSE@	$(MAGICK_DEP_LIBS) $(am__append_2)
 @WITH_MODULES_TRUE@MagickCore_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_LIBADD =  \
-@WITH_MODULES_TRUE@	$(MAGICK_DEP_LIBS) $(am__append_1)
+@WITH_MODULES_TRUE@	$(MAGICK_DEP_LIBS) $(am__append_2)
 nodist_MagickCore_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_SOURCES =  \
-	$(am__append_2)
+	$(am__append_3)
 MagickCore_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBRARY_EXTRA_CPPFLAGS)
 @HAVE_LD_VERSION_SCRIPT_FALSE@MagickCore_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_LDFLAGS_VERSION = -export-symbols-regex ".*"
 @HAVE_LD_VERSION_SCRIPT_TRUE@MagickCore_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_LDFLAGS_VERSION = -Wl,--version-script=$(top_srcdir)/MagickCore/libMagickCore.map

--- a/coders/Makefile.am
+++ b/coders/Makefile.am
@@ -1390,6 +1390,9 @@ coders_url_la_SOURCES      = coders/url.c
 coders_url_la_CPPFLAGS     = $(MAGICK_CODER_CPPFLAGS)
 coders_url_la_LDFLAGS      = $(MODULECOMMONFLAGS)
 coders_url_la_LIBADD       = $(MAGICKCORE_LIBS) $(XML_LIBS) $(LZMA_LIBS) $(ZLIB_LIBS) $(MATH_LIBS)
+if WIN32_NATIVE_BUILD
+coders_url_la_LIBADD += -lurlmon
+endif
 
 # UYVY coder module
 coders_uyvy_la_SOURCES     = coders/uyvy.c

--- a/coders/url.c
+++ b/coders/url.c
@@ -72,8 +72,7 @@
 #  include <libxml/nanohttp.h>
 #endif
 #endif
-#if defined(MAGICKCORE_WINDOWS_SUPPORT) && \
-    !defined(__MINGW32__)
+#if defined(MAGICKCORE_WINDOWS_SUPPORT)
 #  include <urlmon.h>
 #  pragma comment(lib, "urlmon.lib")
 #endif
@@ -155,7 +154,7 @@ static Image *ReadURLImage(const ImageInfo *image_info,ExceptionInfo *exception)
   image=AcquireImage(image_info,exception);
   read_info=CloneImageInfo(image_info);
   SetImageInfoBlob(read_info,(void *) NULL,0);
-#if !defined(MAGICKCORE_WINDOWS_SUPPORT) || defined(__MINGW32__)
+#if !defined(MAGICKCORE_WINDOWS_SUPPORT)
   if (LocaleCompare(read_info->magick,"https") == 0)
     {
       MagickBooleanType
@@ -210,7 +209,7 @@ static Image *ReadURLImage(const ImageInfo *image_info,ExceptionInfo *exception)
   LocaleLower(filename);
   (void) ConcatenateMagickString(filename,image_info->filename,
     MagickPathExtent);
-#if defined(MAGICKCORE_WINDOWS_SUPPORT) && !defined(__MINGW32__)
+#if defined(MAGICKCORE_WINDOWS_SUPPORT)
   (void) fclose(file);
   if (URLDownloadToFile(NULL,filename,read_info->filename,0,NULL) != S_OK)
     {
@@ -319,8 +318,7 @@ ModuleExport size_t RegisterURLImage(void)
     *entry;
 
   entry=AcquireMagickInfo("URL","HTTP","Uniform Resource Locator (http://)");
-#if (defined(MAGICKCORE_WINDOWS_SUPPORT) && \
-    !defined(__MINGW32__)) || \
+#if defined(MAGICKCORE_WINDOWS_SUPPORT) || \
     (defined(MAGICKCORE_XML_DELEGATE) && defined(LIBXML_HTTP_ENABLED))
   entry->decoder=(DecodeImageHandler *) ReadURLImage;
 #endif
@@ -331,8 +329,7 @@ ModuleExport size_t RegisterURLImage(void)
   entry->format_type=ImplicitFormatType;
   (void) RegisterMagickInfo(entry);
   entry=AcquireMagickInfo("URL","FTP","Uniform Resource Locator (ftp://)");
-#if (defined(MAGICKCORE_WINDOWS_SUPPORT) && \
-    !defined(__MINGW32__)) || \
+#if defined(MAGICKCORE_WINDOWS_SUPPORT) || \
     (defined(MAGICKCORE_XML_DELEGATE) && defined(LIBXML_FTP_ENABLED))
   entry->decoder=(DecodeImageHandler *) ReadURLImage;
 #endif


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This feature was enabled for Windows platform but disabled for mingw toolchain in 853b77b21ea750b0223c659b86a3372b1729efc2 commit.

This fixes the following error with magick command in mingw:

```
$ magick identify https://imagemagick.org/image/wizard.png
identify: unable to create temporary file '//imagemagick.org/image/wizard.png': No such file or directory @ error/delegate.c/InvokeDelegate/1867.
```
