### PR TITLE
Avoid frame duplication for APNG in video coder

### DIFF
--- a/coders/video.c
+++ b/coders/video.c
@@ -578,7 +578,8 @@ static MagickBooleanType WriteVIDEOImage(const ImageInfo *image_info,
     scene;
 
   ssize_t
-    i;
+    i,
+    length_of_delay_loop;
 
   unsigned char
     *blob;
@@ -620,7 +621,11 @@ static MagickBooleanType WriteVIDEOImage(const ImageInfo *image_info,
     length=0;
     scene=p->scene;
     delay=100.0*p->delay/MagickMax(1.0*p->ticks_per_second,1.0);
-    for (i=0; i < (ssize_t) MagickMax((1.0*delay+1.0)/3.0,1.0); i++)
+    if (LocaleNCompare(image_info->magick,"APNG",MagickPathExtent) == 0)
+      length_of_delay_loop=1;
+    else
+      length_of_delay_loop=(ssize_t) MagickMax((1.0*delay+1.0)/3.0,1.0);
+    for (i=0; i < length_of_delay_loop; i++)
     {
       p->scene=count;
       count++;
@@ -735,7 +740,11 @@ static MagickBooleanType WriteVIDEOImage(const ImageInfo *image_info,
   for (p=clone_images; p != (Image *) NULL; p=GetNextImageInList(p))
   {
     delay=100.0*p->delay/MagickMax(1.0*p->ticks_per_second,1.0);
-    for (i=0; i < (ssize_t) MagickMax((1.0*delay+1.0)/3.0,1.0); i++)
+    if (LocaleNCompare(image_info->magick,"APNG",MagickPathExtent) == 0)
+      length_of_delay_loop=1;
+    else
+      length_of_delay_loop=(ssize_t) MagickMax((1.0*delay+1.0)/3.0,1.0);
+    for (i=0; i < length_of_delay_loop; i++)
     {
       (void) FormatLocaleString(p->filename,MagickPathExtent,"%s%.20g.%s",
         basename,(double) count++,intermediate_format);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The video coder duplicates frames to simulate timing at a fixed frame rate for video formats. APNG supports per-frame delays natively via fcTL chunks just like GIF and other animated image formats, so this duplication is unnecessary and causes the output to have double (or more) the expected number of frames.

Converting this 48 frame GIF to APNG gives 96 frame output. This change fixes that.

![gif](https://github.com/user-attachments/assets/4bee0174-75c6-4cd8-b92c-cedf2c3c1ead)

`magick anim-icos.gif -coalesce APNG:output.png`

https://github.com/user-attachments/assets/b98acdcb-0f87-4ef7-b749-f1f6e514a991

My conversion tests after all the recent fixes: https://ezgif.com/im-convert-test/index.html

