### PR TITLE
#7941 Added if statement to avoid crash when there are no channels

### DIFF
--- a/coders/exr.c
+++ b/coders/exr.c
@@ -212,29 +212,32 @@ static MagickBooleanType InitializeEXRChannels(Image *image,exr_context_t ctxt,
     }
   channel=decoder.channels;
   prefix_length=0;
-  prefix=strrchr(decoder.channels[0].channel_name,'.');
-  if (prefix != (const char*) NULL)
+  if (decoder.channel_count > 0)
     {
-      /*
-      * When all channel names have the same prefix, we will skip that
-      * part when determining the channel type.
-      */
-      prefix_length=1+(size_t)(prefix-decoder.channels[0].channel_name);
-      if (prefix_length < MagickPathExtent)
+      prefix=strrchr(decoder.channels[0].channel_name,'.');
+      if (prefix != (const char*) NULL)
         {
-          CopyMagickString(channel_name,decoder.channels[0].channel_name
-            ,prefix_length+1);
-          channel=decoder.channels;
-          for (c = 0; c < decoder.channel_count; ++c)
-          {
-            if (strncmp(channel->channel_name,channel_name,
-                  prefix_length) != 0)
+          /*
+          * When all channel names have the same prefix, we will skip that
+          * part when determining the channel type.
+          */
+          prefix_length=1+(size_t)(prefix-decoder.channels[0].channel_name);
+          if (prefix_length < MagickPathExtent)
+            {
+              CopyMagickString(channel_name,decoder.channels[0].channel_name
+                ,prefix_length+1);
+              channel=decoder.channels;
+              for (c = 0; c < decoder.channel_count; ++c)
               {
-                prefix_length=0;
-                break;
+                if (strncmp(channel->channel_name,channel_name,
+                      prefix_length) != 0)
+                  {
+                    prefix_length=0;
+                    break;
+                  }
+                channel++;
               }
-            channel++;
-          }
+            }
         }
     }
   channel=decoder.channels;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

For #7941 there is an assumption that at least one channel is found while decoding as the first entry in the array is used when checking the prefix.

This change checks that we do have at least one channel before we use the channels array.

<!-- Thanks for contributing to ImageMagick! -->
