### PR TITLE
uhdr.c: verify the availability of error message before accessing it

### DIFF
--- a/coders/uhdr.c
+++ b/coders/uhdr.c
@@ -177,17 +177,18 @@ static Image *ReadUHDRImage(const ImageInfo *image_info,
   else
     decoded_img_fmt = UHDR_IMG_FMT_UNSPECIFIED;
 
-#define CHECK_IF_ERR(x) \
-  { \
-    uhdr_error_info_t retval = (x); \
-    if (retval.error_code != UHDR_CODEC_OK) \
-    { \
-      (void) ThrowMagickException(exception,GetMagickModule(),CoderError, \
-        retval.detail,"`%s'",image->filename); \
-      uhdr_release_decoder(handle); \
-      CloseBlob(image); \
-      return DestroyImageList(image); \
-    } \
+#define CHECK_IF_ERR(x)                                                                       \
+  {                                                                                           \
+    uhdr_error_info_t retval = (x);                                                           \
+    if (retval.error_code != UHDR_CODEC_OK)                                                   \
+    {                                                                                         \
+      (void)ThrowMagickException(exception, GetMagickModule(), CoderError,                    \
+                                 retval.has_detail ? retval.detail : "unknown error", "`%s'", \
+                                 image->filename);                                            \
+      uhdr_release_decoder(handle);                                                           \
+      CloseBlob(image);                                                                       \
+      return DestroyImageList(image);                                                         \
+    }                                                                                         \
   }
 
   CHECK_IF_ERR(uhdr_dec_set_image(handle, &img))
@@ -714,16 +715,17 @@ static MagickBooleanType WriteUHDRImage(const ImageInfo *image_info,
   {
     uhdr_codec_private_t *handle = uhdr_create_encoder();
 
-#define CHECK_IF_ERR(x) \
-  { \
-    uhdr_error_info_t retval = (x); \
-    if (retval.error_code != UHDR_CODEC_OK) \
-    { \
-      (void) ThrowMagickException(exception,GetMagickModule(),CoderError, \
-        retval.detail,"`%s'",image->filename); \
-      uhdr_release_encoder(handle); \
-      status = MagickFalse; \
-    } \
+#define CHECK_IF_ERR(x)                                                                       \
+  {                                                                                           \
+    uhdr_error_info_t retval = (x);                                                           \
+    if (retval.error_code != UHDR_CODEC_OK)                                                   \
+    {                                                                                         \
+      (void)ThrowMagickException(exception, GetMagickModule(), CoderError,                    \
+                                 retval.has_detail ? retval.detail : "unknown error", "`%s'", \
+                                 image->filename);                                            \
+      uhdr_release_encoder(handle);                                                           \
+      status = MagickFalse;                                                                   \
+    }                                                                                         \
   }
 
     if (image->quality > 0 && image->quality <= 100)


### PR DESCRIPTION
Change-Id: Idb78fba530772cd4e80614ce7ffd1d78f13f0c95

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
