### PR TITLE
Silence warning and fix HEIC_COMPUTE_NUMERIC_VERSION definition when heic delegate is disabled.

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -75,9 +75,9 @@
 #include "MagickCore/string-private.h"
 #include "MagickCore/module.h"
 #include "MagickCore/utility.h"
-#if defined(MAGICKCORE_HEIC_DELEGATE)
 #define HEIC_COMPUTE_NUMERIC_VERSION(major,minor,patch) \
   ((major<<24) | (minor<<16) | (patch<<8) | 0)
+#if defined(MAGICKCORE_HEIC_DELEGATE)
 #include <libheif/heif.h>
 #if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,17,0)
 #include <libheif/heif_properties.h>
@@ -796,6 +796,9 @@ static MagickBooleanType IsHEIC(const unsigned char *magick,const size_t length)
   type=heif_check_filetype(magick,(int) length);
   if (type == heif_filetype_yes_supported)
     return(MagickTrue);
+#else
+  magick_unreferenced(magick);
+  magick_unreferenced(length);
 #endif
   return(MagickFalse);
 }


### PR DESCRIPTION
Use magick_unreferenced to silence warning to avoid
error C2220: the following warning is treated as an error
warning C4100: 'length': unreferenced formal parameter
warning C4100: 'magick': unreferenced formal parameter

Make HEIC_COMPUTE_NUMERIC_VERSION definition available even when heic delegate is disabled since it is used outside of MAGICKCORE_HEIC_DELEGATE scope.