### PR TITLE
Fix warnings about operations on volatiles that are deprecated in C++20

### DIFF
--- a/Magick++/tests/attributes.cpp
+++ b/Magick++/tests/attributes.cpp
@@ -19,7 +19,7 @@ int main( int /*argc*/, char ** argv)
   // Initialize ImageMagick install location for Windows
   MagickPlusPlusGenesis genesis(*argv);
 
-  volatile int failures=0;
+  int failures=0;
 
   try {
 

--- a/Magick++/tests/exceptions.cpp
+++ b/Magick++/tests/exceptions.cpp
@@ -18,7 +18,7 @@ int main( int /*argc*/, char ** argv)
   // Initialize ImageMagick install location for Windows
   MagickPlusPlusGenesis genesis(*argv);
       
-  volatile int failures=0;
+  int failures=0;
       
   cout << "Checking for working exceptions (may crash) ... ";
   cout.flush();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The warnings are emitted by gcc 13.3 when ImageMagick is compiled in C++20 or later mode. The variables need not be volatile anyway.
