### PR TITLE
Libxml2 fixes

### DIFF
--- a/MagickCore/magick.c
+++ b/MagickCore/magick.c
@@ -93,9 +93,6 @@
 #include "MagickCore/utility.h"
 #include "MagickCore/utility-private.h"
 #include "MagickCore/xwindow-private.h"
-#if defined(MAGICKCORE_XML_DELEGATE)
-#  include <libxml/parser.h>
-#endif
 
 /*
   Define declarations.
@@ -1646,9 +1643,6 @@ MagickExport void MagickCoreTerminus(void)
     }
   MonitorComponentTerminus();
   RegistryComponentTerminus();
-#if defined(MAGICKCORE_XML_DELEGATE)
-  xmlCleanupParser();
-#endif
   AnnotateComponentTerminus();
   MimeComponentTerminus();
   TypeComponentTerminus();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This pull request mainly removes a lot of unnecessary SAX handlers copied more or less verbatim from an ancient libxml2 version. This old code probably contains bugs and uses a few low-level libxml2 API functions about to be deprecated. It should be more maintainable and safe to rely on the original libxml2 handlers.

Other commits remove an unsafe call to `xmlCleanupParser` and code that uses the deprecated HTTP and FTP clients in libxml2. (HTTPS was never supported, so this feature is of very limited use these days.)