### PR TITLE
Fix GIF ICC profile reading. (https://github.com/ImageMagick/ImageMagick/issues/7281)

### DIFF
--- a/coders/gif.c
+++ b/coders/gif.c
@@ -1156,7 +1156,7 @@ static Image *ReadGIFImage(const ImageInfo *image_info,ExceptionInfo *exception)
                 */
                 if (LocaleNCompare((char *) buffer,"ImageMagick",11) == 0)
                   magick=MagickTrue;
-                else if (LocaleNCompare((char *) buffer,"ICCRGBG1012",11))
+                else if (LocaleNCompare((char *) buffer,"ICCRGBG1012",11) == 0)
                   (void) CopyMagickString(name,"icc",sizeof(name));
                 else if (LocaleNCompare((char *) buffer,"MGK8BIM0000",11) == 0)
                   (void) CopyMagickString(name,"8bim",sizeof(name));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Non-ICC profiles were getting marked as ICC profiles when reading GIF images because of a missing `== 0` comparison in the name logic. I've made the comparison consistent with it's surrounding comparisons to fix the issue.
