### PR TITLE
ci: update release.yml, removing fuse requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04
-      options: --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined
 
     strategy:
       matrix:
@@ -80,7 +79,7 @@ jobs:
         unset QT_PLUGIN_PATH
         unset LD_LIBRARY_PATH
         export VERSION=$(git rev-parse --short HEAD)-${{ matrix.compiler }}
-        /app-image/linuxdeployqt-continuous-x86_64.AppImage /appdir/usr/share/applications/imagemagick.desktop -bundle-non-qt-libs
+        /app-image/linuxdeployqt-continuous-x86_64.AppImage --appimage-extract-and-run /appdir/usr/share/applications/imagemagick.desktop -bundle-non-qt-libs
         rm /appdir/AppRun
         cp ./app-image/AppRun /appdir
         chmod a+x /appdir/AppRun


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

:wave:

According to AppImageKit documentation, [fuse permission is not necessary with Docker](https://github.com/AppImage/AppImageKit/wiki/FUSE#docker).

I've tested the modification with local Dockerfile & docker-compose; I'm not sure it works with Github CI.

Regards.