### PR TITLE
Fix composite -dissolve adding random noise

### DIFF
--- a/MagickCore/composite.c
+++ b/MagickCore/composite.c
@@ -71,8 +71,6 @@
 #include "MagickCore/pixel-accessor.h"
 #include "MagickCore/property.h"
 #include "MagickCore/quantum.h"
-#include "MagickCore/random_.h"
-#include "MagickCore/random-private.h"
 #include "MagickCore/resample.h"
 #include "MagickCore/resource_.h"
 #include "MagickCore/string_.h"
@@ -1461,9 +1459,6 @@ MagickExport MagickBooleanType CompositeImage(Image *image,
   MagickStatusType
     flags;
 
-  RandomInfo
-    *random_info;
-
   ssize_t
     y;
 
@@ -2196,7 +2191,6 @@ MagickExport MagickBooleanType CompositeImage(Image *image,
   status=MagickTrue;
   progress=0;
   midpoint=((MagickRealType) QuantumRange+1.0)/2;
-  random_info=AcquireRandomInfo();
   source_view=AcquireVirtualCacheView(source_image,exception);
   image_view=AcquireAuthenticCacheView(image,exception);
 #if defined(MAGICKCORE_OPENMP_SUPPORT)
@@ -2929,10 +2923,8 @@ MagickExport MagickBooleanType CompositeImage(Image *image,
           }
           case DissolveCompositeOp:
           {
-            if (GetPseudoRandomValue(random_info) < (source_dissolve*Sa))
-              pixel=Sc;
-            else
-              pixel=Dc;
+            pixel=gamma*(source_dissolve*Sa*Sc-source_dissolve*Sa*
+              canvas_dissolve*Da*Dc+canvas_dissolve*Da*Dc);
             break;
           }
           case DivideDstCompositeOp:
@@ -3585,7 +3577,6 @@ MagickExport MagickBooleanType CompositeImage(Image *image,
   }
   source_view=DestroyCacheView(source_view);
   image_view=DestroyCacheView(image_view);
-  random_info=DestroyRandomInfo(random_info);
   if (canvas_image != (Image * ) NULL)
     canvas_image=DestroyImage(canvas_image);
   else


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Revert DissolveCompositeOp from per-pixel coin-flip (GetPseudoRandomValue) back to the original deterministic weighted alpha-blend formula. The random approach produced lots of visible dithering noise.

Also removes the RandomInfo infrastructure (includes, declaration, acquire, destroy) that was only used for this broken dissolve implementation.

Regression introduced in 49e5a1114 (issue #8579 refactoring).

Example of the issue can be seen here: https://github.com/ImageMagick/ImageMagick/issues/8620
