### PR TITLE
Set BackgroundDispose for animated JXL frames with alpha

### DIFF
--- a/coders/jxl.c
+++ b/coders/jxl.c
@@ -48,6 +48,7 @@
 #include "MagickCore/exception-private.h"
 #include "MagickCore/image.h"
 #include "MagickCore/image-private.h"
+#include "MagickCore/layer.h"
 #include "MagickCore/list.h"
 #include "MagickCore/magick.h"
 #include "MagickCore/memory_.h"
@@ -644,6 +645,9 @@ static Image *ReadJXLImage(const ImageInfo *image_info,
         (void) memset(&frame_header,0,sizeof(frame_header));
         if (JxlDecoderGetFrameHeader(jxl_info,&frame_header) == JXL_DEC_SUCCESS)
           image->delay=(size_t) frame_header.duration;
+        if ((basic_info.have_animation == JXL_TRUE) &&
+            (basic_info.alpha_bits != 0))
+          image->dispose=BackgroundDispose;
         break;
       }
       case JXL_DEC_NEED_IMAGE_OUT_BUFFER:


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

JXL delivers fully coalesced frames where each frame is a complete independent image. Without setting dispose, converting transparent animated JXL to GIF/WebP/MNG causes frames to accumulate instead of replacing, making previous frames bleed through transparent areas.

JXL to GIF conversion before:
![jxl-to-gif-before](https://github.com/user-attachments/assets/8f97d02e-5557-48f7-86b4-49dd3b61c830)

After this fix:
![jxl-to-gif-after](https://github.com/user-attachments/assets/c39cc1b7-3a4e-4308-ad91-795087b19066)

Test file:
[anim-icos.jxl.zip](https://github.com/user-attachments/files/26193519/anim-icos.jxl.zip)