### PR TITLE
Remove fix for BeOS r4 which breaks gcc build with external toolchain

### DIFF
--- a/config/ltmain.sh
+++ b/config/ltmain.sh
@@ -5731,10 +5731,6 @@ func_exec_program ()
     # Add our own library path to $shlibpath_var
     $shlibpath_var=\"$temp_rpath\$$shlibpath_var\"
 
-    # Some systems cannot cope with colon-terminated $shlibpath_var
-    # The second colon is a workaround for a bug in BeOS R4 sed
-    $shlibpath_var=\`\$ECHO \"\$$shlibpath_var\" | $SED 's/::*\$//'\`
-
     export $shlibpath_var
 "
 	fi


### PR DESCRIPTION
Hi all, 

This piece of code seems obsolete as it fixed something in BeOS R4 (which is from 1998). However it breaks the tests if the project is build with exteranl toolchain (not the one that comes from the Linux distribution). As LD_LIBRARY_PATH is already set (couple of lines above), $SED (sed) loads different glibc causing it to core. This leaves LD_LIBRARY_PATH *NOT* properly set and once the test are run (with make check) libmagic is unable to find external dependencies like bzip2, zlib etc. 

As I saw that $SED is used after as well it may potentially core at some other places (which however didn't happen in my build as it seems it didn't pass from that part of the code). This wouldn't happen of course if sed is completely statically build.

Thanks

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
