### PR TITLE
Fix slow processing for TIFFs that lie about their page numbers.

### DIFF
--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -1229,7 +1229,8 @@ static Image *ReadTIFFImage(const ImageInfo *image_info,
     sample_format = 0,
     samples_per_pixel = 0,
     units = 0,
-    value = 0;
+    value = 0,
+    page_number = 0;
 
   uint32
     height,
@@ -1571,9 +1572,7 @@ static Image *ReadTIFFImage(const ImageInfo *image_info,
             ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
           }
       }
-    value=(unsigned short) image->scene;
-    if (TIFFGetFieldDefaulted(tiff,TIFFTAG_PAGENUMBER,&value,&pages,sans) == 1)
-      image->scene=value;
+    image->scene = page_number;
     if (image->storage_class == PseudoClass)
       {
         size_t
@@ -1618,8 +1617,9 @@ static Image *ReadTIFFImage(const ImageInfo *image_info,
     if (image_info->ping != MagickFalse)
       {
         if (image_info->number_scenes != 0)
-          if (image->scene >= (image_info->scene+image_info->number_scenes-1))
+          if (page_number >= (page_number+image_info->number_scenes-1))
             break;
+        page_number += 1;
         goto next_tiff_frame;
       }
     status=SetImageExtent(image,image->columns,image->rows,exception);
@@ -2248,7 +2248,7 @@ static Image *ReadTIFFImage(const ImageInfo *image_info,
       Proceed to next image.
     */
     if (image_info->number_scenes != 0)
-      if (image->scene >= (image_info->scene+image_info->number_scenes-1))
+      if (page_number >= (page_number+image_info->number_scenes-1))
         break;
     more_frames=TIFFReadDirectory(tiff) != 0 ? MagickTrue : MagickFalse;
     if (more_frames != MagickFalse)
@@ -2264,7 +2264,7 @@ static Image *ReadTIFFImage(const ImageInfo *image_info,
           }
         image=SyncNextImageInList(image);
         status=SetImageProgress(image,LoadImagesTag,(MagickOffsetType)
-          image->scene-1,image->scene);
+          page_number-1,page_number);
         if (status == MagickFalse)
           break;
       }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Previously, the code tried to query for the page number tag, which is documented as being "The page number of the page from which this image was scanned". https://www.loc.gov/preservation/digital/formats/content/tiff_tags.shtml

However, we've identified TIFFs in the wild that have the page number set as 0 for all pages.

This causes the current code to never break early, and causes the rendering to be slow.

This commit replaces the querying of TIFFTAG_PAGENUMBER with a counter.

It otherwise keeps the original behavior and API contract.