### PR TITLE
Fix infinite loop when decoding JXL with `-limit height/width`

### DIFF
--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -643,8 +643,10 @@ static Image *ReadJXLImage(const ImageInfo *image_info,
       case JXL_DEC_NEED_IMAGE_OUT_BUFFER:
       {
         status=SetImageExtent(image,image->columns,image->rows,exception);
-        if (status == MagickFalse)
+        if (status == MagickFalse) {
+          jxl_status=JXL_DEC_ERROR;
           break;
+        }
         (void) ResetImagePixels(image,exception);
         JXLSetFormat(image,&pixel_format,exception);
         if (extent == 0)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Image transform was hanging up in an infinite loop on some of my jxl's.
Break was breaking the switch instead of a loop.
This should do the trick.

```sh
magick -limit width 200 cat.jxl JPG:test
```

