### PR TITLE
remove todo, cause cHRM+gAMA is never sRGB

### DIFF
--- a/coders/png.c
+++ b/coders/png.c
@@ -11125,7 +11125,6 @@ static MagickBooleanType WriteOnePNGImage(MngInfo *mng_info,
         {
           /*
             Note image gamma.
-            To do: check for cHRM+gAMA == sRGB, and write sRGB instead.
           */
           if (logging != MagickFalse)
             (void) LogMagickEvent(CoderEvent,GetMagickModule(),
@@ -11142,7 +11141,6 @@ static MagickBooleanType WriteOnePNGImage(MngInfo *mng_info,
             {
               /*
                 Note image chromaticity.
-                Note: if cHRM+gAMA == sRGB write sRGB instead.
               */
                PrimaryInfo
                  bp,


### PR DESCRIPTION
Also looks like unrelated change in 918b9dc4bb00c06632ccc6169ea05a828f7b6fc1.

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
