### PR TITLE
Fix animated JXL frame delay handling

### DIFF
--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -626,6 +626,9 @@ static Image *ReadJXLImage(const ImageInfo *image_info,
       }
       case JXL_DEC_FRAME:
       {
+        JxlFrameHeader
+          frame_header;
+
         if (image_count++ != 0)
           {
             JXLAddProfilesToImage(image,&exif_profile,&xmp_profile,exception);
@@ -638,6 +641,9 @@ static Image *ReadJXLImage(const ImageInfo *image_info,
             image=SyncNextImageInList(image);
             JXLInitImage(image,&basic_info);
           }
+        (void) memset(&frame_header,0,sizeof(frame_header));
+        if (JxlDecoderGetFrameHeader(jxl_info,&frame_header) == JXL_DEC_SUCCESS)
+          image->delay=(size_t) frame_header.duration;
         break;
       }
       case JXL_DEC_NEED_IMAGE_OUT_BUFFER:
@@ -1070,7 +1076,6 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
       basic_info.animation.tps_numerator=(uint32_t) image->ticks_per_second;
       basic_info.animation.tps_denominator=1;
       JxlEncoderInitFrameHeader(&frame_header);
-      frame_header.duration=1;
     }
   jxl_status=JxlEncoderSetBasicInfo(jxl_info,&basic_info);
   if (jxl_status != JXL_ENC_SUCCESS)
@@ -1177,6 +1182,7 @@ static MagickBooleanType WriteJXLImage(const ImageInfo *image_info,Image *image,
 
     if (basic_info.have_animation == JXL_TRUE)
       {
+        frame_header.duration=(uint32_t) image->delay;
         jxl_status=JxlEncoderSetFrameHeader(frame_settings,&frame_header);
         if (jxl_status != JXL_ENC_SUCCESS)
           break;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

ImageMagick supports animated JXL format, but any edit made to a JXL file is messing up the animation speed, because the duration is hardcoded to 1. This change preserves the original animation timing when resizing or editing animated JXL files.

Read per-frame duration from JxlFrameHeader during decode by calling JxlDecoderGetFrameHeader() in the JXL_DEC_FRAME handler, setting image->delay from frame_header.duration.

Write per-frame delay from image->delay during encode instead of hardcoding frame_header.duration to 1.

This partly solves https://github.com/ImageMagick/ImageMagick/issues/8464

https://github.com/user-attachments/assets/11e8b843-098c-4023-a5d3-afd8d7ce5e0b

Image from https://jpegxl.info/resources/jpeg-xl-test-page.html
