### PR TITLE
try pngalpha if png16malpha not available

### DIFF
--- a/configure
+++ b/configure
@@ -5258,7 +5258,7 @@ MAGICK_PATCHLEVEL_VERSION=46
 
 MAGICK_VERSION=7.1.1-46
 
-MAGICK_GIT_REVISION=37b3453c6:20250309
+MAGICK_GIT_REVISION=c4afe0b7e:20250313
 
 
 # Substitute library versioning
@@ -5292,7 +5292,7 @@ PACKAGE_LIB_VERSION=0x711
 
 PACKAGE_LIB_VERSION_NUMBER=7,1,1,46
 
-PACKAGE_RELEASE_DATE=2025-03-09
+PACKAGE_RELEASE_DATE=2025-03-13
 
 
 # Ensure that make can run correctly
@@ -38796,6 +38796,8 @@ printf "%s\n" "$GSColorDevice" >&6; }
 printf %s "checking for gs alpha device... " >&6; }
     if $PSDelegate -q -dBATCH -sDEVICE=$GSAlphaDevice -sOutputFile=/dev/null < /dev/null 1>&5 2>&5; then
         :
+    elif $PSDelegate -q -dBATCH -sDEVICE=pngalpha -sOutputFile=/dev/null < /dev/null 1>&5 2>&5; then
+        GSAlphaDevice=pngalpha
     else
         GSAlphaDevice=$GSColorDevice
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -3864,6 +3864,8 @@ if test $have_gs = 'yes'; then
     AC_MSG_CHECKING([for gs alpha device])
     if $PSDelegate -q -dBATCH -sDEVICE=$GSAlphaDevice -sOutputFile=/dev/null < /dev/null 1>&AS_MESSAGE_LOG_FD 2>&AS_MESSAGE_LOG_FD; then
         :
+    elif $PSDelegate -q -dBATCH -sDEVICE=pngalpha -sOutputFile=/dev/null < /dev/null 1>&AS_MESSAGE_LOG_FD 2>&AS_MESSAGE_LOG_FD; then
+        GSAlphaDevice=pngalpha
     else
         GSAlphaDevice=$GSColorDevice
     fi


### PR DESCRIPTION
Related to #8019 

In fe3b58fa3d102bbd2f69ddce8fbf1d43d6ece3dd
Default change from  `pngalpha` to `png16malpha`

But `png16malpha` is not available in libgs 9.x, only in 10.x

This proposal try `pngalpha` before switching to fallback value.

#8019 is not fixed, as the main issue was missing Ghostscript binary, so device cannot be checeked.