### PR TITLE
Fix unsound free of uninitialized pointers in GetImageFeatures error path

### DIFF
--- a/MagickCore/feature.c
+++ b/MagickCore/feature.c
@@ -790,11 +790,7 @@ MagickExport ChannelFeatures *GetImageFeatures(const Image *image,
       (sum == (ChannelStatistics *) NULL))
     {
       if (Q != (ChannelStatistics **) NULL)
-        {
-          for (i=0; i < (ssize_t) number_grays; i++)
-            Q[i]=(ChannelStatistics *) RelinquishMagickMemory(Q[i]);
-          Q=(ChannelStatistics **) RelinquishMagickMemory(Q);
-        }
+        Q=(ChannelStatistics **) RelinquishMagickMemory(Q);
       if (sum != (ChannelStatistics *) NULL)
         sum=(ChannelStatistics *) RelinquishMagickMemory(sum);
       if (density_y != (ChannelStatistics *) NULL)
@@ -804,13 +800,8 @@ MagickExport ChannelFeatures *GetImageFeatures(const Image *image,
       if (density_x != (ChannelStatistics *) NULL)
         density_x=(ChannelStatistics *) RelinquishMagickMemory(density_x);
       if (cooccurrence != (ChannelStatistics **) NULL)
-        {
-          for (i=0; i < (ssize_t) number_grays; i++)
-            cooccurrence[i]=(ChannelStatistics *)
-              RelinquishMagickMemory(cooccurrence[i]);
-          cooccurrence=(ChannelStatistics **) RelinquishMagickMemory(
-            cooccurrence);
-        }
+        cooccurrence=(ChannelStatistics **) RelinquishMagickMemory(
+          cooccurrence);
       grays=(PixelPacket *) RelinquishMagickMemory(grays);
       channel_features=(ChannelFeatures *) RelinquishMagickMemory(
         channel_features);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The first error-cleanup branch in `MagickCore/feature.c::GetImageFeatures` calls `RelinquishMagickMemory` on each `Q[i]` and `cooccurrence[i]`, but those inner pointer-array elements are still uninitialized at that point — they only get populated by the subsequent `for (i=0; i < number_grays; i++)` init loop a few lines later. `free()` on uninitialized values is undefined behavior.

The fix removes the two inner free loops. The outer `Q` and `cooccurrence` arrays are still released. The function's second error-cleanup branch (entered if one of the inner allocations fails partway through the init loop) already handles partially-initialized arrays correctly with `i--` rewind plus `if (Q[i] != NULL)` / `if (cooccurrence[i] != NULL)` guards and is unchanged.
