### PR TITLE
Bounds-check IPTC record header and data in GetIPTCProperty

### DIFF
--- a/MagickCore/property.c
+++ b/MagickCore/property.c
@@ -453,7 +453,8 @@ static void GetIPTCProperty(const Image *image,const char *key,
     i;
 
   size_t
-    length;
+    length,
+    offset;
 
   profile=GetImageProfile(image,"iptc");
   if (profile == (StringInfo *) NULL)
@@ -470,12 +471,13 @@ static void GetIPTCProperty(const Image *image,const char *key,
     if ((ssize_t) GetStringInfoDatum(profile)[i] != 0x1c)
       continue;
     /* IPTC record header is 5 bytes: marker, dataset, record, 2-byte length. */
-    if ((i+5) > (ssize_t) GetStringInfoLength(profile))
+    offset=(size_t) i+5;
+    if (offset > GetStringInfoLength(profile))
       break;
     length=(size_t) (GetStringInfoDatum(profile)[i+3] << 8);
     length|=GetStringInfoDatum(profile)[i+4];
     /* Record claims `length` bytes of data following the header. */
-    if (((size_t) (i+5)+length) > GetStringInfoLength(profile))
+    if (length > (GetStringInfoLength(profile)-offset))
       break;
     if (((long) GetStringInfoDatum(profile)[i+1] == dataset) &&
         ((long) GetStringInfoDatum(profile)[i+2] == record))

--- a/MagickCore/property.c
+++ b/MagickCore/property.c
@@ -469,8 +469,14 @@ static void GetIPTCProperty(const Image *image,const char *key,
     length=1;
     if ((ssize_t) GetStringInfoDatum(profile)[i] != 0x1c)
       continue;
+    /* IPTC record header is 5 bytes: marker, dataset, record, 2-byte length. */
+    if ((i+5) > (ssize_t) GetStringInfoLength(profile))
+      break;
     length=(size_t) (GetStringInfoDatum(profile)[i+3] << 8);
     length|=GetStringInfoDatum(profile)[i+4];
+    /* Record claims `length` bytes of data following the header. */
+    if (((size_t) (i+5)+length) > GetStringInfoLength(profile))
+      break;
     if (((long) GetStringInfoDatum(profile)[i+1] == dataset) &&
         ((long) GetStringInfoDatum(profile)[i+2] == record))
       {


### PR DESCRIPTION
# Bounds-check IPTC record header and data in GetIPTCProperty

## What

Adds two bounds checks in `MagickCore/property.c` `GetIPTCProperty()` to prevent OOB reads when parsing malformed IPTC profiles. The loop walks IPTC records of the form `[0x1c][dataset][record][length_hi][length_lo][data...]`, advancing `5 + length` bytes per record, but the entry-level guard `i < GetStringInfoLength(profile)` is the only check.

## Why

Two unchecked accesses result:

1. **Header OOB.** After the `0x1c` marker match at `property.c:470`, the code reads `profile[i+1]`, `profile[i+2]`, `profile[i+3]`, `profile[i+4]` to extract `dataset`, `record`, and `length`. When the profile's last byte is `0x1c`, those reads go up to 4 bytes past the buffer.
2. **Data OOB.** The 16-bit length field is attacker-controlled (up to 65,535) and flows directly to `CopyMagickString` at `property.c:482-483`, which strncpy-copies up to `length` bytes from `profile+i+5`. No check that the claimed data region fits in the profile.

## Practical impact

Both reads are latent in the standard binary. Profiles are stored via `AcquireStringInfo(length)` which allocates `length + MagickPathExtent` (4096) bytes with the trailing region zeroed. The header OOB reads land in zero-initialized padding, and `CopyMagickString` uses strncpy semantics so the copy terminates at the first zero byte of padding — no heap content is disclosed in practice. The fix nonetheless eliminates the OOB accesses themselves; the padding is incidental allocator behavior, not defensive intent.

## Fix

Two early-exit checks matching the `break`-out-of-loop idiom already used in the file (e.g. the `EXIF_FMT_UNDEFINED` branch of `GetEXIFProperty` at `property.c:1606`):

```c
if ((ssize_t) GetStringInfoDatum(profile)[i] != 0x1c)
  continue;
/* IPTC record header is 5 bytes: marker, dataset, record, 2-byte length. */
if ((i+5) > (ssize_t) GetStringInfoLength(profile))
  break;
length=(size_t) (GetStringInfoDatum(profile)[i+3] << 8);
length|=GetStringInfoDatum(profile)[i+4];
/* Record claims `length` bytes of data following the header. */
if (((size_t) (i+5)+length) > GetStringInfoLength(profile))
  break;
```

If either check fails, the loop terminates. Records parsed before the malformed one are still used to build the attribute string, matching existing behavior on short profiles.

## Reproducer (Tier 1, ASan harness)

A self-contained harness that extracts the IPTC parsing loop verbatim confirms both OOB reads.

Header OOB (2-byte payload `\x1c\x02`):
```
==PID==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1 at ... thread T0
  #0 run_iptc_loop at .../harness_iptc_oob.c:130  (= property.c:472)
```

Data OOB (7-byte payload `\x1c\x02\x00\x00\xff\x41\x42` — marker + dataset=2 + record=0 + length=0xFF00 + two data bytes):
```
==PID==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 3 at ... thread T0
  #0 __interceptor_strncpy
  #1 CopyMagickString at .../harness_iptc_oob.c:52  (= property.c:482)
```

Both disappear with the patch applied.

## Testing

- Tier 1 ASan harness on both payloads: triggers on HEAD, silent with patch.
- End-to-end via `magick identify -verbose` on PNG with `Raw profile type iptc` tEXt chunk and on TIFF with `TIFFTAG_RICHTIFFIPTC`: identical output for valid records with and without the patch; malformed records are silently skipped rather than producing `unknown[2,0]` entries.
- All reachable image formats (JPEG APP13, PNG tEXt raw profile, TIFF RICHTIFFIPTC, HEIC IPTC box) go through the same `BlobToProfileStringInfo` → `AcquireStringInfo` path, so behavior is uniform across formats.

## Credits

This bug was discovered using the security-investigation workflow at https://ironcurtain.dev/workflows/, which performed a structured ASan-instrumented audit of the profile-parsing surface. Claude Code assisted with patch preparation and PR drafting.
