### PR TITLE
Fix Exif writing for HEIF/JPEG XL

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -856,21 +856,8 @@ static void WriteProfile(struct heif_context *context,Image *image,
     profile=GetImageProfile(image,name);
     length=GetStringInfoLength(profile);
     if (LocaleCompare(name,"EXIF") == 0)
-      {
-        StringInfo *exif_profile = StringToStringInfo("\0\0\0\0");
-        ConcatenateStringInfo(exif_profile,profile);
-        length=GetStringInfoLength(exif_profile);
-        if (length > 65533L)
-          {
-            (void) ThrowMagickException(exception,GetMagickModule(),
-              CoderWarning,"ExifProfileSizeExceedsLimit","`%s'",
-              image->filename);
-            length=65533L;
-          }
-        (void) heif_context_add_exif_metadata(context,image_handle,
-          (void*) GetStringInfoDatum(exif_profile),(int) length);
-        exif_profile=DestroyStringInfo(exif_profile);
-      }
+      (void) heif_context_add_exif_metadata(context,image_handle,
+        (void*) GetStringInfoDatum(profile),(int) length);
     if (LocaleCompare(name,"XMP") == 0)
       for (i=0; i < (ssize_t) GetStringInfoLength(profile); i+=65533L)
       {

--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -955,11 +955,10 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
           (GetStringInfoLength(exif_profile) > 6))
         {
           /*
-            Add Exif profile.
+            Add Exif profile. Assumes "Exif\0\0" JPEG APP1 prefix was added by SetImageProfile().
           */
-          StringInfo *profile = CloneStringInfo(exif_profile);
-          DestroyStringInfo(SplitStringInfo(profile,2));
-          SetStringInfoLength(profile,GetStringInfoLength(profile));
+          StringInfo *profile = StringToStringInfo("\0\0\0\6");
+          ConcatenateStringInfo(profile,exif_profile);
           (void) JxlEncoderAddBox(jxl_info,"Exif",GetStringInfoDatum(profile),
             GetStringInfoLength(profile),0);
           profile=DestroyStringInfo(profile);
@@ -967,7 +966,7 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
       if (xmp_profile != (StringInfo *) NULL)
         {
           /*
-            Add Exif profile.
+            Add XMP profile.
           */
           (void) JxlEncoderAddBox(jxl_info,"xml ",GetStringInfoDatum(
             xmp_profile),GetStringInfoLength(xmp_profile),0);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The HEIF method actually takes care of the offset calculation, and there is no limit on Exif size for HEIFs.

<!-- Thanks for contributing to ImageMagick! -->
