### PR TITLE
Use OpenMP in ashlar

### DIFF
--- a/coders/ashlar.c
+++ b/coders/ashlar.c
@@ -56,6 +56,7 @@
 #include "MagickCore/option.h"
 #include "MagickCore/property.h"
 #include "MagickCore/quantum-private.h"
+#include "MagickCore/resource_.h"
 #include "MagickCore/static.h"
 #include "MagickCore/string_.h"
 #include "MagickCore/string-private.h"
@@ -458,6 +459,10 @@ static inline MagickBooleanType PackAshlarTiles(AshlarInfo *ashlar_info,
   /*
     Pack tiles so they fit the canvas with minimum excess.
   */
+#if defined(MAGICKCORE_OPENMP_SUPPORT)
+  #pragma omp parallel for schedule(dynamic) shared(status) \
+    num_threads((int) GetMagickResourceLimit(ThreadResource))
+#endif
   for (i=0; i < (ssize_t) number_tiles; i++)
     tiles[i].order=(i);
   qsort((void *) tiles,number_tiles,sizeof(*tiles),CompareTileHeight);
@@ -483,6 +488,10 @@ static inline MagickBooleanType PackAshlarTiles(AshlarInfo *ashlar_info,
   }
   qsort((void *) tiles,number_tiles,sizeof(*tiles),RestoreTileOrder);
   status=MagickTrue;
+#if defined(MAGICKCORE_OPENMP_SUPPORT)
+  #pragma omp parallel for schedule(dynamic) shared(status) \
+    num_threads((int) GetMagickResourceLimit(ThreadResource))
+#endif
   for (i=0; i < (ssize_t) number_tiles; i++)
   {
     tiles[i].order=(ssize_t) ((tiles[i].x != (ssize_t) MAGICK_SSIZE_MAX) ||
@@ -618,6 +627,10 @@ static Image *ASHLARImage(ImageInfo *image_info,Image *image,
   value=GetImageOption(image_info,"label");
   extent.width=0;
   extent.height=0;
+#if defined(MAGICKCORE_OPENMP_SUPPORT)
+  #pragma omp parallel for schedule(dynamic) shared(status) \
+    num_threads((int) GetMagickResourceLimit(ThreadResource))
+#endif
   for (i=0; i < n; i++)
   {
     Image


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The ashlar generation process seems to go something like this:
    1. Load images into memory
    2. Think about the arrangement for a bit
    3. Arrange images into the final layout

The third step happens to take a lot of time
By using parallelism from OpenMP with `#pragma omp parallel for ...`
In my testing the total time was reduced by 26.4% when output resolution is provided and by 12.8% otherwise

All tests were made on a CPU with 12 threads
Images' sizes are ranging from 30x30 to 1300x1300

Command: `magick -verbose *.png *.jpg -resize 1000x1000 -define ashlar:best-fit=true -gravity center ashlar:output${output}`
Benchmarked with `hyperfine -w 1 --runs 3`

|  Output                       |  Time     |  Parallelism applied                                                      |  Same output  |  Amount of images  |
|-------------------------------|-----------|---------------------------------------------------------------------------|---------------|--------------------|
| `.jpg[10000x10000+0+0]` |  96.4  |  nowhere (original version)                                               |  yes          |  2000              |
| `.jpg[10000x10000+0+0]` |  71.0  |  last `for` in `ASHLARImage`                                              |  yes          |  2000              |
| `.jpg[10000x10000+0+0]` |  70.9  |  last `for` in `ASHLARImage` and last `for` in `PackAshlarTiles`          |  yes          |  2000              |
| `.jpg[10000x10000+0+0]` |  ∞     |  last `for` in `ASHLARImage` and last two `for`s in `PackAshlarTiles`     |  no (stuck)           |  2000              |
| `.qoi`                  |  14.1  |  nowhere (original version)                                               |  yes          |  300               |
| `.qoi`                  |  12.2  |  last `for` in `ASHLARImage` and last `for` in `PackAshlarTiles`          |  yes          |  300               |
| `.qoi`                  |  12.3  |  last `for` in `ASHLARImage`, first and last `for` in `PackAshlarTiles`  |  yes          |  300               |
| `.qoi`                  |  9.2  |  last `for` in `ASHLARImage`, all `for`s in `PackAshlarTiles`  |  no (segfault)          |  300               |

Edit: time in seconds