### PR TITLE
fix type casting in statistic.c

### DIFF
--- a/MagickCore/statistic.c
+++ b/MagickCore/statistic.c
@@ -2257,7 +2257,7 @@ MagickExport ChannelStatistics *GetImageStatistics(const Image *image,
       double
         count;
 
-      count=(fouble) (area*histogram[(ssize_t) GetPixelChannels(image)*j+i]);
+      count=(double) (area*histogram[(ssize_t) GetPixelChannels(image)*j+i]);
       channel_statistics[channel].entropy+=((long double) -count*
         MagickLog10(count)*PerceptibleReciprocalLD((long double)
         MagickLog10(number_bins)));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
fix type casting in statistic.c
https://github.com/ImageMagick/ImageMagick/issues/7981
