### PR TITLE
Fix APNG output duration/framerate

### DIFF
--- a/coders/video.c
+++ b/coders/video.c
@@ -711,6 +711,21 @@ static MagickBooleanType WriteVIDEOImage(const ImageInfo *image_info,
             " -pix_fmt \"%s\""," -pix_fmt '%s'",option);
           (void) ConcatenateMagickString(options,command,MagickPathExtent);
         }
+      if (LocaleNCompare(image_info->magick,"APNG",MagickPathExtent) == 0)
+        {
+          double
+            time_per_frame;
+
+          time_per_frame=1.0*clone_images->delay/MagickMax(1.0*
+            clone_images->ticks_per_second,1.0);
+          if (time_per_frame > 0.0)
+            {
+              (void) FormatLocaleString(command,MagickPathExtent,
+                " -filter:v \"setpts=(25*%.20g)*PTS\" -r 1/%.20g",
+                time_per_frame,time_per_frame);
+              (void) ConcatenateMagickString(options,command,MagickPathExtent);
+            }
+        }
       AcquireUniqueFilename(write_info->unique);
       (void) FormatLocaleString(command,MagickPathExtent,
         GetDelegateCommands(delegate_info),basename,intermediate_format,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
After my previous pull request for aviding duplicating frames in APNG, exactly one intermediate file is passed to ffmpeg for each original frame. FFmpeg assumes 25 fps for image sequence inputs and no framerate was explicitly passed, so the output APNG was always forced to exactly 25 fps (40ms per frame), ignoring the actual image delay.

This commit appends a precise setpts and -r override to the ffmpeg options for APNG outputs, stretching or squeezing the input PTS to match the requested time_per_frame and ensuring the correct APNG metadata is written and the output has both correct frame count and delay.

https://github.com/user-attachments/assets/4dff57bd-b382-481a-8536-3b4ab0748622

