### PR TITLE
fix misleading comment in dds.c

### DIFF
--- a/coders/dds.c
+++ b/coders/dds.c
@@ -1417,7 +1417,7 @@ static MagickBooleanType ReadMipmaps(const ImageInfo *image_info,Image *image,
     status;
 
   /*
-    Only skip mipmaps for textures and cube maps
+    Only read mipmaps for textures and cube maps
   */
   if (EOFBlob(image) != MagickFalse)
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
comment was apparently copypasted from similar `SkipDXTMipmaps()` func
