### PR TITLE
When writing BMP to v3 or lower, ignore the ICC profile.

### DIFF
--- a/coders/bmp.c
+++ b/coders/bmp.c
@@ -2016,7 +2016,10 @@ static MagickBooleanType WriteBMPImage(const ImageInfo *image_info,Image *image,
       }
     bytes_per_line=4*((image->columns*bmp_info.bits_per_pixel+31)/32);
     bmp_info.ba_offset=0;
-    profile=GetImageProfile(image,"icc");
+    if (type <= 3)
+      profile=(StringInfo *) NULL;
+    else
+      profile=GetImageProfile(image,"icc");
     have_color_info=(image->rendering_intent != UndefinedIntent) ||
       (profile != (StringInfo *) NULL) || (image->gamma != 0.0) ?  MagickTrue :
       MagickFalse;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

If writing a BMP file as v3 or earlier, have the ICC profile ignored.

Currently, when ImageMagick outputs a BMP file, it embeds the ICC profile regardless of the BMP version, but BMP v2, v3, and v4 do not support ICC profiles, which increases data unnecessarily and is considered harmful.

When BMP v2 and v3 are specified, ICC profiles are not supported and should not be embedded.

ImageMagick cannot explicitly specify v5 and is included in v4, so if v4 is specified and there is an ICC profile, I would like to maintain the current method of interpreting it as v5.

This is a bug caused by my lack of attention. sorry.

```
$ identify  sRGB.icc
sRGB.icc ICC 1x1 1x1+0+0 16-bit sRGB 3212B 0.000u 0:00.000
$  # HEAD:main ImageMagick
$ magick rose: -profile sRGB.icc rose1.bmp 
$ magick rose: -profile sRGB.icc BMP3:rose2.bmp
$  # coders/bmp.c modified ImageMagick
$ ~/ImageMagick/yoya/bin/magick rose: -profile sRGB.icc rose3.bmp 
$ ~/ImageMagick/yoya/bin/magick rose: -profile sRGB.icc BMP3:rose4.bmp 
$ identify  *.bmp
rose1.bmp BMP 70x46 70x46+0+0 8-bit sRGB 13102B 0.000u 0:00.000
rose2.bmp BMP3 70x46 70x46+0+0 8-bit sRGB 13018B 0.000u 0:00.000
rose3.bmp BMP 70x46 70x46+0+0 8-bit sRGB 13102B 0.000u 0:00.000
rose4.bmp BMP3 70x46 70x46+0+0 8-bit sRGB 9806B 0.000u 0:00.000
```

<!-- Thanks for contributing to ImageMagick! -->
