### PR TITLE
Support ICN file extension for old Windows icons

### DIFF
--- a/coders/icon.c
+++ b/coders/icon.c
@@ -851,6 +851,13 @@ ModuleExport size_t RegisterICONImage(void)
   entry->flags|=CoderDecoderSeekableStreamFlag;
   entry->flags|=CoderEncoderSeekableStreamFlag;
   (void) RegisterMagickInfo(entry);
+  entry=AcquireMagickInfo("ICON","ICN","Microsoft icon");
+  entry->decoder=(DecodeImageHandler *) ReadICONImage;
+  entry->encoder=(EncodeImageHandler *) WriteICONImage;
+  entry->flags ^= CoderAdjoinFlag;
+  entry->flags|=CoderDecoderSeekableStreamFlag;
+  entry->flags|=CoderEncoderSeekableStreamFlag;
+  (void) RegisterMagickInfo(entry);
   entry=AcquireMagickInfo("ICON","ICON","Microsoft icon");
   entry->decoder=(DecodeImageHandler *) ReadICONImage;
   entry->encoder=(EncodeImageHandler *) WriteICONImage;

--- a/coders/icon.h
+++ b/coders/icon.h
@@ -20,7 +20,8 @@
 
 #define MagickICONAliases \
   MagickCoderAlias("ICON", "CUR") \
-  MagickCoderAlias("ICON", "ICO")
+  MagickCoderAlias("ICON", "ICO") \
+  MagickCoderAlias("ICON", "ICN")
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Old archives of Windows icons from software found on the Internet archive have an .ICN extension. When converting them to BMP I get this error message:

```text
convert 007.ICN ../tmp.bmp
convert-im6.q16: no decode delegate for this image format ICN' @ error/constitute.c/ReadImage/581.
convert-im6.q16: no images defined ../tmp.bmp' @ error/convert.c/ConvertImageCommand/3234.
```

So I added ICN to the Windows Icon loader and [tested it](https://asciinema.org/a/716003) with the attached icons:
[HR7ICN.zip](https://github.com/user-attachments/files/19785487/HR7ICN.zip)