### PR TITLE
magick-config.h: Remove redundant block

### DIFF
--- a/MagickCore/magick-config.h
+++ b/MagickCore/magick-config.h
@@ -93,38 +93,6 @@ extern "C" {
 # define MAGICKCORE_64BIT_CHANNEL_MASK_SUPPORT 1
 #endif
 
-/* Compatibility block */
-#if !defined(MAGICKCORE_QUANTUM_DEPTH) && defined(MAGICKCORE_QUANTUM_DEPTH_OBSOLETE_IN_H)
-# warning "you should set MAGICKCORE_QUANTUM_DEPTH to sensible default set it to configure time default"
-# warning "this is an obsolete behavior please fix yours makefile"
-# define MAGICKCORE_QUANTUM_DEPTH MAGICKCORE_QUANTUM_DEPTH_OBSOLETE_IN_H
-#endif
-
-/* Number of bits in a pixel Quantum (8/16/32/64) */
-#ifndef MAGICKCORE_QUANTUM_DEPTH
-# error "you should set MAGICKCORE_QUANTUM_DEPTH"
-#endif
-
-/* check values */
-#if MAGICKCORE_QUANTUM_DEPTH != 8
-# if MAGICKCORE_QUANTUM_DEPTH != 16
-#  if MAGICKCORE_QUANTUM_DEPTH != 32
-#   if MAGICKCORE_QUANTUM_DEPTH != 64
-#    error "MAGICKCORE_QUANTUM_DEPTH is not 8/16/32/64 bits"
-#   endif
-#  endif
-# endif
-#endif
-
-/* whether HDRI is enable */
-#if !defined(MAGICKCORE_HDRI_ENABLE)
-# error "you should set MAGICKCORE_HDRI_ENABLE"
-#endif
-
-#if MAGICKCORE_HDRI_ENABLE
-# define MAGICKCORE_HDRI_SUPPORT 1
-#endif
-
 #if defined __CYGWIN32__ && !defined __CYGWIN__
    /* For backwards compatibility with Cygwin b19 and
       earlier, we define __CYGWIN__ here, so that


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The section labeled `/* Compatibility block */` was present in the file twice, identical except for one character.

(The one character was a typo correction in a warning message, "fix yours makefile" => "fix your makefile".)

If you compare lines 60:91, they're identical to the removed lines 95:126 except, as I said, for that typo that was only corrected in the first copy.