### PR TITLE
Fix leak when throwing in `Magick::Color` ctor

### DIFF
--- a/Magick++/lib/Color.cpp
+++ b/Magick++/lib/Color.cpp
@@ -239,7 +239,12 @@ const Magick::Color& Magick::Color::operator=(const std::string &color_)
       setPixelType(target_color);
     }
   else
-    _isValid = false;
+    {
+      _isValid = false;
+      _pixelOwn = false;
+      delete _pixel;
+      _pixel = nullptr;
+    }
   ThrowPPException(false);
 
   return(*this);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Fix #7066 

This the minimal fix. It is not clear if an assignment should invalidate the target when throwing, but here this is already the case anyway.

The right solution would be to complete eliminate all forms of a constructor initializing a member pointer with `new` (there are many cases in `Color`, and a few more elsewhere) - either by replacing `_pixel` with a member variable or with a smart pointer (this is the official current C++ guidelines: https://isocpp.org/wiki/faq/exceptions#selfcleaning-members ). As both require very extensive changes, I prefer to submit a very small patch.