### PR TITLE
honor pkg-config when searching for libjpeg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2498,7 +2498,7 @@ if test "$with_jpeg" != 'no'; then
     fi
 fi
 AM_CONDITIONAL([JPEG_DELEGATE],[test "$have_jpeg" = 'yes'])
-AC_SUBST([JPEG_FLAGS])
+AC_SUBST([JPEG_CFLAGS])
 AC_SUBST([JPEG_LIBS])
 
 dnl ===========================================================================

--- a/configure.ac
+++ b/configure.ac
@@ -2470,6 +2470,11 @@ if test "$with_jpeg" != 'no'; then
     AC_MSG_RESULT([])
     failed=0
     passed=0
+
+    PKG_CHECK_MODULES([JPEG],[libjpeg >= 2.0.0],[have_jpeg=yes],[have_jpeg=no])
+    CFLAGS="$CFLAGS $JPEG_CFLAGS"
+    LIBS="$LIBS $JPEG_LIBS"
+
     AC_CHECK_HEADER([jconfig.h],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`])
     AC_CHECK_HEADER([jerror.h],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`])
     AC_CHECK_HEADER([jmorecfg.h],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`])
@@ -2493,6 +2498,7 @@ if test "$with_jpeg" != 'no'; then
     fi
 fi
 AM_CONDITIONAL([JPEG_DELEGATE],[test "$have_jpeg" = 'yes'])
+AC_SUBST([JPEG_FLAGS])
 AC_SUBST([JPEG_LIBS])
 
 dnl ===========================================================================


### PR DESCRIPTION
### Prerequisites

- [x ] I have written a descriptive pull-request title
- [x ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Honor pkg-config when searching for libjpeg. If there is no pkg-config, the old direct detection method is used.