### PR TITLE
Fix a typo in `convert` deprecation warning

### DIFF
--- a/MagickWand/deprecate.c
+++ b/MagickWand/deprecate.c
@@ -552,7 +552,7 @@ WandExport MagickBooleanType ConvertImageCommand(ImageInfo *image_info,
   if (IsEventLogging() != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"...");
   (void) FormatLocaleFile(stderr,"WARNING: %s\n",
-        "The convert command is deprecated in IMv7, use \"magick\" instead of \"comvert\" or \"magick convert\"\n");
+        "The convert command is deprecated in IMv7, use \"magick\" instead of \"convert\" or \"magick convert\"\n");
   if (argc == 2)
     {
       option=argv[1];


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Just fixing a small typo in a warning message (modified yesterday in ec17fd0d45ed510d2d846676944487bb76d6256b)