### PR TITLE
Fix NULL pointer dereference in ReadDOTImage()

### DIFF
--- a/coders/dot.c
+++ b/coders/dot.c
@@ -136,11 +136,23 @@ static Image *ReadDOTImage(const ImageInfo *image_info,ExceptionInfo *exception)
   (void) AcquireUniqueFilename(read_info->filename);
   (void) FormatLocaleString(command,MagickPathExtent,"-Tsvg -o%s %s",
     read_info->filename,image_info->filename);
+  {
+    FILE
+      *file;
+
+    file=GetBlobFileHandle(image);
+    if (file == (FILE *) NULL)
+      {
+        (void) RelinquishUniqueFileResource(read_info->filename);
+        read_info=DestroyImageInfo(read_info);
+        return(DestroyImageList(image));
+      }
 #if !defined(WITH_CGRAPH)
-  graph=agread(GetBlobFileHandle(image));
+    graph=agread(file);
 #else
-  graph=agread(GetBlobFileHandle(image),(Agdisc_t *) NULL);
+    graph=agread(file,(Agdisc_t *) NULL);
 #endif
+  }
   if (graph == (graph_t *) NULL)
     {
       (void) RelinquishUniqueFileResource(read_info->filename);


### PR DESCRIPTION
## Summary

`GetBlobFileHandle()` can return NULL when the image blob is opened in a non-file mode (e.g., when gzip/bzip2 magic bytes are detected by `OpenBlob()`). In `ReadDOTImage()`, the return value was passed directly to `agread()` without a NULL check, causing a NULL pointer dereference crash.

This adds a NULL guard before calling `agread()`, returning early with proper cleanup consistent with the existing error handling pattern in the function.

## Test plan

- [ ] Open a `.dot` file whose first bytes are gzip magic (`0x1F 0x8B 0x08`) — should return gracefully instead of crashing
- [ ] Normal `.dot` file processing still works