### PR TITLE
Bounds-check GPS URATIONAL reads in GetEXIFProperty

### DIFF
--- a/MagickCore/property.c
+++ b/MagickCore/property.c
@@ -1565,8 +1565,13 @@ static void GetEXIFProperty(const Image *image,const char *property,
               if ((tag_value == GPS_LATITUDE) || (tag_value == GPS_LONGITUDE) ||
                   (tag_value == GPS_TIMESTAMP))
                 {
+                  size_t
+                    needed;
+
                   /* GPS fractions are three URATIONAL values (deg, min, sec). */
-                  if ((p < exif) || (p > (exif+length-3*tag_bytes[EXIF_FMT_URATIONAL])))
+                  needed=3*(size_t) tag_bytes[EXIF_FMT_URATIONAL];
+                  if ((p < exif) || (length < needed) ||
+                      ((size_t) (p-exif) > length-needed))
                     break;
                   components=1;
                   EXIFGPSFractions("%.20g/%.20g,%.20g/%.20g,%.20g/%.20g",

--- a/MagickCore/property.c
+++ b/MagickCore/property.c
@@ -1565,6 +1565,9 @@ static void GetEXIFProperty(const Image *image,const char *property,
               if ((tag_value == GPS_LATITUDE) || (tag_value == GPS_LONGITUDE) ||
                   (tag_value == GPS_TIMESTAMP))
                 {
+                  /* GPS fractions are three URATIONAL values (deg, min, sec). */
+                  if ((p < exif) || (p > (exif+length-3*tag_bytes[EXIF_FMT_URATIONAL])))
+                    break;
                   components=1;
                   EXIFGPSFractions("%.20g/%.20g,%.20g/%.20g,%.20g/%.20g",
                     (double) ReadPropertyUnsignedLong(endian,p),


### PR DESCRIPTION
# Bounds-check GPS URATIONAL reads in GetEXIFProperty

## What

Adds a bounds check in `MagickCore/property.c` `GetEXIFProperty()` before the GPS-specific URATIONAL branch reads 24 bytes from the EXIF buffer.

## Why

The branch at `property.c:1565-1577` reads six 4-byte ULONGs (24 bytes total) at offsets `p`, `p+4`, `p+8`, `p+12`, `p+16`, `p+20`. However, the surrounding entry-level bounds check at `property.c:1512` only validates `tag_bytes[URATIONAL]` = 8 bytes. When an EXIF GPS entry declares `components=1` with `format=URATIONAL`, the validator passes with 8 bytes available but the GPS handler reads 24 — a 16-byte OOB heap read.

This is a regression introduced by commit [`66ceff0f`](https://github.com/ImageMagick/ImageMagick/commit/66ceff0fde288813570dfb8da5c1cfa647e999d5) (Sep 2023, "properly extract EXIF GPS fractions"). That commit replaced a call to `EXIFMultipleFractions` (which read 8 bytes, matching the validator) with the new `EXIFGPSFractions` macro (which reads 24 bytes), but did not update the bounds check.

## Practical impact

The bug is latent against the standard ImageMagick binary. Profiles are stored via `AcquireStringInfo(length)`, which allocates `length + MagickPathExtent` (4096) bytes with the trailing region zeroed. The OOB reads at `p+8`..`p+23` therefore land in zero-initialized padding in practice, producing benign `0/0` fractions rather than heap-content disclosure. The fix nonetheless removes the OOB access itself — the padding is incidental allocator behavior, not a defensive mitigation, and could be changed in future refactors.

## Fix

Three-line addition at `property.c:1568`, expressed as `3 * tag_bytes[EXIF_FMT_URATIONAL]` to match the existing `tag_bytes` idiom at `property.c:1512` and document that the GPS branch reads three URATIONAL values (degrees, minutes, seconds) rather than one:

```c
/* GPS fractions are three URATIONAL values (deg, min, sec). */
if ((p < exif) || (p > (exif+length-3*tag_bytes[EXIF_FMT_URATIONAL])))
  break;
```

If the check fails, `break` exits the `switch` and falls through to the post-switch `if (value != NULL)` guard, which correctly handles the skipped-read case. Matches the same break-out-of-switch pattern already used in the `EXIF_FMT_UNDEFINED` case at `property.c:1606`.

## Reproducer (Tier 1, ASan harness)

A minimal reproducer using a self-contained harness that extracts the IFD-walking loop verbatim from `GetEXIFProperty` confirms the OOB read:

```
==PID==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x... at pc 0x...
READ of size 1 at ... thread T0
  #0 ReadPropertyUnsignedLong
  #1 EXIFGPSFractions (macro expansion)
  #2 run_exif_parsing
```

The harness is self-contained (extracts the affected loop body; no ImageMagick build required) and can be provided if helpful for verification.

## Testing

- Tier 1 reproducer triggers ASan on HEAD; does not trigger with this patch.
- Benign seeds (GPS with `components=3`, valid coordinates) produce identical output with and without the patch — confirmed via `magick identify -verbose` on PNG files containing `eXIf` chunks.
- No changes to behavior for non-GPS URATIONAL tags.

## Credits

This bug was discovered using the security-investigation workflow at https://ironcurtain.dev/workflows/, which performed a structured ASan-instrumented audit of the profile-parsing surface. Claude Code assisted with patch preparation and PR drafting.
