### PR TITLE
Add Canon Raw v2 (CR2) as mime type

### DIFF
--- a/coders/dng.h
+++ b/coders/dng.h
@@ -17,8 +17,8 @@
 #include "coders/coders-private.h"
 
 #define MagickDNGHeaders \
-  MagickCoderHeader("CR2", 0, "\115\115\000\052\000\020\000\000\122\103\002") \
-  MagickCoderHeader("CR2", 0, "\111\111\052\000\020\000\000\000\103\122\002") \
+  MagickCoderHeader("CR2", 0, "MM\x00\x2a\x00\x10\x00\x00RC\x02") \
+  MagickCoderHeader("CR2", 0, "II\x2a\x00\x10\x00\x00\x00CR\x02") \
   MagickCoderHeader("CR3", 4, "ftypcrx ") \
   MagickCoderHeader("CRW", 0, "II\x1a\x00\x00\x00HEAPCCDR") \
   MagickCoderHeader("ORF", 0, "IIRO\x08\x00\x00\x00") \

--- a/config/mime.xml
+++ b/config/mime.xml
@@ -763,6 +763,8 @@
   <mime type="image/x-adobe-dng" acronym="DNG" description="Digital Negative" priority="100" pattern="*.dng" />
   <mime type="image/x-canon-crw" description="Canon RaW" data-type="string" offset="0" magic="II\x1a\x00\x00\x00HEAPCCDR" priority="50" />
   <mime type="image/x-canon-crw" acronym="CRW" description="Canon RaW" priority="100" pattern="*.crw" />
+  <mime type="image/x-canon-cr2" description="Canon Raw 2" data-type="string" offset="0" magic="MM\x00\x2a\x00\x10\x00\x00RC\x02" priority="50" />
+  <mime type="image/x-canon-cr2" description="Canon Raw 2" data-type="string" offset="0" magic="II\x2a\x00\x10\x00\x00\x00CR\x02" priority="50" />
   <mime type="image/x-canon-cr2" acronym="CR2" description="Canon Raw 2" priority="100" pattern="*.cr2" />
   <mime type="image/x-canon-cr3" description="Canon Raw 3" data-type="string" offset="4" magic="ftypcrx " priority="50" />
   <mime type="image/x-canon-cr3" acronym="CR3" description="Canon Raw 3" priority="100" pattern="*.cr3" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
It appears that commit cc5af50a6348a88321eb4af20c581b79282cc1d6 only introduced Canon RAW v2 format in the header, but omitted its inclusion in `mime.xml`. I'm not sure if this was intentional, but if not, this PR corrects it. 

Additionally, let's represent the magic signature in hexadecimal format while making these changes.