### PR TITLE
cache.c: Fix unused function warning

### DIFF
--- a/MagickCore/cache.c
+++ b/MagickCore/cache.c
@@ -652,6 +652,7 @@ static MagickBooleanType ClonePixelCacheOnDisk(
   return(MagickTrue);
 }
 
+#if defined(MAGICKCORE_OPENMP_SUPPORT)
 static inline int GetCacheNumberThreads(const CacheInfo *source,
   const CacheInfo *destination,const size_t chunk,const int factor)
 {
@@ -674,6 +675,7 @@ static inline int GetCacheNumberThreads(const CacheInfo *source,
     number_threads=MagickMin(number_threads,4);
   return((int) number_threads);
 }
+#endif
 
 static MagickBooleanType ClonePixelCacheRepository(
   CacheInfo *magick_restrict clone_info,CacheInfo *magick_restrict cache_info,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

* Minor fix, warning only.
* Fix "warning: unused function 'GetCacheNumberThreads'"
* Need guards because the only function references are also in guarded blocks.