### PR TITLE
install perl module into user-specified prefix

### DIFF
--- a/PerlMagick/Makefile.PL.in
+++ b/PerlMagick/Makefile.PL.in
@@ -223,6 +223,9 @@ WriteMakefile
    # Linker flags for building a dynamically loadable module
    'LDDLFLAGS' => $LDDLFLAGS_magick,
 
+   # Install PerlMagick into ImageMagick prefix
+   'INSTALL_BASE' => '@PREFIX_DIR@',
+
    # Install PerlMagick binary into ImageMagick bin directory
    'INSTALLBIN'	=> '@BIN_DIR@',
 


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This makes perl module installation respect the `--prefix` option to the configure script. Without this change, the perl module gets intalled into /usr/local regardless of the specified prefix.

Fixes #7191.