### PR TITLE
Add an alias for the original Magic Kernel

### DIFF
--- a/MagickCore/option.c
+++ b/MagickCore/option.c
@@ -1544,6 +1544,7 @@ static const OptionInfo
     { "Lanczos2Sharp", Lanczos2SharpFilter, UndefinedOptionFlag, MagickFalse },
     { "LanczosRadius", LanczosRadiusFilter, UndefinedOptionFlag, MagickFalse },
     { "LanczosSharp", LanczosSharpFilter, UndefinedOptionFlag, MagickFalse },
+    { "MagicKernel2011", QuadraticFilter, UndefinedOptionFlag, MagickFalse }, /* same kernel */
     { "MagicKernelSharp2013", MagicKernelSharp2013Filter, UndefinedOptionFlag, MagickFalse },
     { "MagicKernelSharp2021", MagicKernelSharp2021Filter, UndefinedOptionFlag, MagickFalse },
     { "Mitchell", MitchellFilter, UndefinedOptionFlag, MagickFalse },


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

ImageMagick currently includes Magic Kernel Sharp 2013 and Magic Kernel Sharp 2021, but not the original (non-sharp) Magic Kernel from 2011. Luckily, `Quadratic` happens to be the exact same kernel:

<img width="430" height="325" alt="Analytical formula for the Magic Kernel, identical to Quadratic" src="https://github.com/user-attachments/assets/7d649486-8bc4-4213-8861-4f1b5b4f125e" />

```c
static double Quadratic(const double x,
  const ResizeFilter *magick_unused(resize_filter))
{
  magick_unreferenced(resize_filter);

  /*
    2rd order (quadratic) B-Spline approximation of Gaussian.
  */
  if (x < 0.5)
    return(0.75-x*x);
  if (x < 1.5)
    return(0.5*(x-1.5)*(x-1.5));
  return(0.0);
}
```

This PR adds a `MagicKernel2011` alias for completeness.