### PR TITLE
Add heic:chroma-downsampling-algorithm define for HEIC format images.

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -347,6 +347,11 @@ static MagickBooleanType ReadHEICImageHandle(const ImageInfo *image_info,
   struct heif_image
     *heif_image;
 
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,16,0)
+  const char
+    *option;
+#endif
+
   /*
     Read HEIC image from container.
   */
@@ -376,6 +381,28 @@ static MagickBooleanType ReadHEICImageHandle(const ImageInfo *image_info,
   if (status == MagickFalse)
     return(MagickFalse);
   decode_options=heif_decoding_options_alloc();
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,16,0)
+  option=GetImageOption(image_info,"heic:chroma-upsampling");
+  if (option != (char *) NULL)
+    {
+      if (LocaleCompare(option,"nearest-neighbor") == 0)
+        {
+          decode_options->color_conversion_options.
+            preferred_chroma_upsampling_algorithm =
+              heif_chroma_upsampling_nearest_neighbor;
+          decode_options->color_conversion_options.
+            only_use_preferred_chroma_algorithm = 1;
+        }
+      if (LocaleCompare(option,"bilinear") == 0)
+        {
+          decode_options->color_conversion_options.
+            preferred_chroma_upsampling_algorithm =
+              heif_chroma_upsampling_bilinear;
+          decode_options->color_conversion_options.
+            only_use_preferred_chroma_algorithm = 1;
+        }
+    }
+#endif
   if (preserve_orientation != MagickFalse)
     decode_options->ignore_transformations=1;
   chroma=heif_chroma_interleaved_RGB;
@@ -763,7 +790,7 @@ ModuleExport size_t RegisterHEICImage(void)
   entry->flags|=CoderDecoderSeekableStreamFlag;
   entry->flags^=CoderBlobSupportFlag;
   (void) RegisterMagickInfo(entry);
-#if LIBHEIF_NUMERIC_VERSION > HEIC_COMPUTE_NUMERIC_VERSION(1,6,2) 
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,7,0)
   entry=AcquireMagickInfo("HEIC","AVIF","AV1 Image File Format");
 #if defined(MAGICKCORE_HEIC_DELEGATE)
   if (heif_have_decoder_for_format(heif_compression_AV1))
@@ -804,7 +831,7 @@ ModuleExport size_t RegisterHEICImage(void)
 */
 ModuleExport void UnregisterHEICImage(void)
 {
-#if LIBHEIF_NUMERIC_VERSION > HEIC_COMPUTE_NUMERIC_VERSION(1,6,2)
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,7,0)
   (void) UnregisterMagickInfo("AVIF");
 #endif
   (void) UnregisterMagickInfo("HEIC");
@@ -1176,7 +1203,7 @@ static MagickBooleanType WriteHEICImage(const ImageInfo *image_info,
   Image *image,ExceptionInfo *exception)
 {
   MagickBooleanType
-#if LIBHEIF_NUMERIC_VERSION > HEIC_COMPUTE_NUMERIC_VERSION(1,6,2)
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,7,0)
     encode_avif,
 #endif
     status;
@@ -1210,7 +1237,7 @@ static MagickBooleanType WriteHEICImage(const ImageInfo *image_info,
     return(status);
   scene=0;
   heif_context=heif_context_alloc();
-#if LIBHEIF_NUMERIC_VERSION > HEIC_COMPUTE_NUMERIC_VERSION(1,6,2)
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,7,0)
   encode_avif=(LocaleCompare(image_info->magick,"AVIF") == 0) ? MagickTrue :
     MagickFalse;
 #endif
@@ -1228,13 +1255,16 @@ static MagickBooleanType WriteHEICImage(const ImageInfo *image_info,
     MagickBooleanType
       lossless = image_info->quality >= 100 ? MagickTrue : MagickFalse;
 
+    const char
+      *option;
+
     struct heif_encoding_options
       *options;
 
     /*
       Get encoder for the specified format.
     */
-#if LIBHEIF_NUMERIC_VERSION > HEIC_COMPUTE_NUMERIC_VERSION(1,6,2)
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,7,0)
     if (encode_avif != MagickFalse)
       error=heif_context_get_encoder_for_format(heif_context,
         heif_compression_AV1,&heif_encoder);
@@ -1309,12 +1339,9 @@ static MagickBooleanType WriteHEICImage(const ImageInfo *image_info,
     status=IsHEIFSuccess(image,&error,exception);
     if (status == MagickFalse)
       break;
-#if LIBHEIF_NUMERIC_VERSION > HEIC_COMPUTE_NUMERIC_VERSION(1,6,2)
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,7,0)
     if (encode_avif != MagickFalse)
       {
-        const char
-          *option;
-
         option=GetImageOption(image_info,"heic:speed");
         if (option != (char *) NULL)
           {
@@ -1323,17 +1350,47 @@ static MagickBooleanType WriteHEICImage(const ImageInfo *image_info,
             if (status == MagickFalse)
               break;
           }
-        option=GetImageOption(image_info,"heic:chroma");
-        if (option != (char *) NULL)
+      }
+#endif
+    option=GetImageOption(image_info,"heic:chroma");
+    if (option != (char *) NULL)
+      {
+        error=heif_encoder_set_parameter(heif_encoder,"chroma",option);
+        status=IsHEIFSuccess(image,&error,exception);
+        if (status == MagickFalse)
+          break;
+      }
+    options=heif_encoding_options_alloc();
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,16,0)
+    option=GetImageOption(image_info,"heic:chroma-downsampling");
+    if (option != (char *) NULL)
+      {
+        if (LocaleCompare(option,"nearest-neighbor") == 0)
           {
-            error=heif_encoder_set_parameter(heif_encoder,"chroma",option);
-            status=IsHEIFSuccess(image,&error,exception);
-            if (status == MagickFalse)
-              break;
+            options->color_conversion_options.
+              preferred_chroma_downsampling_algorithm =
+                heif_chroma_downsampling_nearest_neighbor;
+            options->color_conversion_options.
+              only_use_preferred_chroma_algorithm = 1;
+          }
+        if (LocaleCompare(option,"average") == 0)
+          {
+            options->color_conversion_options.
+              preferred_chroma_downsampling_algorithm =
+                heif_chroma_downsampling_average;
+            options->color_conversion_options.
+              only_use_preferred_chroma_algorithm = 1;
+          }
+        if (LocaleCompare(option,"sharp-yuv") == 0)
+          {
+            options->color_conversion_options.
+              preferred_chroma_downsampling_algorithm =
+                heif_chroma_downsampling_sharp_yuv;
+            options->color_conversion_options.
+              only_use_preferred_chroma_algorithm = 1;
           }
       }
 #endif
-    options=heif_encoding_options_alloc();
 #if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,14,0)
     if (image->orientation != UndefinedOrientation)
       options->image_orientation=(enum heif_orientation) image->orientation;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
This change exposes the options made available by libheif for controlling how chroma subsampling is performed. A new define is added named "heic:chroma-downsampling-algorithm" which has valid values of "nearest-neighbor", "average", and "smart-yuv". "smart-yuv" is only available if libheif was built with the "WITH_LIBSHARPYUV" compile-time option.

The "heic:chroma" define has been made available for all HEIC images instead of just AVIF images.

Version checks for libheif have been clarified and also made more accurate.