### PR TITLE
Improve readability of RotateRight in cipher.c

### DIFF
--- a/MagickCore/cipher.c
+++ b/MagickCore/cipher.c
@@ -992,7 +992,11 @@ static inline unsigned int XTime(unsigned char alpha)
 
 static inline unsigned int RotateRight(const unsigned int x)
 {
-  return((x >> 8) | ((x & 0xff) << 24));
+  unsigned int leastSignificantByte = x & 0xFF;
+  unsigned int shiftedRight = x >> 8;
+  unsigned int rotatedByte = leastSignificantByte << 24;
+
+  return shiftedRight | rotatedByte;;
 }
 
 static void SetAESKey(AESInfo *aes_info,const StringInfo *key)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Improve readability of RotateRight in cipher.c
