### PR TITLE
Fix compressed exr reading

### DIFF
--- a/coders/exr.c
+++ b/coders/exr.c
@@ -405,6 +405,10 @@ static MagickBooleanType ReadEXRScanlineImage(exr_context_t ctxt,int part_index,
     Quantum
       *q;
 
+    size_t
+      scans_count_to_read,
+      pixel_count_to_read;
+
     if (y != 0)
       {
         int
@@ -418,11 +422,13 @@ static MagickBooleanType ReadEXRScanlineImage(exr_context_t ctxt,int part_index,
       result=exr_decoding_run(ctxt,part_index,&decoder);
     if (result != EXR_ERR_SUCCESS)
       break;
-    q=QueueAuthenticPixels(image,0,y,image->columns,(size_t) scans_per_chunk,
+    scans_count_to_read=MagickMin((size_t) scans_per_chunk,image->rows-y);
+    pixel_count_to_read=scans_count_to_read*image->columns;
+    q=QueueAuthenticPixels(image,0,y,image->columns,scans_count_to_read,
       exception);
     if (q == (Quantum *) NULL)
       break;
-    status=ReadEXRPixels(image,decoder,pixel_channels,data,q,pixel_count,
+    status=ReadEXRPixels(image,decoder,pixel_channels,data,q,pixel_count_to_read,
       image->columns,0,exception);
     if (status == MagickFalse)
       break;


### PR DESCRIPTION
There is a bug with reading scanline exr files, when chunk size is not a divisor of the image height. Last chunk is not getting read in this case, and there remains a stripe of the undefined data in the bottom of the image. Compressed exrs have 16, 32 and other chunk sizes, so it silently affects them in many cases. Attaching some test exr images.
[CheckersExr.zip](https://github.com/user-attachments/files/21519703/CheckersExr.zip)
