### PR TITLE
PixelChannel: Add field for invalid Channel

### DIFF
--- a/MagickCore/pixel.h
+++ b/MagickCore/pixel.h
@@ -94,7 +94,8 @@ typedef enum
   MetaPixelChannels = 10,
   IntensityPixelChannel = MaxPixelChannels,  /* ???? */
   CompositePixelChannel = MaxPixelChannels,  /* ???? */
-  SyncPixelChannel = MaxPixelChannels+1      /* not a real channel */
+  SyncPixelChannel = MaxPixelChannels+1,     /* not a real channel */
+  InvalidChannel = -1
 } PixelChannel;  /* must correspond to ChannelType */
 
 typedef enum


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The current code in `pixel-accessor.h` gives a compile warnings:
```
/usr/include/ImageMagick-7/MagickCore/pixel-accessor.h:135:26: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  135 |   if (((ssize_t) channel < 0) || ((ssize_t) channel >= MaxPixelChannels))
```
making the header impossible to include, when using `-Werror`.

The warning is thrown, because the enum `PixelChannel` only has unsigned values. I therefore removed the unnecessary checks.