### PR TITLE
Silence warning when freetype delegate is disabled.

### DIFF
--- a/MagickCore/annotate.c
+++ b/MagickCore/annotate.c
@@ -2109,6 +2109,7 @@ static MagickBooleanType RenderFreetype(Image *image,const DrawInfo *draw_info,
   const char *magick_unused(encoding),const PointInfo *offset,
   TypeMetric *metrics,ExceptionInfo *exception)
 {
+  magick_unreferenced(encoding);
   (void) ThrowMagickException(exception,GetMagickModule(),
     MissingDelegateWarning,"DelegateLibrarySupportNotBuiltIn","'%s' (Freetype)",
     draw_info->font != (char *) NULL ? draw_info->font : "none");


### PR DESCRIPTION
Makes use of magick_unreferenced to prevent 

error C2220: the following warning is treated as an error
warning C4100: 'encoding': unreferenced formal parameter
