### PR TITLE
JXL: Preserve ICC profile for lossless encoding

### DIFF
--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -1042,9 +1042,8 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
     }
   if (image_info->quality == 100)
     {
+      basic_info.uses_original_profile=JXL_TRUE;
       icc_profile = GetImageProfile(image, "icc");
-      if (icc_profile != (StringInfo *) NULL)
-        basic_info.uses_original_profile=JXL_TRUE;
     }
   if ((image_info->adjoin != MagickFalse) &&
       (GetNextImageInList(image) != (Image *) NULL))

--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -884,7 +884,7 @@ ModuleExport void UnregisterJXLImage(void)
 */
 
 static JxlEncoderStatus JXLWriteMetadata(const Image *image,
-  JxlEncoder *jxl_info)
+  JxlEncoder *jxl_info, const StringInfo *icc_profile)
 {
   JxlColorEncoding
     color_encoding;
@@ -892,6 +892,14 @@ static JxlEncoderStatus JXLWriteMetadata(const Image *image,
   JxlEncoderStatus
     jxl_status;
 
+  if (icc_profile != (StringInfo *) NULL)
+    {
+      jxl_status = JxlEncoderSetICCProfile(
+        jxl_info,
+        (const uint8_t *)GetStringInfoDatum(icc_profile),
+        GetStringInfoLength(icc_profile));
+      return(jxl_status);
+    }
   (void) memset(&color_encoding,0,sizeof(color_encoding));
   color_encoding.color_space=JXL_COLOR_SPACE_RGB;
   if (IsRGBColorspace(image->colorspace) == MagickFalse)
@@ -920,6 +928,7 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
     *option;
 
   const StringInfo
+    *icc_profile = (StringInfo *) NULL,
     *exif_profile = (StringInfo *) NULL,
     *xmp_profile = (StringInfo *) NULL;
 
@@ -1032,7 +1041,11 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
       basic_info.num_extra_channels=1;
     }
   if (image_info->quality == 100)
-    basic_info.uses_original_profile=JXL_TRUE;
+    {
+      icc_profile = GetImageProfile(image, "icc");
+      if (icc_profile != (StringInfo *) NULL)
+        basic_info.uses_original_profile=JXL_TRUE;
+    }
   if ((image_info->adjoin != MagickFalse) &&
       (GetNextImageInList(image) != (Image *) NULL))
     {
@@ -1108,7 +1121,7 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
         }
       (void) JxlEncoderCloseBoxes(jxl_info);
     }
-  jxl_status=JXLWriteMetadata(image,jxl_info);
+  jxl_status=JXLWriteMetadata(image,jxl_info,icc_profile);
   if (jxl_status != JXL_ENC_SUCCESS)
     {
       JxlThreadParallelRunnerDestroy(runner);

--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -896,7 +896,7 @@ static JxlEncoderStatus JXLWriteMetadata(const Image *image,
     {
       jxl_status = JxlEncoderSetICCProfile(
         jxl_info,
-        (const uint8_t *)GetStringInfoDatum(icc_profile),
+        (const uint8_t *) GetStringInfoDatum(icc_profile),
         GetStringInfoLength(icc_profile));
       return(jxl_status);
     }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
When losslessly encoding an image to JXL, attempt to retrieve any ICC profile set on the source image, and if one exists, apply it to the output JXL image instead of using JxlEncoderSetColorEncoding.

Fixes #8022
