### PR TITLE
ci: fix git version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+      # Avoid fatal: detected dubious ownership in repository at '/__w/ImageMagick/ImageMagick'
+      # Possible workaround: https://github.com/actions/runner/issues/2033#issuecomment-1598547465
+    - name: Flag current workspace as safe for git
+      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
     - name: Download AppImage
       run: |
         mkdir /app-image
@@ -245,6 +250,6 @@ jobs:
       with:
         generate_release_notes: true
         files: |
-          artifacts/AppImage-clang/ImageMagick--clang-x86_64.AppImage
-          artifacts/AppImage-gcc/ImageMagick--gcc-x86_64.AppImage
+          artifacts/AppImage-clang/ImageMagick-*-clang-x86_64.AppImage
+          artifacts/AppImage-gcc/ImageMagick-*-gcc-x86_64.AppImage
           artifacts/Msix-Q16-HDRI/ImageMagick.Q16-HDRI.msixbundle


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

:wave:

I've noticed that the git-version is not present in release's files because of this error during step _Create ImageMagick AppImage_:

> 2024-04-19T06:06:46.9582463Z shell: sh -e {0}
> 2024-04-19T06:06:46.9582855Z ##[endgroup]
> 2024-04-19T06:06:47.0331404Z fatal: detected dubious ownership in repository at '/__w/ImageMagick/ImageMagick'
> 2024-04-19T06:06:47.0332168Z To add an exception for this directory, call:
> 2024-04-19T06:06:47.0332463Z 
> 2024-04-19T06:06:47.0332796Z 	git config --global --add safe.directory /__w/ImageMagick/ImageMagick

This PR add a new step to fix the issue.

As a result:
- AppImages in release now contains the git revision
- Windows package is not affected

Regards.