### PR TITLE
Fix compiler identification with Clang on Darwin

### DIFF
--- a/MagickCore/version.c
+++ b/MagickCore/version.c
@@ -503,7 +503,7 @@ MagickExport const char *GetMagickReleaseDate(void)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 %  GetMagickSignature() returns a signature that uniquely encodes the
-%  MagickCore library version, quantum depth, HDRI status, OS word size, 
+%  MagickCore library version, quantum depth, HDRI status, OS word size,
 %  channel type, and endianness.
 %
 %  The format of the GetMagickSignature method is:
@@ -663,12 +663,12 @@ MagickExport void ListMagickVersion(FILE *file)
 #if defined(MAGICKCORE_MSC_VER)
   (void) FormatLocaleFile(file,"Compiler: Visual Studio %d (%d)\n",
     MAGICKCORE_MSC_VER,_MSC_FULL_VER);
-#elif defined(__GNUC__)
-  (void) FormatLocaleFile(file,"Compiler: gcc (%d.%d)\n",__GNUC__,
-    __GNUC_MINOR__);
 #elif defined(__clang__)
   (void) FormatLocaleFile(file,"Compiler: clang (%d.%d.%d)\n",__clang_major__,
     __clang_minor__,__clang_patchlevel__);
+#elif defined(__GNUC__)
+  (void) FormatLocaleFile(file,"Compiler: gcc (%d.%d)\n",__GNUC__,
+    __GNUC_MINOR__);
 #elif defined(__MINGW32_MAJOR_VERSION)
   (void) FormatLocaleFile(file,"Compiler: MinGW (%d.%d)\n",
     __MINGW32_MAJOR_VERSION,__MINGW32_MINOR_VERSION);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Moves the `__GNUC__` check below the `__clang__` check, as Clang defines `__GNUC__` when compiling for Darwin targets, identifying itself as GCC 4.2 for compatibility, resulting in imagemagick saying it was compiled with GCC 4.2 when it is compiled with Clang for Darwin.