### PR TITLE
Fix NULL pointer dereference in HEIC NCLX profile allocation

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -1482,6 +1482,8 @@ static MagickBooleanType WriteHEICImage(const ImageInfo *image_info,
 
         SetGeometryInfo(&cicp);
         nclx_profile=heif_nclx_color_profile_alloc();
+        if (nclx_profile == (struct heif_color_profile_nclx *) NULL)
+          ThrowWriterException(ResourceLimitError,"MemoryAllocationFailed");
         cicp.rho=(double) nclx_profile->color_primaries;
         cicp.sigma=(double) nclx_profile->transfer_characteristics;
         cicp.xi=(double) nclx_profile->matrix_coefficients;


### PR DESCRIPTION
## Summary

- Add NULL check after `heif_nclx_color_profile_alloc()` in `WriteHEICImage()` (`coders/heic.c:1484`)
- Prevents SIGSEGV crash when allocation fails under memory pressure with `heic:cicp` option

## Problem

`heif_nclx_color_profile_alloc()` can return NULL, but the return value is immediately dereferenced without a check, causing a NULL pointer dereference (CWE-476) and process crash.

## Fix

```c
nclx_profile=heif_nclx_color_profile_alloc();
if (nclx_profile == (struct heif_color_profile_nclx *) NULL)
  ThrowWriterException(ResourceLimitError,"MemoryAllocationFailed");
```

Follows existing ImageMagick allocation-failure conventions used throughout the codebase.

## References

- Closes #8584
- CWE-476 | CVSS 6.5 (`AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H`)

## Test plan

- [x] Verified fix matches ImageMagick `ThrowWriterException` conventions
- [ ] Build with libheif >= 1.17.0 and confirm `magick input.jpg -define heic:cicp=1 output.heic` works normally
- [ ] Confirm allocation failure path returns `ResourceLimitError` instead of crashing