### PR TITLE
Add overflow checks to BMP/DIB write paths and DIB read path

### DIFF
--- a/coders/bmp.c
+++ b/coders/bmp.c
@@ -2042,6 +2042,9 @@ static MagickBooleanType WriteBMPImage(const ImageInfo *image_info,Image *image,
               }
           }
       }
+    if (BMPOverflowCheck(image->columns,(size_t) bmp_info.bits_per_pixel) !=
+        MagickFalse)
+      ThrowWriterException(ImageError,"WidthOrHeightExceedsLimit");
     extent=image->columns*(size_t) bmp_info.bits_per_pixel;
     bytes_per_line=4*((extent+31)/32);
     if (BMPOverflowCheck(bytes_per_line,image->rows) != MagickFalse)


### PR DESCRIPTION
The BMP read path checks `columns * bits_per_pixel` for overflow before computing `extent` (line 1120), but the BMP write path (line 2045) skips this check. The DIB coder has no overflow checks at all; its read and write paths compute `bytes_per_line` and `length` from file-controlled dimensions without guards.

**bmp.c:** Adds `BMPOverflowCheck(columns, bits_per_pixel)` to the write path before the `extent` multiplication, matching the existing read-path pattern.

**dib.c:** Adds `HeapOverflowSanityCheck` calls to both read and write paths covering `columns * bits_per_pixel`, `bytes_per_line * rows`, and the pre-allocation size checks. Also fixes the read-path blob size sanity check to use the safe division form (`length/256 > blob_size` instead of `length > 256*blob_size`) matching bmp.c line 1127, and fixes the write-path memset to use `(size_t) bytes_per_line*image->rows` instead of `dib_info.image_size` (which is `unsigned int` and truncates when the product exceeds UINT32_MAX).

These are the same overflow checks added to the BMP read path after CVE-2025-57803 and CVE-2025-62171. Can provide an ImageMagick6 backport if applicable.