### PR TITLE
opencl.c: replace lt_dlclose() with dlclose() / FreeLibrary()

### DIFF
--- a/MagickCore/opencl.c
+++ b/MagickCore/opencl.c
@@ -90,9 +90,6 @@
 #include "MagickCore/utility-private.h"
 
 #if defined(MAGICKCORE_OPENCL_SUPPORT)
-#if defined(MAGICKCORE_LTDL_DELEGATE)
-#include "ltdl.h"
-#endif
 
 #ifndef MAGICKCORE_WINDOWS_SUPPORT
 #include <dlfcn.h>
@@ -2599,7 +2596,11 @@ MagickPrivate void OpenCLTerminus()
   if (openCL_library != (MagickLibrary *) NULL)
     {
       if (openCL_library->library != (void *) NULL)
-        (void) lt_dlclose(openCL_library->library);
+#ifdef MAGICKCORE_WINDOWS_SUPPORT
+        (void) FreeLibrary((HMODULE)openCL_library->library);
+#else
+        (void) dlclose(openCL_library->library);
+#endif
       openCL_library=(MagickLibrary *) RelinquishMagickMemory(openCL_library);
     }
 }
@@ -2759,7 +2760,7 @@ MagickPrivate MagickBooleanType RecordProfileData(MagickCLDevice device,
       return(MagickTrue);
     }
   start/=1000; /* usecs */
-  end/=1000;   
+  end/=1000;
   elapsed=end-start;
   LockSemaphoreInfo(device->lock);
   i=0;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
`opencl.c` makes use of the OpenCL runtime library and opens it using `dlopen()` / `LoadLibraryA()`:
https://github.com/ImageMagick/ImageMagick/blob/54b13e91d262b1083e27fc8c02532c89d3ff649c/MagickCore/opencl.c#L2495-L2499
but closes it using `lt_dlclose()`:
https://github.com/ImageMagick/ImageMagick/blob/54b13e91d262b1083e27fc8c02532c89d3ff649c/MagickCore/opencl.c#L2601-L2603

I wonder if there's a particular reason the libtool version of the `dlclose()` function is being used? Eliminating the libtool dependency simplifies Windows builds of ImageMagick quite a bit.