### PR TITLE
Add profile_fuzzer for raw EXIF/XMP/IPTC/ICC parsing

### DIFF
--- a/oss-fuzz/profile_fuzzer.cc
+++ b/oss-fuzz/profile_fuzzer.cc
@@ -1,0 +1,53 @@
+/*
+  Copyright @ 2026 ImageMagick Studio LLC, a non-profit organization
+  dedicated to making software imaging solutions freely available.
+
+  You may not use this file except in compliance with the License.  You may
+  obtain a copy of the License at
+
+    https://imagemagick.org/license/
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <cstdint>
+
+#include <Magick++/Blob.h>
+#include <Magick++/Image.h>
+
+#include "utils.cc"
+
+static const char *kProfileNames[] = {
+  "exif", "xmp", "iptc", "icc", "8bim", "app1", "app13"
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data,size_t Size)
+{
+  if (IsInvalidSize(Size,2))
+    return(0);
+
+  const unsigned int sel=Data[0] % (sizeof(kProfileNames) /
+    sizeof(kProfileNames[0]));
+  const Magick::Blob blob(Data + 1, Size - 1);
+
+  try
+  {
+    Magick::Image image("16x16","white");
+    image.profile(kProfileNames[sel],blob);
+  }
+#if defined(BUILD_MAIN)
+  catch (Magick::Exception &e)
+  {
+    std::cout << "Exception when reading profile: " << e.what() << std::endl;
+  }
+#else
+  catch (Magick::Exception)
+  {
+  }
+#endif
+  return(0);
+}

--- a/oss-fuzz/profile_fuzzer.cc
+++ b/oss-fuzz/profile_fuzzer.cc
@@ -21,7 +21,7 @@
 
 #include "utils.cc"
 
-static const char *kProfileNames[] = {
+static const char *profileNames[] = {
   "exif", "xmp", "iptc", "icc", "8bim", "app1", "app13"
 };
 
@@ -30,14 +30,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data,size_t Size)
   if (IsInvalidSize(Size,2))
     return(0);
 
-  const unsigned int sel=Data[0] % (sizeof(kProfileNames) /
-    sizeof(kProfileNames[0]));
+  const unsigned int profileIndex=Data[0];
+  if (profileIndex >= sizeof(profileNames) / sizeof(*profileNames))
+    return(0);
   const Magick::Blob blob(Data + 1, Size - 1);
 
   try
   {
     Magick::Image image("16x16","white");
-    image.profile(kProfileNames[sel],blob);
+    image.profile(profileNames[profileIndex],blob);
   }
 #if defined(BUILD_MAIN)
   catch (Magick::Exception &e)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Per earlier discussion, adding a single fuzzer first.

Existing `encoder_fuzzer` reaches the EXIF/XMP/IPTC/ICC sub-parsers only as a side-effect of full-format reads (e.g. a JPEG containing an EXIF segment). libFuzzer's mutation budget therefore spends most of its time synthesising a valid container before any entropy lands on the metadata parser itself.

`profile_fuzzer` calls `image.profile(name, blob)` directly with raw attacker-controlled bytes, routing into `MagickCore/profile.c::ProfileImage` for one of seven sub-types (`exif`, `xmp`, `iptc`, `icc`, `8bim`, `app1`, `app13`) selected by the first input byte. The remainder of the input is the profile blob.

Style follows `ping_fuzzer.cc` — `IsInvalidSize` from `utils.cc`, Magick++ Image + Blob, `Magick::Exception` swallow, no extra build-script changes (the existing `build_fuzzers.sh` loop auto-picks up `*_fuzzer.cc`).
