### PR TITLE
Fix MNG frame disposal for transparent animations

### DIFF
--- a/coders/png.c
+++ b/coders/png.c
@@ -6328,6 +6328,11 @@ static Image *ReadOneMNGImage(MngReadInfo* mng_info,
         else
           image->delay=0;
 
+        if (mng_info->framing_mode == 3)
+          image->dispose=BackgroundDispose;
+        else
+          image->dispose=NoneDispose;
+
         image->page.width=mng_info->mng_width;
         image->page.height=mng_info->mng_height;
         image->page.x=mng_info->x_off[object_id];
@@ -13583,7 +13588,7 @@ static MagickBooleanType WriteMNGImage(const ImageInfo *image_info,Image *image,
 
    mng_info->write_mng=write_mng;
 
-   if ((int) image->dispose >= 3)
+   if ((int) image->dispose >= BackgroundDispose)
      mng_info->framing_mode=3;
 
    if (mng_info->need_fram != MagickFalse && mng_info->adjoin != MagickFalse &&


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Transparent MNG image frame disposal was not handled correctly, previous frames were not disappearing after editing with IM.

Reader: set image->dispose=BackgroundDispose when MNG framing_mode is 3 (restore background before next frame). Previously disposal was never set from framing_mode, defaulting to NoneDispose and losing the disposal information on read.

Writer: trigger framing_mode=3 when image->dispose >= BackgroundDispose (value 2) instead of only >= PreviousDispose (value 3). This was an off-by-one in the dispose check that prevented BackgroundDispose from producing the correct MNG framing mode.

Together these ensure disposal information survives read-edit-write cycles for transparent MNG animations.

I'm adding files in GIF format (converted from MNG) since neither github, nor any modern browser supports MNG.

Original:
![original](https://github.com/user-attachments/assets/5918527c-c7eb-43e4-806d-7cee10faac2c)

IM output, before change:
![before](https://github.com/user-attachments/assets/de9c490b-9274-4cdd-abbe-5a85b384c32f)

IM output after:
![after](https://github.com/user-attachments/assets/7b7dc627-5983-4df9-b96e-761705bedee1)

Source MNG file:
[anim-icos.mng.zip](https://github.com/user-attachments/files/26061102/anim-icos.mng.zip)
