### PR TITLE
Strip EOI marker from Exif payloads in HEIF and JPEG XL

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -80,7 +80,7 @@
 #include <libheif/heif.h>
 #endif
 #endif
-
+
 #if defined(MAGICKCORE_HEIC_DELEGATE)
 /*
   Forward declarations.
@@ -227,6 +227,19 @@ static MagickBooleanType ReadHEICExifProfile(Image *image,
       offset|=(unsigned int) (*(GetStringInfoDatum(snippet)+2)) << 8;
       offset|=(unsigned int) (*(GetStringInfoDatum(snippet)+3)) << 0;
       snippet=DestroyStringInfo(snippet);
+      /*
+        Strip any EOI marker if payload starts with a JPEG marker.
+      */
+      size_t exif_length = GetStringInfoLength(exif_profile);
+      unsigned char *exif_datum = GetStringInfoDatum(exif_profile);
+      if (exif_length > 2 && 
+          (memcmp(exif_datum, "\0xFF\0xD8", 2) == 0 ||
+           memcmp(exif_datum, "\0xFF\0xE1", 2) == 0) &&
+          memcmp(exif_datum+exif_length-2, "\0xFF\0xD9", 2) == 0)
+        SetStringInfoLength(exif_profile, exif_length-2);
+      /*
+        Skip to actual Exif payload.
+      */
       if (offset < GetStringInfoLength(exif_profile))
         {
           (void) DestroyStringInfo(SplitStringInfo(exif_profile,offset));
@@ -636,7 +649,7 @@ static Image *ReadHEICImage(const ImageInfo *image_info,
   return(GetFirstImageInList(image));
 }
 #endif
-
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -676,7 +689,7 @@ static MagickBooleanType IsHEIC(const unsigned char *magick,const size_t length)
 #endif
   return(MagickFalse);
 }
-
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -756,7 +769,7 @@ ModuleExport size_t RegisterHEICImage(void)
 #endif
   return(MagickImageCoderSignature);
 }
-
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -789,7 +802,7 @@ ModuleExport void UnregisterHEICImage(void)
 #endif
 #endif
 }
-
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %

--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -34,7 +34,7 @@
 %
 %
 */
-
+
 /*
   Include declarations.
 */
@@ -77,14 +77,14 @@ typedef struct MemoryManagerInfo
   ExceptionInfo
     *exception;
 } MemoryManagerInfo;
-
+
 #if defined(MAGICKCORE_JXL_DELEGATE)
 /*
   Forward declarations.
 */
 static MagickBooleanType
   WriteJXLImage(const ImageInfo *,Image *,ExceptionInfo *);
-
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -119,7 +119,7 @@ static MagickBooleanType IsJXL(const unsigned char *magick,const size_t length)
     return(MagickFalse);
   return(MagickTrue);
 }
-
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -620,6 +620,19 @@ static Image *ReadJXLImage(const ImageInfo *image_info,ExceptionInfo *exception)
       offset|=(unsigned int) (*(GetStringInfoDatum(snippet)+2)) << 8;
       offset|=(unsigned int) (*(GetStringInfoDatum(snippet)+3)) << 0;
       snippet=DestroyStringInfo(snippet);
+      /*
+        Strip any EOI marker if payload starts with a JPEG marker.
+      */
+      size_t exif_length = GetStringInfoLength(exif_profile);
+      unsigned char *exif_datum = GetStringInfoDatum(exif_profile);
+      if (exif_length > 2 && 
+          (memcmp(exif_datum, "\0xFF\0xD8", 2) == 0 ||
+           memcmp(exif_datum, "\0xFF\0xE1", 2) == 0) &&
+          memcmp(exif_datum+exif_length-2, "\0xFF\0xD9", 2) == 0)
+        SetStringInfoLength(exif_profile, exif_length-2);
+      /*
+        Skip to actual Exif payload.
+      */
       if (offset < GetStringInfoLength(exif_profile))
         (void) DestroyStringInfo(SplitStringInfo(exif_profile,
           offset));
@@ -645,7 +658,7 @@ static Image *ReadJXLImage(const ImageInfo *image_info,ExceptionInfo *exception)
   return(GetFirstImageInList(image));
 }
 #endif
-
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -695,7 +708,7 @@ ModuleExport size_t RegisterJXLImage(void)
   (void) RegisterMagickInfo(entry);
   return(MagickImageCoderSignature);
 }
-
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -719,7 +732,7 @@ ModuleExport void UnregisterJXLImage(void)
 {
   (void) UnregisterMagickInfo("JXL");
 }
-
+
 #if defined(MAGICKCORE_JXL_DELEGATE)
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Strips the superfluous JPEG EOI marker (0xFFD9) from Exif payloads in HEIC and JPEG XL images, like the [one here](https://github.com/ImageMagick/ImageMagick/issues/5604#issuecomment-1263216119) that includes the entire JPEG APP1 segment + EOI marker.