### PR TITLE
Fix statistic.c GetImageRange initializer

### DIFF
--- a/MagickCore/statistic.c
+++ b/MagickCore/statistic.c
@@ -1892,8 +1892,6 @@ MagickExport MagickBooleanType GetImageRange(const Image *image,double *minima,
         status=MagickFalse;
         continue;
       }
-    row_maxima=(double) p[0];
-    row_minima=(double) p[0];
     for (x=0; x < (ssize_t) image->columns; x++)
     {
       ssize_t


### PR DESCRIPTION
https://github.com/ImageMagick/ImageMagick/commit/099e1a2ef7bf91f26f5281a165a85443b285abd9 cleaned up row_minima row_maxima initialization.
But with the above commit these 2 values are once initialized with MagickMinimumValue, MagickMaximumValue, later these are again initialized with p[0]. The latter is apparently not needed.

Fixes https://github.com/rmagick/rmagick/issues/1679 .

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.


