### PR TITLE
Fix bmp option to bypass file size check

### DIFF
--- a/coders/bmp.c
+++ b/coders/bmp.c
@@ -620,6 +620,9 @@ static Image *ReadBMPImage(const ImageInfo *image_info,ExceptionInfo *exception)
     magick[12],
     *p,
     *pixels;
+  
+  const char
+    *option;
 
   unsigned int
     blue,
@@ -657,6 +660,8 @@ static Image *ReadBMPImage(const ImageInfo *image_info,ExceptionInfo *exception)
   if (count != 2)
     ThrowReaderException(CorruptImageError,"ImproperImageHeader");
   blob_size=GetBlobSize(image);
+  
+  option=GetImageOption(image_info,"bmp:ignore-filesize");
   do
   {
     PixelInfo
@@ -700,7 +705,8 @@ static Image *ReadBMPImage(const ImageInfo *image_info,ExceptionInfo *exception)
       }
     if (bmp_info.size > 124)
       ThrowReaderException(CorruptImageError,"ImproperImageHeader");
-    if ((bmp_info.file_size != 0) &&
+    if (!IsStringTrue(option) && 
+        (bmp_info.file_size != 0) &&
         ((MagickSizeType) bmp_info.file_size > GetBlobSize(image)))
       ThrowReaderException(CorruptImageError,"ImproperImageHeader");
     if (bmp_info.offset_bits < bmp_info.size)
@@ -942,10 +948,6 @@ static Image *ReadBMPImage(const ImageInfo *image_info,ExceptionInfo *exception)
       }
     if ((MagickSizeType) bmp_info.file_size != blob_size)
       {
-        const char
-          *option;
-
-        option=GetImageOption(image_info,"bmp:ignore-filesize");
         if (IsStringTrue(option) == MagickFalse)
           (void) ThrowMagickException(exception,GetMagickModule(),
             CorruptImageError,"LengthAndFilesizeDoNotMatch","`%s'",

--- a/coders/bmp.c
+++ b/coders/bmp.c
@@ -661,7 +661,6 @@ static Image *ReadBMPImage(const ImageInfo *image_info,ExceptionInfo *exception)
     ThrowReaderException(CorruptImageError,"ImproperImageHeader");
   blob_size=GetBlobSize(image);
   
-  option=GetImageOption(image_info,"bmp:ignore-filesize");
   do
   {
     PixelInfo
@@ -705,6 +704,10 @@ static Image *ReadBMPImage(const ImageInfo *image_info,ExceptionInfo *exception)
       }
     if (bmp_info.size > 124)
       ThrowReaderException(CorruptImageError,"ImproperImageHeader");
+    /*
+      Get option to bypass file size check
+    */
+    option=GetImageOption(image_info,"bmp:ignore-filesize");
     if (!IsStringTrue(option) && 
         (bmp_info.file_size != 0) &&
         ((MagickSizeType) bmp_info.file_size > GetBlobSize(image)))
@@ -948,6 +951,7 @@ static Image *ReadBMPImage(const ImageInfo *image_info,ExceptionInfo *exception)
       }
     if ((MagickSizeType) bmp_info.file_size != blob_size)
       {
+        option=GetImageOption(image_info,"bmp:ignore-filesize");
         if (IsStringTrue(option) == MagickFalse)
           (void) ThrowMagickException(exception,GetMagickModule(),
             CorruptImageError,"LengthAndFilesizeDoNotMatch","`%s'",


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
ImageMagick provides an option for user to bypass file size check for bmp image. Currently, ImageMagick is retrieving option **after** file size check. This pull request aims to fix this by moving the option retrieval infront of the file size check, if the option 
_bmp:ignore-filesize_ is defined, actual file size won't be checked against file structure file size.

