### PR TITLE
Enable any dither method such as Floyd-Steinberg for Magick::Image::map()

### DIFF
--- a/Magick++/lib/Image.cpp
+++ b/Magick++/lib/Image.cpp
@@ -3569,9 +3569,14 @@ void Magick::Image::magnify(void)
 
 void Magick::Image::map(const Image &mapImage_,const bool dither_)
 {
+  map(mapImage_, dither_ ? RiemersmaDitherMethod : NoDitherMethod);
+}
+
+void Magick::Image::map(const Image &mapImage_,const DitherMethod ditherMethod_)
+{
   modifyImage();
   GetPPException;
-  options()->quantizeDither(dither_);
+  options()->quantizeDither(ditherMethod_);
   RemapImage(options()->quantizeInfo(),image(),mapImage_.constImage(),
     exceptionInfo);
   ThrowImageException;

--- a/Magick++/lib/Magick++/Image.h
+++ b/Magick++/lib/Magick++/Image.h
@@ -1081,8 +1081,10 @@ namespace Magick
     // Magnify image by integral size
     void magnify(void);
 
-    // Remap image colors with closest color from reference image
+    // backwards compatibility
     void map(const Image &mapImage_,const bool dither_=false);
+    // Remap image colors with closest color from reference image
+    void map(const Image &mapImage_,const DitherMethod ditherMethod_);
 
     // Delineate arbitrarily shaped clusters in the image.
     void meanShift(const size_t width_,const size_t height_,

--- a/Magick++/lib/Magick++/Options.h
+++ b/Magick++/lib/Magick++/Options.h
@@ -165,8 +165,10 @@ namespace Magick
     void quantizeColorSpace(const ColorspaceType colorSpace_);
     ColorspaceType quantizeColorSpace(void) const;
 
-    // Dither image during quantization.
+    // backwards compatibility
     void quantizeDither(const bool ditherFlag_);
+    // Dither image during quantization.
+    void quantizeDither(const DitherMethod ditherMethod_);
     bool quantizeDither(void) const;
 
     // Dither method

--- a/Magick++/lib/Options.cpp
+++ b/Magick++/lib/Options.cpp
@@ -472,10 +472,15 @@ Magick::ColorspaceType Magick::Options::quantizeColorSpace(void) const
 
 void Magick::Options::quantizeDither(const bool ditherFlag_)
 {
-  _imageInfo->dither=(MagickBooleanType) ditherFlag_;
-  _quantizeInfo->dither_method=ditherFlag_ ? RiemersmaDitherMethod :
-    NoDitherMethod;
+  quantizeDither(ditherFlag_ ? RiemersmaDitherMethod : NoDitherMethod);
 }
+
+void Magick::Options::quantizeDither(const DitherMethod ditherMethod_)
+{
+  _imageInfo->dither=(MagickBooleanType) (ditherMethod_ != NoDitherMethod);
+  _quantizeInfo->dither_method=ditherMethod_;
+}
+
 
 bool Magick::Options::quantizeDither(void) const
 {


### PR DESCRIPTION
Today, one can use imagemagick CLI and perform the following:
```
$ magick ... -dither FloydSteinberg -remap some_remapping.png  ...
```
When trying to convert that into C++, one would likely come up with:
```
#include <Magick++.h>
...
  image.quantizeDitherMethod(MagickCore::DitherMethod::FloydSteinbergDitherMethod);
  image.map(Magick::Image("some_remapping.png"), false);
...
```
However, that does not employ the Floyd-Steinberg algorithm. Todays `void Magick::Image::map(const Image &mapImage_,const bool dither_)` method forsees to solely pass a boolean towards `void Magick::Options::quantizeDither(const DitherMethod ditherMethod_)`. Which considers a `True` to be `RiemersmaDitherMethod` algorithm, while a `False` forsees no dithering at all (`NoDitherMethod`). As `Magick::Options::quantizeDither` also re-sets the dithering algorithm, any beforehand defined dithering algorithm such as FloydSteinberg (like above) doesn't have any effect.

Thus, my proposal here is to create the same interfaces, just with the ability to pass the dithering method of interest, not relying on a pure boolean, that is not aware of a Floyd-Steinberg. 

Closes #7938