### PR TITLE
fix heap over-read in BilateralBlurImage with even-dimension kernels

### DIFF
--- a/MagickCore/effect.c
+++ b/MagickCore/effect.c
@@ -1039,8 +1039,8 @@ MagickExport Image *BilateralBlurImage(const Image *image,const size_t width,
           double
             intensity;
 
-          r=p+(ssize_t) (GetPixelChannels(image)*MagickMax(width,1)*
-            (size_t) (mid.y-v)+GetPixelChannels(image)*(size_t) (mid.x-u));
+          r=p+(ssize_t) GetPixelChannels(image)*(ssize_t) MagickMax(width,1)*
+            (v-mid.y)+(ssize_t) GetPixelChannels(image)*(u-mid.x);
           intensity=ScaleQuantumToChar((const Quantum) GetPixelIntensity(image,r))-
             (double) ScaleQuantumToChar((const Quantum) GetPixelIntensity(image,p));
           if ((intensity >= -MaxIntensity) && (intensity <= MaxIntensity))
@@ -1084,8 +1084,8 @@ MagickExport Image *BilateralBlurImage(const Image *image,const size_t width,
             {
               for (u=0; u < (ssize_t) MagickMax(width,1); u++)
               {
-                r=p+GetPixelChannels(image)*MagickMax(width,1)*(size_t)
-                  (mid.y-v)+GetPixelChannels(image)*(size_t) (mid.x-u);
+                r=p+(ssize_t) GetPixelChannels(image)*(ssize_t) MagickMax(width,1)*
+                  (v-mid.y)+(ssize_t) GetPixelChannels(image)*(u-mid.x);
                 pixel+=weights[id][n]*(double) r[i];
                 gamma+=weights[id][n];
                 n++;
@@ -1106,8 +1106,8 @@ MagickExport Image *BilateralBlurImage(const Image *image,const size_t width,
               alpha,
               beta;
 
-            r=p+GetPixelChannels(image)*MagickMax(width,1)*(size_t) (mid.y-v)+
-              GetPixelChannels(image)*(size_t) (mid.x-u);
+            r=p+(ssize_t) GetPixelChannels(image)*(ssize_t) MagickMax(width,1)*
+              (v-mid.y)+(ssize_t) GetPixelChannels(image)*(u-mid.x);
             alpha=(double) (QuantumScale*(double) GetPixelAlpha(image,p));
             beta=(double) (QuantumScale*(double) GetPixelAlpha(image,r));
             pixel+=weights[id][n]*(double) r[i];


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The mirrored pixel mapping `(mid.x-u, mid.y-v)` in `BilateralBlurImage()` accesses buffer position `(2*mid.x - u)`. For even width `2k`, `mid.x = k`, so `u = 0` accesses column `2k = width` — one past the buffer end. This is a heap over-read of one pixel, caught by ASAN on any image processed with even-dimension `-bilateral-blur` kernels (e.g. 4x4, 6x6). Odd-dimension kernels are unaffected.

This patch reverses the mapping to `(v-mid.y, u-mid.x)` with signed arithmetic at all three call sites (lines 1042, 1087, 1109). The bilateral filter output is unchanged since the spatial Gaussian weights are symmetric. ASAN-verified with kernel sizes 2x2 through 10x10.

Closes #8593