### PR TITLE
uhdr: fix language choice in autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2896,7 +2896,6 @@ if test "$with_uhdr" != 'no'; then
     PKG_CHECK_MODULES([UHDR],[libuhdr >= 1.2.0],[have_uhdr=yes],[have_uhdr=no])
     CFLAGS="$CFLAGS $UHDR_CFLAGS"
     LIBS="$LIBS $UHDR_LIBS"
-    AC_LANG_PUSH([C++])
     AC_CHECK_HEADER([ultrahdr_api.h],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`])
     AC_CHECK_LIB([uhdr],[uhdr_create_decoder],[passed=`expr $passed + 1`],[failed=`expr $failed + 1`],[])
 
@@ -2916,7 +2915,6 @@ if test "$with_uhdr" != 'no'; then
     else
         AC_MSG_RESULT([no])
     fi
-    AC_LANG_POP([C++])
 fi
 
 AM_CONDITIONAL([UHDR_DELEGATE],[test "$have_uhdr" = 'yes'])


### PR DESCRIPTION
While checking for uhdr delegate, cflags is set with uhdr_cflags but language chosen is c++. This would fail AC_CHECK_HEADER(...). This is corrected.

Test: Build

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->
