### PR TITLE
Fix autoconf syntax errors (configure.ac)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1047,18 +1047,18 @@ AC_CHECK_SIZEOF([void *])
 ########
 AC_MSG_CHECKING([whether our compiler supports __func__])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
- [{ const char *func = __func__; return(func != 0 ? 0 : 1); }],
+ [{ const char *func = __func__; return(func != 0 ? 0 : 1); }])],
  AC_MSG_RESULT([yes]),
  AC_MSG_RESULT([no])
  AC_MSG_CHECKING([whether our compiler supports __FUNCTION__])
- AC_COMPILE_IFELSE([],
-   [{ const char *func = __FUNCTION__; return(func != 0 ? 0 : 1); }],
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
+   [{ const char *func = __FUNCTION__; return(func != 0 ? 0 : 1); }])],
    AC_MSG_RESULT([yes])
    AC_DEFINE(__func__, __FUNCTION__,
      [Define to appropriate substitute if compiler does not have __func__]),
    AC_MSG_RESULT([no])
    AC_DEFINE(__func__, __FILE__,
-     [Define to appropriate substitute if compiler does not have __func__])))])
+     [Define to appropriate substitute if compiler does not have __func__])))
 
 ########
 #
@@ -1455,7 +1455,7 @@ if test "$enable_ccmalloc" = 'yes'; then
         OLIBS="$LIBS"
         # Assume that gcc is used with ccmalloc.
         LIBS="$LIBS $CCMALLOC_PREFIX/lib/ccmalloc-gcc.o"
-        AC_CHECK_LIB([ccmalloc],[ccmalloc_malloc],[CCMALLOC_LIBS="$CCMALLOC_PREFIX/lib/ccmalloc-gcc.o -lccmalloc -ldl"],[,-ldl])
+        AC_CHECK_LIB([ccmalloc],[ccmalloc_malloc],[CCMALLOC_LIBS="$CCMALLOC_PREFIX/lib/ccmalloc-gcc.o -lccmalloc -ldl"],[],[-ldl])
         if test -n "$CCMALLOC_LIBS"; then
             LIBS="$OLIBS"
             LIBS="$LIBS $CCMALLOC_LIBS"
@@ -2274,7 +2274,7 @@ if test "$with_fontpath" != "yes" && test -z "$with_fontpath"; then
 else
     AC_DEFINE_UNQUOTED([MAGICK_FONT_PATH],["$with_fontpath"],[Define to prepend to default font search path.])
 fi
-if test "$with_fontpath=" != ''; then
+if test "$with_fontpath" != ''; then
     DISTCHECK_CONFIG_FLAGS="${DISTCHECK_CONFIG_FLAGS} --with-fontpath=$with_fontpath "
 fi
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->
When I parsed configure.ac in your project, several syntax errors were found in `configure.ac`.
- In nested `AC_COMPILE_IFELSE` calls, several syntax errors were found including unclosed quotes, missing `AC_LANG_PROGRAM` call, etc..
- The fourth & fifth arguments of a `AC_CHECK_LIB` call are not correctly quoted, and an invalid command (`-ldl`) is generated in the configure.

Unfortunately I could not produce a minimally changed `configure` script even with my autoconf-2.72, I believe this fix will help the developers to generate more robust `configure`. 
<!-- Thanks for contributing to ImageMagick! -->
