### PR TITLE
Make Magick++-config work from non-standard places

### DIFF
--- a/Magick++/bin/Magick++-config.in
+++ b/Magick++/bin/Magick++-config.in
@@ -7,6 +7,7 @@
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
+export PKG_CONFIG_LIBDIR="${exec_prefix}/lib/pkgconfig"
 
 usage='Usage: Magick++-config [--cppflags] [--cxxflags] [--exec-prefix] [--ldflags] [--libs] [--prefix] [--version]
 

--- a/MagickCore/MagickCore-config.in
+++ b/MagickCore/MagickCore-config.in
@@ -6,6 +6,7 @@
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
+export PKG_CONFIG_LIBDIR="${exec_prefix}/lib/pkgconfig"
 
 usage="\
 Usage: MagickCore-config [--cflags] [--cppflags] [--exec-prefix] [--ldflags] [--libs] [--prefix] [--version]"

--- a/MagickWand/MagickWand-config.in
+++ b/MagickWand/MagickWand-config.in
@@ -6,6 +6,7 @@
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
+export PKG_CONFIG_LIBDIR="${exec_prefix}/lib/pkgconfig"
 
 usage="\
 Usage: MagickWand-config [--cflags] [--cppflags] [--exec-prefix] [--ldflags] [--libs] [--prefix] [--version]"


### PR DESCRIPTION
When the .pc file is installed in a location not searched by pkg-config by default, Magick++-config failed.

Fixes #7007
