### PR TITLE
Fix Potential NULL dereference in WriteJSONImage( ) when SyncNextImageInList returns NULL

### DIFF
--- a/coders/json.c
+++ b/coders/json.c
@@ -1763,6 +1763,8 @@ static MagickBooleanType WriteJSONImage(const ImageInfo *image_info,
       }
     (void) WriteBlobString(image,",\n");
     image=SyncNextImageInList(image);
+    if (image == NULL)
+      break;
     status=SetImageProgress(image,SaveImagesTag,scene++,number_scenes);
     if (status == MagickFalse)
       break;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title  
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/) open  
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Describe

This patch fixes a potential NULL pointer dereference in the `WriteJSONImage()` function of `coders/json.c`.

In the loop that processes each image in the list, `image` is updated via `SyncNextImageInList(image)`. However, if the current image is the last in the list, this function can return `NULL`. The returned pointer is then passed directly to `SetImageProgress()` without a NULL check, which dereferences `image->progress_monitor`, leading to undefined behavior or a crash.

### Expected Behavior

The program should safely exit the image processing loop when there are no more images in the list, avoiding any NULL dereference.

### Actual Behavior

If the image list ends (i.e., `image->next == NULL`), the next iteration sets `image = NULL`, and then `SetImageProgress(image, ...)` attempts to dereference the NULL pointer, causing a segmentation fault.

This patch preserves the existing logic while ensuring memory safety.
Thanks for reviewing.