### PR TITLE
another approach to fix #5836

### DIFF
--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -489,9 +489,20 @@ static Image *ReadJXLImage(const ImageInfo *image_info,ExceptionInfo *exception)
               CorruptImageError,"Unsupported data type","`%s'",image->filename);
             break;
           }
-        status=ImportImagePixels(image,0,0,image->columns,image->rows,
-          image->alpha_trait == BlendPixelTrait ? "RGBA" : "RGB",type,
-          output_buffer,exception);
+        switch (image->colorspace){
+        case sRGBColorspace:
+        case RGBColorspace:
+          status=ImportImagePixels(image,0,0,image->columns,image->rows,
+            image->alpha_trait == BlendPixelTrait ? "RGBA" : "RGB",type,
+            output_buffer,exception);
+          break;
+        case GRAYColorspace:
+        case LinearGRAYColorspace:
+          status=ImportImagePixels(image,0,0,image->columns,image->rows,
+            image->alpha_trait == BlendPixelTrait ? "IA" : "I",type,
+            output_buffer,exception);
+          break;
+        }
         if (status == MagickFalse)
           jxl_status=JXL_DEC_ERROR;
         break;

--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -469,6 +469,7 @@ static Image *ReadJXLImage(const ImageInfo *image_info,ExceptionInfo *exception)
           output_buffer,extent);
         if (jxl_status == JXL_DEC_SUCCESS)
           jxl_status=JXL_DEC_NEED_IMAGE_OUT_BUFFER;
+        break;
       }
       case JXL_DEC_FULL_IMAGE:
       {

--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -488,14 +488,9 @@ static Image *ReadJXLImage(const ImageInfo *image_info,ExceptionInfo *exception)
               CorruptImageError,"Unsupported data type","`%s'",image->filename);
             break;
           }
-        if (IssRGBCompatibleColorspace(image->colorspace) == MagickFalse)
-          status=ImportImagePixels(image,0,0,image->columns,image->rows,
-            image->alpha_trait == BlendPixelTrait ? "RGBA" : "RGB",type,
-            output_buffer,exception);
-        else
-          status=ImportImagePixels(image,0,0,image->columns,image->rows,
-            image->alpha_trait == BlendPixelTrait ? "IA" : "I",type,
-            output_buffer,exception);
+        status=ImportImagePixels(image,0,0,image->columns,image->rows,
+          image->alpha_trait == BlendPixelTrait ? "RGBA" : "RGB",type,
+          output_buffer,exception);
         if (status == MagickFalse)
           jxl_status=JXL_DEC_ERROR;
         break;


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->

This PR try to fix #5836 
1. add a missing break in switch-case so the `JXL_DEC_FULL_IMAGE` case would not run twice;
2. import pixels according to the colorspace value (the `IssRGBCompatibleColorspace` is not that to detect colorspace is RGB or GRAY).
