### PR TITLE
uhdr.c: default initialize range field for hdr/sdr intent inputs to enc

### DIFF
--- a/coders/uhdr.c
+++ b/coders/uhdr.c
@@ -558,7 +558,8 @@ static void fillRawImageDescriptor(uhdr_raw_image_t *imgDescriptor, const ImageI
     imgDescriptor->ct = UHDR_CT_SRGB;
   }
 
-  imgDescriptor->range = UHDR_CR_UNSPECIFIED;
+  imgDescriptor->range = imgDescriptor->fmt == UHDR_IMG_FMT_24bppYCbCrP010 ? UHDR_CR_LIMITED_RANGE
+                                                                           : UHDR_CR_FULL_RANGE;
   imgDescriptor->w = image->columns;
   imgDescriptor->h = image->rows;
 }


### PR DESCRIPTION
Test: ./utilities/magick -define uhdr:hdr-color-transfer=hlg -define uhdr:sdr-color-gamut=bt709 -define uhdr:hdr-color-gamut=bt2100 sdr_intent.jpg hdr_intent.heic uhdr:out.jpg

Change-Id: I7874932c56476cd2204fb9e3f111ba6e7ece711c

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
