### PR TITLE
Add overflow checks to PS3 write path

### DIFF
--- a/coders/ps3.c
+++ b/coders/ps3.c
@@ -325,6 +325,10 @@ static MagickBooleanType SerializeImage(const ImageInfo *image_info,
   const Quantum
     *p;
 
+  size_t
+    channels,
+    extent;
+
   ssize_t
     x;
 
@@ -339,8 +343,13 @@ static MagickBooleanType SerializeImage(const ImageInfo *image_info,
   if (IsEventLogging() != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",image->filename);
   status=MagickTrue;
-  *length=(image->colorspace == CMYKColorspace ? 4 : 3)*(size_t)
-    image->columns*image->rows;
+  channels=(image->colorspace == CMYKColorspace ? 4 : 3);
+  if (HeapOverflowSanityCheckGetSize(channels,(size_t) image->columns,
+        &extent) != MagickFalse)
+    ThrowWriterException(ResourceLimitError,"MemoryAllocationFailed");
+  if (HeapOverflowSanityCheckGetSize(extent,image->rows,length) !=
+        MagickFalse)
+    ThrowWriterException(ResourceLimitError,"MemoryAllocationFailed");
   *pixel_info=AcquireVirtualMemory(*length,sizeof(*q));
   if (*pixel_info == (MemoryInfo *) NULL)
     ThrowWriterException(ResourceLimitError,"MemoryAllocationFailed");


### PR DESCRIPTION
The PS3 encoder's `SerializeImage` pre-multiplies `channels * columns * rows` before `AcquireVirtualMemory`, bypassing the internal overflow check. This adds two-stage `HeapOverflowSanityCheckGetSize` checks before the multiplication.

Same pattern as the BMP/DIB fixes in #8573 and the sixel/SGI fixes in #8587 and #8588.