### PR TITLE
Add HEIF to appimage

### DIFF
--- a/.github/workflows/app-image.yml
+++ b/.github/workflows/app-image.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         set -e
         apt-get update -y
-        apt-get install -y autoconf curl fuse git kmod libbz2-dev libdjvulibre-dev libfontconfig-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev liblcms-dev libopenexr-dev libturbojpeg0-dev liblqr-dev libraqm-dev libtiff-dev libwebp-dev libx11-dev libxml2-dev liblzma-dev software-properties-common wget
+        apt-get install -y autoconf curl fuse git kmod libbz2-dev libdjvulibre-dev libfontconfig-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libheif-dev liblcms-dev libopenexr-dev libturbojpeg0-dev liblqr-dev libraqm-dev libtiff-dev libwebp-dev libx11-dev libxml2-dev liblzma-dev software-properties-common wget
         add-apt-repository ppa:git-core/ppa -y
         apt-get install -y git
 


### PR DESCRIPTION
### Prerequisites

- [ X ] I have written a descriptive pull-request title
- [ X ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ X ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
I would love an portable version of ImageMagick with HEIF support. I don't know much about app-images and make files, but it seems to me that this is a very small change, since the ./configure script will build ImageMagick with HEIF support if the dependency is installed.

I have seen there is another PR that aims to add this feature, but it seems stale.

Sorry if I am mistaken and this little change is not enough to make this work.