### PR TITLE
Fix zstd not being listed under GetMagickDelegates()

### DIFF
--- a/MagickCore/version.c
+++ b/MagickCore/version.c
@@ -214,7 +214,10 @@ MagickExport const char *GetMagickDelegates(void)
   "zip "
 #endif
 #if defined(MAGICKCORE_ZLIB_DELEGATE)
-  "zlib"
+  "zlib "
+#endif
+#if defined(MAGICKCORE_ZSTD_DELEGATE)
+  "zstd"
 #endif
   ;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

It is the only delegate missing from that list, as far as I can tell.

