### PR TITLE
add `BC5_UNORM` compression support

### DIFF
--- a/coders/dds.c
+++ b/coders/dds.c
@@ -2843,7 +2843,7 @@ static Image *ReadDDSImage(const ImageInfo *image_info,ExceptionInfo *exception)
             case DXGI_FORMAT_BC5_UNORM:
             {
               alpha_trait = BlendPixelTrait;
-              compression = BC7Compression;
+              compression = NoCompression;
               decoder = ReadBC5;
               break;
             }

--- a/coders/dds.c
+++ b/coders/dds.c
@@ -2306,7 +2306,7 @@ static MagickBooleanType ReadBC5Pixels(Image *image,
       }
       if (mode == 4) {
         colors.r[6] = 0;
-        colors.r[7] = 0;
+        colors.r[7] = 255;
       }
 
       /* Green palette */
@@ -2321,7 +2321,7 @@ static MagickBooleanType ReadBC5Pixels(Image *image,
       }
       if (mode == 4) {
         colors.g[6] = 0;
-        colors.g[7] = 0;
+        colors.g[7] = 255;
       }
 
       /* Write the pixels */


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Add support for `BC5_UNORM` compression for DDS files

Description of the compression: https://learn.microsoft.com/en-gb/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#bc5
Test file: http://momtchil.momtchev.com/texture.dds.gz
Issue: #5919 

<!-- Thanks for contributing to ImageMagick! -->
