### PR TITLE
honor pkg-config when searching for bzip2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1528,6 +1528,11 @@ if test "$with_bzlib" != 'no'; then
   failed=0
   passed=0
   found_libbz=0
+
+  PKG_CHECK_MODULES([BZLIB],[bzip2 >= 1.0.0],[have_bzlib=yes],[have_bzlib=no])
+  CFLAGS="$CFLAGS $BZLIB_CFLAGS"
+  LIBS="$LIBS $BZLIB_LIBS"
+
   AC_CHECK_HEADER([bzlib.h],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`])
   AC_CHECK_LIB([bz2],[BZ2_bzDecompress],[found_libbz=`expr $found_libbz + 1`],,)
   if test "$native_win32_build" = 'yes'; then
@@ -1556,6 +1561,7 @@ if test "$with_bzlib" != 'no'; then
 fi
 AM_CONDITIONAL([BZLIB_DELEGATE],[test "$have_bzlib" = 'yes'])
 AC_SUBST([BZLIB_LIBS])
+AC_SUBST([BZLIB_CFLAGS])
 
 #
 # Find the X11 include and library directories.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Honor pkg-config when searching for bzip2. If no pkg-config is found, use the old direct detection method. 