### PR TITLE
Add overflow check to sixel write path

### DIFF
--- a/coders/sixel.c
+++ b/coders/sixel.c
@@ -815,6 +815,8 @@ static MagickBooleanType sixel_encode_impl(sixel_pixel_t *pixels,size_t width,
   context->pos = 0;
   if (ncolors < 1)
     return(MagickFalse);
+  if (HeapOverflowSanityCheck(ncolors,width) != MagickFalse)
+    return(MagickFalse);
   len=ncolors*width;
   context->active_palette=(-1);
   map=(sixel_pixel_t *) AcquireQuantumMemory(len,sizeof(sixel_pixel_t));


### PR DESCRIPTION
The sixel encoder pre-multiplies `ncolors * width` before `AcquireQuantumMemory`, bypassing the internal overflow check. This adds `HeapOverflowSanityCheck` before the multiplication.

Complements the read-path bounds checks in 47a803c.