### PR TITLE
add strict flag to fail on missing compression method

### DIFF
--- a/MagickCore/constitute.c
+++ b/MagickCore/constitute.c
@@ -69,6 +69,7 @@
 #include "MagickCore/profile-private.h"
 #include "MagickCore/property.h"
 #include "MagickCore/quantum.h"
+#include "MagickCore/registry.h"
 #include "MagickCore/resize.h"
 #include "MagickCore/resource_.h"
 #include "MagickCore/semaphore.h"
@@ -1177,6 +1178,67 @@ MagickExport Image *ReadInlineImage(const ImageInfo *image_info,
   return(image);
 }
 
+static MagickBooleanType ValidateCompressionStrict(
+  const ImageInfo *image_info,
+  const Image *image,
+  ExceptionInfo *exception)
+{
+  // WONTFIX this does not work
+  // this would be nice to avoid patching all coders
+
+  const char *strict = GetImageRegistry(StringRegistryType, "strict", exception);
+  // if (GetStrictMode() == MagickFalse)
+  if (LocaleCompare(strict, "true") != 0)
+    return MagickTrue;
+
+  printf("ValidateCompressionStrict: strict is true -> checking\n");
+
+  if (image_info->compression == UndefinedCompression) {
+    printf("ValidateCompressionStrict: compression is undefined\n");
+    return MagickTrue;
+  }
+
+  /*
+    Ask the coder indirectly by checking if the requested compression
+    differs from what would actually be used.
+  */
+  CompressionType requested = image_info->compression;
+
+  /*
+    Clone info so we can probe without mutating caller state
+  */
+  ImageInfo *probe_info = CloneImageInfo(image_info);
+  if (probe_info == (ImageInfo *) NULL)
+    return MagickFalse;
+
+  /*
+    Let IM normalize/resolve compression for the format
+  */
+  (void) SetImageInfo(probe_info, 0, exception);
+
+  CompressionType resolved = probe_info->compression;
+
+  DestroyImageInfo(probe_info);
+
+  printf("ValidateCompressionStrict: resolved: %s\n", CommandOptionToMnemonic(MagickCompressOptions, resolved));
+  printf("ValidateCompressionStrict: requested: %s\n", CommandOptionToMnemonic(MagickCompressOptions, requested));
+
+  if (resolved != requested)
+  {
+    ThrowMagickException(exception,
+      GetMagickModule(),
+      OptionError,
+      "CompressionNotSupported",
+      "`%s` compression not supported for `%s`",
+      CommandOptionToMnemonic(MagickCompressOptions, requested),
+      image_info->magick);
+
+    return MagickFalse;
+  }
+
+  return MagickTrue;
+}
+
 /*
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                                                             %
@@ -1348,6 +1410,9 @@ MagickExport MagickBooleanType WriteImage(const ImageInfo *image_info,
         LockSemaphoreInfo(magick_info->semaphore);
       status=IsCoderAuthorized(magick_info->magick_module,write_info->magick,
         WritePolicyRights,exception);
+      status = ValidateCompressionStrict(image_info, image, exception);
+      if (status == MagickFalse)
+        return(status);
       if (status != MagickFalse)
         status=encoder(write_info,image,exception);
       if (GetMagickEncoderThreadSupport(magick_info) == MagickFalse)

--- a/MagickCore/option.c
+++ b/MagickCore/option.c
@@ -1156,6 +1156,7 @@ static const OptionInfo
     { "-stereo", 1L, NonMagickOptionFlag, MagickFalse },
     { "+stretch", 1L, DeprecateOptionFlag, MagickTrue },
     { "-stretch", 1L, SimpleOperatorFlag, MagickFalse },
+    { "-strict", 0L, SpecialOptionFlag, MagickFalse },
     { "+strip", 0L, DeprecateOptionFlag, MagickTrue },
     { "-strip", 0L, SimpleOperatorFlag, MagickFalse },
     { "+stroke", 0L, ImageInfoOptionFlag | DrawInfoOptionFlag, MagickFalse },

--- a/MagickCore/option.c
+++ b/MagickCore/option.c
@@ -468,6 +468,8 @@ static const OptionInfo
     { "  solarize", 0, UndefinedOptionFlag, MagickFalse },
     { "  splice", 0, UndefinedOptionFlag, MagickFalse },
     { "  spread", 0, UndefinedOptionFlag, MagickFalse },
+    // TODO is this needed?
+    // { "  strict", 0, UndefinedOptionFlag, MagickFalse },
     { "  strip", 0, UndefinedOptionFlag, MagickFalse },
     { "  swirl", 0, UndefinedOptionFlag, MagickFalse },
     { "  threshold", 0, UndefinedOptionFlag, MagickFalse },

--- a/MagickWand/magick-cli.c
+++ b/MagickWand/magick-cli.c
@@ -694,6 +694,15 @@ WandExport int ProcessCommandOptions(MagickCLI *cli_wand,int argc,char **argv,
       if ( (option_type & GenesisOptionFlag) != 0 )
         break; /* next option */
 
+      /* Handle special option -strict */
+      if ( (option_type & SpecialOptionFlag) != 0 ) {
+        if ( (cli_wand->process_flags & ProcessStrictOption) == 0
+             && LocaleCompare(option,"-strict") == 0 ) {
+          // -define registry:strict=true
+          SetImageRegistry(StringRegistryType, "strict", "true", cli_wand->wand.exception);
+        }
+        break; /* next option */
+      }
       /* Handle any special options for CLI (-script handled above) */
       if ( (option_type & SpecialOptionFlag) != 0 ) {
         if ( (cli_wand->process_flags & ProcessExitOption) != 0
@@ -812,6 +821,7 @@ static MagickBooleanType MagickCommandUsage(void)
       "  -help                print program options\n"
       "  -list type           print a list of supported option arguments\n"
       "  -log format          format of debugging information\n"
+      "  -strict              fail if an option is not available\n"
       "  -usage               print program usage\n"
       "  -version             print version information",
     operators[] =

--- a/MagickWand/wandcli-private.h
+++ b/MagickWand/wandcli-private.h
@@ -71,6 +71,7 @@ typedef enum
   ProcessScriptOption         = 0x0200,  /* allow '-script' use */
   ProcessReadOption           = 0x0400,  /* allow '-read' use */
   ProcessWarnDeprecated       = 0x0800,  /* warn about deprecated options */
+  ProcessStrictOption         = 0x1000,  /* allow '-strict' use */
 
   /* Option Processing Flags */
   ProcessOneOptionOnly        = 0x4000,  /* Process one option only */

--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -357,6 +357,7 @@ static Image *ReadGROUP4Image(const ImageInfo *image_info,
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",
       image_info->filename);
   image=AcquireImage(image_info,exception);
+  printf("tiff line 360: OpenBlob\n");
   status=OpenBlob(image_info,image,ReadBinaryBlobMode,exception);
   if (status == MagickFalse)
     {
@@ -1244,6 +1245,7 @@ static Image *ReadTIFFImage(const ImageInfo *image_info,
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",
       image_info->filename);
   image=AcquireImage(image_info,exception);
+  printf("tiff line 1248: OpenBlob\n");
   status=OpenBlob(image_info,image,ReadBinaryBlobMode,exception);
   if (status == MagickFalse)
     {
@@ -2681,6 +2683,7 @@ static MagickBooleanType WriteGROUP4Image(const ImageInfo *image_info,
   assert(exception->signature == MagickCoreSignature);
   if (IsEventLogging() != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",image->filename);
+  printf("tiff line 2686: OpenBlob\n");
   status=OpenBlob(image_info,image,WriteBinaryBlobMode,exception);
   if (status == MagickFalse)
     return(status);
@@ -3527,6 +3530,7 @@ static MagickBooleanType WriteTIFFImage(const ImageInfo *image_info,
   assert(exception->signature == MagickCoreSignature);
   if (IsEventLogging() != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",image->filename);
+  printf("tiff line 3533: OpenBlob\n");
   status=OpenBlob(image_info,image,WriteBinaryBlobMode,exception);
   if (status == MagickFalse)
     return(status);
@@ -3574,6 +3578,42 @@ static MagickBooleanType WriteTIFFImage(const ImageInfo *image_info,
         (image_info->type != image->type))
       (void) SetImageType(image,image_info->type,exception);
     compression=image_info->compression;
+
+    // debug
+    printf("tiff: compression: %s\n", CommandOptionToMnemonic(MagickCompressOptions, compression));
+    printf("tiff: image->compression: %s\n", CommandOptionToMnemonic(MagickCompressOptions, image->compression));
+    printf("tiff: preserve_compression: %d\n", preserve_compression);
+
+    #if defined(COMPRESSION_JBIG)
+    printf("tiff: COMPRESSION_JBIG is defined\n");
+    #else
+    printf("tiff: COMPRESSION_JBIG is not defined\n");
+    #endif
+
+    #if defined(COMPRESSION_JBIG2)
+    printf("tiff: COMPRESSION_JBIG2 is defined\n");
+    #else
+    printf("tiff: COMPRESSION_JBIG2 is not defined\n");
+    #endif
+
+    #if defined(COMPRESSION_LERC)
+    printf("tiff: COMPRESSION_LERC is defined\n");
+    #else
+    printf("tiff: COMPRESSION_LERC is not defined\n");
+    #endif
+
+    #if defined(COMPRESSION_LZMA)
+    printf("tiff: COMPRESSION_LZMA is defined\n");
+    #else
+    printf("tiff: COMPRESSION_LZMA is not defined\n");
+    #endif
+
+    #if defined(COMPRESSION_ZSTD)
+    printf("tiff: COMPRESSION_ZSTD is defined\n");
+    #else
+    printf("tiff: COMPRESSION_ZSTD is not defined\n");
+    #endif
+
     if (preserve_compression != MagickFalse)
       compression=image->compression;
     switch (compression)
@@ -3636,8 +3676,16 @@ static MagickBooleanType WriteTIFFImage(const ImageInfo *image_info,
 
     MagickBooleanType is_strict = MagickFalse;
     const char *strict_val = GetImageRegistry(StringRegistryType, "strict", exception);
+    if (strict_val == NULL) {
+      printf("tiff: strict_val is NULL\n");
+    }
     if (strict_val != NULL && LocaleCompare(strict_val, "true") == 0) {
       is_strict = MagickTrue;
+      // is_strict = 1;
+      printf("tiff: strict = true\n");
+    }
+    else {
+      printf("tiff: strict = false\n");
     }
 
     switch (compression)
@@ -3659,6 +3707,14 @@ static MagickBooleanType WriteTIFFImage(const ImageInfo *image_info,
         break;
       }
 #endif
+// TODO implement JBIG2 compression
+// #if defined(COMPRESSION_JBIG2)
+//       case JBIG2Compression:
+//       {
+//         compress_tag=COMPRESSION_JBIG2;
+//         break;
+//       }
+// #endif
       case JPEGCompression:
       {
         compress_tag=COMPRESSION_JPEG;

--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -78,6 +78,7 @@
 #include "MagickCore/quantum.h"
 #include "MagickCore/quantum-private.h"
 #include "MagickCore/profile-private.h"
+#include "MagickCore/registry.h"
 #include "MagickCore/resize.h"
 #include "MagickCore/resource_.h"
 #include "MagickCore/semaphore.h"
@@ -3632,6 +3633,13 @@ static MagickBooleanType WriteTIFFImage(const ImageInfo *image_info,
       ThrowWriterException(ImageError,"WidthOrHeightExceedsLimit");
     (void) TIFFSetField(tiff,TIFFTAG_IMAGELENGTH,(uint32) image->rows);
     (void) TIFFSetField(tiff,TIFFTAG_IMAGEWIDTH,(uint32) image->columns);
+
+    MagickBooleanType is_strict = MagickFalse;
+    const char *strict_val = GetImageRegistry(StringRegistryType, "strict", exception);
+    if (strict_val != NULL && LocaleCompare(strict_val, "true") == 0) {
+      is_strict = MagickTrue;
+    }
+
     switch (compression)
     {
       case FaxCompression:
@@ -3699,12 +3707,32 @@ static MagickBooleanType WriteTIFFImage(const ImageInfo *image_info,
         break;
       }
     }
-    if ((compress_tag != COMPRESSION_NONE) &&
-        (TIFFIsCODECConfigured(compress_tag) == 0))
+    if (((compress_tag != COMPRESSION_NONE) &&
+        (TIFFIsCODECConfigured(compress_tag) == 0)) || (
+          is_strict &&
+          // some compression was requested
+          compression != UndefinedCompression &&
+          compression != NoCompression &&
+          // but no compression is set
+          compress_tag == COMPRESSION_NONE
+        ))
       {
+        // FIXME if is_strict==1:
+        // no output file should be written
+        // not even an empty file
+        // TODO defer OpenBlob in line 3533
         (void) ThrowMagickException(exception,GetMagickModule(),CoderError,
           "CompressionNotSupported","`%s'",CommandOptionToMnemonic(
           MagickCompressOptions,(ssize_t) compression));
+        if (is_strict) {
+          TIFFClose(tiff);
+          (void) CloseBlob(image);
+          // no: magick: MagickCore/blob.c:1780: GetBlobError: Assertion `image->signature == MagickCoreSignature' failed.
+          // image=DestroyImage(image);
+          // remove the empty output file
+          (void) RelinquishUniqueFileResource(image_info->filename);
+          return(MagickFalse);
+        }
         compress_tag=COMPRESSION_NONE;
         compression=NoCompression;
       }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

fix #8682

test

```sh
make
for flags in "" "-strict"; do
  echo
  echo "flags=$flags"
  rm -v test.jbig2.tiff
  ./utilities/magick $flags rose: -compress JBIG2 test.jbig2.tiff
  echo $?
  tiffinfo test.jbig2.tiff | grep Compression
done
```

output

```
flags=
removed 'test.jbig2.tiff'
0
  Compression Scheme: None

flags=-strict
removed 'test.jbig2.tiff'
magick: CompressionNotSupported `JBIG2' @ error/tiff.c/WriteTIFFImage/3724.
1
TIFFOpen: test.jbig2.tiff: No such file or directory.
```

### todo

- defer `OpenBlob` in `coders/tiff.c`
  - on error, no output file should be created or overwritten or removed
- patch other coders
- maybe rename "strict" to something more specific
  - strict-codec
  - fail-on-missing-codec
  - no-fallback-codec

### status: abandoned

probably this is too much work for too little gain
so im giving up for now...
