### PR TITLE
revert map changes breaking ABI

### DIFF
--- a/MagickCore/libMagickCore.map
+++ b/MagickCore/libMagickCore.map
@@ -1,4 +1,4 @@
- VERS_10.2 {
+ VERS_10.0 {
      	 global:
      		 *;
      };

--- a/MagickWand/libMagickWand.map
+++ b/MagickWand/libMagickWand.map
@@ -1,4 +1,4 @@
- VERS_10.2 {
+ VERS_10.0 {
      	 global:
      		 *;
      };


### PR DESCRIPTION
Partial revert of 799454079e502187fd20941d21b5e69b7f9a49e6

as this change breaks ABI

At RPM level
```
removed     REQUIRES libMagickWand-7.Q16HDRI.so.10(VERS_10.0)(64bit)  
added       REQUIRES libMagickWand-7.Q16HDRI.so.10(VERS_10.2)(64bit)  
```

Also from objdump
```
$ objdump -T libMagickWand-7.Q16HDRI.so.10.0.1 
00000000000add90 g    DF .text	00000000000001b4  VERS_10.0   MagickWriteImageFile
000000000009b500 g    DF .text	000000000000012f  VERS_10.0   MagickEdgeImage
00000000000ac220 g    DF .text	0000000000000183  VERS_10.0   MagickSpliceImage
000000000008ab00 g    DF .text	000000000000c704  VERS_10.0   ImportImageCommand
00000000000a94e0 g    DF .text	0000000000000112  VERS_10.0   MagickSetImageDepth
...
$ objdump -T libMagickWand-7.Q16HDRI.so.10.0.2
00000000000addb0 g    DF .text	00000000000001b4  VERS_10.2   MagickWriteImageFile
000000000009b520 g    DF .text	000000000000012f  VERS_10.2   MagickEdgeImage
00000000000ac240 g    DF .text	0000000000000183  VERS_10.2   MagickSpliceImage
000000000008ab20 g    DF .text	000000000000c704  VERS_10.2   ImportImageCommand
00000000000a9500 g    DF .text	0000000000000112  VERS_10.2   MagickSetImageDepth
...
```

Strangely only MagicWand is affected, the libMagickCore.map seems unused.