### PR TITLE
fix PKG_CONFIG_LIBDIR

### DIFF
--- a/Magick++/bin/Magick++-config.in
+++ b/Magick++/bin/Magick++-config.in
@@ -7,7 +7,9 @@
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-export PKG_CONFIG_LIBDIR="${exec_prefix}/lib/pkgconfig"
+libdir=@libdir@
+pkgconfigdir=@pkgconfigdir@
+export PKG_CONFIG_LIBDIR="${pkgconfigdir}"
 
 usage='Usage: Magick++-config [--cppflags] [--cxxflags] [--exec-prefix] [--ldflags] [--libs] [--prefix] [--version]
 

--- a/MagickCore/MagickCore-config.in
+++ b/MagickCore/MagickCore-config.in
@@ -6,7 +6,9 @@
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-export PKG_CONFIG_LIBDIR="${exec_prefix}/lib/pkgconfig"
+libdir=@libdir@
+pkgconfigdir=@pkgconfigdir@
+export PKG_CONFIG_LIBDIR="${pkgconfigdir}"
 
 usage="\
 Usage: MagickCore-config [--cflags] [--cppflags] [--exec-prefix] [--ldflags] [--libs] [--prefix] [--version]"

--- a/MagickWand/MagickWand-config.in
+++ b/MagickWand/MagickWand-config.in
@@ -6,7 +6,9 @@
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-export PKG_CONFIG_LIBDIR="${exec_prefix}/lib/pkgconfig"
+libdir=@libdir@
+pkgconfigdir=@pkgconfigdir@
+export PKG_CONFIG_LIBDIR="${pkgconfigdir}"
 
 usage="\
 Usage: MagickWand-config [--cflags] [--cppflags] [--exec-prefix] [--ldflags] [--libs] [--prefix] [--version]"


### PR DESCRIPTION
broken by PR #7008 for distro not using `lib`, but `lib64` 


