### PR TITLE
Add Canon Raw v3 (CR3) as mime type

### DIFF
--- a/coders/dng.h
+++ b/coders/dng.h
@@ -19,6 +19,7 @@
 #define MagickDNGHeaders \
   MagickCoderHeader("CR2", 0, "\115\115\000\052\000\020\000\000\122\103\002") \
   MagickCoderHeader("CR2", 0, "\111\111\052\000\020\000\000\000\103\122\002") \
+  MagickCoderHeader("CR3", 4, "ftypcrx ") \
   MagickCoderHeader("CRW", 0, "II\x1a\x00\x00\x00HEAPCCDR") \
   MagickCoderHeader("ORF", 0, "IIRO\x08\x00\x00\x00") \
   MagickCoderHeader("MRW", 0, "\x00MRM") \

--- a/config/mime.xml
+++ b/config/mime.xml
@@ -764,6 +764,8 @@
   <mime type="image/x-canon-crw" description="Canon RaW" data-type="string" offset="0" magic="II\x1a\x00\x00\x00HEAPCCDR" priority="50" />
   <mime type="image/x-canon-crw" acronym="CRW" description="Canon RaW" priority="100" pattern="*.crw" />
   <mime type="image/x-canon-cr2" acronym="CR2" description="Canon Raw 2" priority="100" pattern="*.cr2" />
+  <mime type="image/x-canon-cr3" description="Canon Raw 3" data-type="string" offset="4" magic="ftypcrx " priority="50" />
+  <mime type="image/x-canon-cr3" acronym="CR3" description="Canon Raw 3" priority="100" pattern="*.cr3" />
   <mime type="image/x-fuji-raf" description="RAw Format" data-type="string" offset="0" magic="FUJIFILMCCD-RAW " priority="50" />
   <mime type="image/x-fuji-raf" acronym="RAF" description="RAw Format" priority="100" pattern="*.raf" />
   <mime type="image/x-kodak-dcr" acronym="DCR" description="Digital Camera Raw" priority="100" pattern="*.dcr" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
This image format uses ISOBMFF as container with `crx ` as compatible brand.
