### PR TITLE
Fix off-by-one in MNG FRAM chunk delay/timeout parsing

### DIFF
--- a/coders/png.c
+++ b/coders/png.c
@@ -5589,7 +5589,7 @@ static Image *ReadOneMNGImage(MngReadInfo* mng_info,
                     change_clipping=(*p++);
                     p++; /* change_sync */
 
-                    if (change_delay && ((p-chunk) < (ssize_t) (length-4)))
+                    if (change_delay && ((p-chunk)+4 <= (ssize_t) length))
                       {
                         frame_delay=(size_t) image->ticks_per_second*
                           (size_t) mng_get_long(p);
@@ -5610,7 +5610,7 @@ static Image *ReadOneMNGImage(MngReadInfo* mng_info,
                             "    Framing_delay=%.20g",(double) frame_delay);
                       }
 
-                    if (change_timeout && ((p-chunk) < (ssize_t) (length-4)))
+                    if (change_timeout && ((p-chunk)+4 <= (ssize_t) length))
                       {
                         frame_timeout=(size_t) image->ticks_per_second*
                           (size_t) mng_get_long(p);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The boundary check (p-chunk) < (length-4) rejected valid FRAM chunks where the 4-byte delay value ends exactly at the chunk boundary. Changed to (p-chunk)+4 <= length to correctly allow reading the delay when it fits within the chunk data.

This caused all MNG frames to use the MHDR default delay (1 tick) instead of the per-frame delay specified in the FRAM chunk. Resizing or editing an animated MNG would produce output running at the wrong speed.

I attached an example file. Doing anything with this file (resize, flip etc.) will cause it to change the speed (total length is reduced from 00:00:02.40 to 00:00:00.52). After this fix, it keeps the original animation speed.

[sample.mng.zip](https://github.com/user-attachments/files/26055147/sample.mng.zip)