### PR TITLE
Chrome, Mozilla, GIMP do not assume sRGB

### DIFF
--- a/coders/png.c
+++ b/coders/png.c
@@ -2920,26 +2920,6 @@ static Image *ReadOnePNGImage(MngInfo *mng_info,
           ping_found_sRGB_cHRM=MagickTrue;
     }
 
-  if (image->rendering_intent != UndefinedIntent)
-    {
-      if (ping_found_sRGB != MagickTrue &&
-          (ping_found_gAMA != MagickTrue ||
-          (image->gamma > .45 && image->gamma < .46)) &&
-          (ping_found_cHRM != MagickTrue ||
-          ping_found_sRGB_cHRM != MagickFalse) &&
-          ping_found_iCCP != MagickTrue)
-      {
-         png_set_sRGB(ping,ping_info,
-            Magick_RenderingIntent_to_PNG_RenderingIntent
-            (image->rendering_intent));
-         file_gamma=0.45455f;
-         ping_found_sRGB=MagickTrue;
-         if (logging != MagickFalse)
-           (void) LogMagickEvent(CoderEvent,GetMagickModule(),
-             "    Setting sRGB as if in input");
-      }
-    }
-
 #if defined(PNG_oFFs_SUPPORTED)
   if (png_get_valid(ping,ping_info,PNG_INFO_oFFs))
     {

--- a/www/defines.html
+++ b/www/defines.html
@@ -1227,8 +1227,8 @@ use:</p>
 
     <p>As a special case, if the <samp>sRGB</samp> chunk is excluded and
     the <samp>gAMA</samp> chunk is included, the <samp>gAMA</samp> chunk will
-    only be written if gamma is not 1/2.2, since most decoders assume
-    sRGB and gamma=1/2.2 when no colorspace information is included in
+    only be written if gamma is not 1/2.2, since most decoders do not assume
+    sRGB for gAMA=0.45455 when no colorspace information is included in
     the PNG file.  Because the list is processed from left to right, you
     can achieve this with a single define:</p>
 


### PR DESCRIPTION
I think it was misworded, 2.2 gAMA should be deleted, cause it is mandatery in the case sRGB chunk is included, but does not mean sRGB if sRGB chunk is absent. It means pure 2.2 gamma. Doc part of #4375.

Reference: PNG spec. about fallback for sRGB chunk.

Photoshop still cannot read any chunks.

GIMP added proper support for chunks per my many questions.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
