### PR TITLE
.cut (Dr Halo) reading when run count in header

### DIFF
--- a/coders/cut.c
+++ b/coders/cut.c
@@ -384,7 +384,7 @@ static Image *ReadCUTImage(const ImageInfo *image_info,ExceptionInfo *exception)
       if (offset < 0)
         ThrowCUTReaderException(CorruptImageError,"ImproperImageHeader");
       if(EOFBlob(image) != MagickFalse) goto CUT_KO;  /*wrong data*/
-      EncodedByte=(size_t) ((ssize_t) EncodedByte-i+1);
+      EncodedByte=(size_t) ((ssize_t) EncodedByte-(i+1));
       ldblk+=(ssize_t) RunCountMasked;
 
       RunCount=(unsigned char) ReadBlobByte(image);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

When reading a .cut file where the run counts for a row are all together (RunCount > 0x80), the EncodedByte isn't decremented correctly.

By comparison with the working IM6 code (https://github.com/ImageMagick/ImageMagick6/blob/main/coders/cut.c#407), this is supposed to decrement by i+1, but the change to introduce the cast changed the precedence.

<!-- Thanks for contributing to ImageMagick! -->
