### PR TITLE
Fixed typo in documentation of MagickAdaptiveBlurImage

### DIFF
--- a/MagickWand/magick-image.c
+++ b/MagickWand/magick-image.c
@@ -152,7 +152,7 @@ WandExport Image *GetImageFromMagickWand(const MagickWand *wand)
 %                                                                             %
 %                                                                             %
 %                                                                             %
-%   M a g i c k A d a p t i v e S h a r p e n I m a g e                       %
+%   M a g i c k A d a p t i v e B l u r I m a g e                             %
 %                                                                             %
 %                                                                             %
 %                                                                             %


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->
The documentation for the function MagickAdaptiveBlurImage incorrectly called it MagickAdaptiveSharpenImage, so I replaced it with the correct name.
<!-- Thanks for contributing to ImageMagick! -->
