### PR TITLE
fix build when libjpeg is not in its default location

### DIFF
--- a/coders/Makefile.am
+++ b/coders/Makefile.am
@@ -1025,7 +1025,7 @@ coders_json_la_LIBADD      = $(MAGICKCORE_LIBS)
 
 # JXL coder module
 coders_jxl_la_SOURCES      = coders/jxl.c
-coders_jxl_la_CPPFLAGS     = $(MAGICK_CODER_CPPFLAGS)
+coders_jxl_la_CPPFLAGS     = $(MAGICK_CODER_CPPFLAGS) $(JXL_CFLAGS)
 coders_jxl_la_LDFLAGS      = $(MODULECOMMONFLAGS)
 coders_jxl_la_LIBADD       = $(MAGICKCORE_LIBS) $(JXL_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2470,7 +2470,9 @@ if test "$with_jpeg" != 'no'; then
             AC_MSG_RESULT([no -- some components failed test])
             have_jpeg='no (failed tests)'
         else
-            JPEG_LIBS='-ljpeg'
+            if test -z "$JPEG_LIBS"; then
+              JPEG_LIBS='-ljpeg'
+            fi
             LIBS="$JPEG_LIBS $LIBS"
             AC_DEFINE([JPEG_DELEGATE],[1],[Define if you have JPEG library])
             AC_MSG_RESULT([yes])


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The `configure` scripts ignore non-standard locations for `libjpeg` and `jpeg-xl`. On most macOS computers these come from Homebrew and are usually located either in `/opt/homebrew` or in `/usr/local` with `pkgconfig` correctly pointing to the right location.
Currently the `configure` script manages to find these but the build fails because the needed build flags are missing.

<!-- Thanks for contributing to ImageMagick! -->
