### PR TITLE
configure.ac: fixup LFS check for autoconf-2.72

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -503,7 +503,8 @@ if test "$enable_largefile" != no; then
     unknown)
         AC_MSG_CHECKING([for native large file support])
         AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <unistd.h>
-          main () {
+          #include <stdlib.h>
+          int main () {
           exit(!(sizeof(off_t) == 8));
         }])],
         [ac_cv_sys_file_offset_bits=64; AC_DEFINE(_FILE_OFFSET_BITS,64)
@@ -511,6 +512,9 @@ if test "$enable_largefile" != no; then
         [AC_MSG_RESULT([no])])
         ;;
     *)
+        if test "$ac_cv_sys_file_offset_bits" = ''; then
+            ac_cv_sys_file_offset_bits=64;
+        fi
         LFS_CPPFLAGS="$LFS_CPPFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
         ;;
     esac


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

There are two problems with the check:
1) The 'unknown' case has a problem which is rejected by stricter C compilers because it has -Wimplicit-int and -Wimplicit-function-declaration warnings. Fix that.

2) For the 'other' case, we were using the value of ac_cv_sys_file_offset_bits for -D_FILE_OFFSET_BITS to pass down into the Perl module build, but autoconf-2.72 drops the use of ac_cv_sys_file_offset_bits in cf09f48841b66fe76f606dd6018bb3a93242a7c9, so this ends up defining '-D_FILE_OFFSET_BITS=' which then breaks the build.

I've added a hack for 2) to preserve the old behavior.