### PR TITLE
Animated AVIF support (libheif 1.20.0+)

### DIFF
--- a/coders/heic.c
+++ b/coders/heic.c
@@ -121,7 +121,7 @@ static MagickBooleanType
 %    o exception: return any errors or warnings in this structure.
 %
 */
-#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,20,0)
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,19,0)
 static inline void HEICSetUint32SecurityLimit(const ImageInfo *image_info,
   const char *name,uint32_t *value)
 {
@@ -981,7 +981,7 @@ static Image *ReadHEICImage(const ImageInfo *image_info,
   heif_context=heif_context_alloc();
   if (heif_context == (struct heif_context *) NULL)
     ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
-#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,20,0)
+#if LIBHEIF_NUMERIC_VERSION >= HEIC_COMPUTE_NUMERIC_VERSION(1,19,0)
   HEICSecurityLimits(image_info,heif_context);
 #endif
   error=heif_context_read_from_file(heif_context,image->filename,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This change adds animated AVIF read and write support using libheif sequences API introduced in [version v1.20.0](https://github.com/strukturag/libheif/releases/tag/v1.20.0).

The code is checking libheif version, so the older versions still work without the animation support as before.

My test page for converting between various animated image formats with this change included: https://ezgif.com/im-convert-test/index.html

The code is partly LLM generated, but to me it looks and works fine. Any suggestions are welcome.

This solves https://github.com/ImageMagick/ImageMagick/issues/8464