### PR TITLE
Fix for space handling in appimage path

### DIFF
--- a/app-image/AppRun
+++ b/app-image/AppRun
@@ -19,7 +19,7 @@ elif [ "$1" == "info" ] ; then
   export INFOPATH="$HERE/usr/share/info:$INFOPATH" ; exec "$@" ; exit $?
 fi
 
-if [ ! -z $APPIMAGE ] ; then
+if [ -n "$APPIMAGE" ] ; then
   BINARY_NAME=$(basename "$ARGV0")
   if [ -e "$HERE/usr/bin/$BINARY_NAME" ] ; then
     exec "$HERE/usr/bin/$BINARY_NAME" "$@"


### PR DESCRIPTION
The unquoted string in the AppRun yields errors, this happens when the user runs the appimage from within a path that has spaces:

```bash
❯ ./imagemagick co5ipi.png co5ipi.jpg
/tmp/.mount_imagemFIg6MC/AppRun: line 22: [: /home/ruan/test: binary operator expected
❯ pwd
/home/ruan/test folder
```

`[ ! -z $APPIMAGE ]` expands to `[ ! -z /home/ruan/test folder ]`

I also changed `! -z` to `-n`, because `! -z` == `-n`. From the bash manpage:

```
 -z string
        True if the length of string is zero.
 string
 -n string
        True if the length of string is non-zero.

```
