### PR TITLE
Define quantum depth for PerlMagick on windows

### DIFF
--- a/PerlMagick/Makefile.PL.in
+++ b/PerlMagick/Makefile.PL.in
@@ -173,7 +173,7 @@ if (($^O eq 'MSWin32') && ($Config{cc} =~ /gcc/)) {
   #
   # Setup for strawberry perl.
   #
-  $INC_magick       = "$Ipaths";
+  $INC_magick       = "$Ipaths @CPPFLAGS@";
   $LIBS_magick      = "-lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@";
   $CCFLAGS_magick   = "$Config{'ccflags'}";
   $LDFLAGS_magick   = "$Config{'ldflags'} $Lpaths ";

--- a/PerlMagick/default/Makefile.PL.in
+++ b/PerlMagick/default/Makefile.PL.in
@@ -173,7 +173,7 @@ if (($^O eq 'MSWin32') && ($Config{cc} =~ /gcc/)) {
   #
   # Setup for strawberry perl.
   #
-  $INC_magick       = "$Ipaths";
+  $INC_magick       = "$Ipaths @CPPFLAGS@";
   $LIBS_magick      = "-lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@";
   $CCFLAGS_magick   = "$Config{'ccflags'}";
   $LDFLAGS_magick   = "$Config{'ldflags'} $Lpaths ";

--- a/PerlMagick/quantum/Makefile.PL.in
+++ b/PerlMagick/quantum/Makefile.PL.in
@@ -173,7 +173,7 @@ if (($^O eq 'MSWin32') && ($Config{cc} =~ /gcc/)) {
   #
   # Setup for strawberry perl.
   #
-  $INC_magick       = "$Ipaths";
+  $INC_magick       = "$Ipaths @CPPFLAGS@";
   $LIBS_magick      = "-lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@";
   $CCFLAGS_magick   = "$Config{'ccflags'}";
   $LDFLAGS_magick   = "$Config{'ldflags'} $Lpaths ";


### PR DESCRIPTION
Make `MAGICKCORE_QUANTUM_DEPTH` defined when compiling PerlMagick on Windows.

See https://github.com/StrawberryPerl/Perl-Dist-Strawberry/issues/139 for background.