### PR TITLE
reject farbfeld files with zero columns or rows

### DIFF
--- a/coders/farbfeld.c
+++ b/coders/farbfeld.c
@@ -181,6 +181,8 @@ static Image *ReadFARBFELDImage(const ImageInfo *image_info,
     ThrowReaderException(CorruptImageError,"ImproperImageHeader");
   image->columns=(size_t) ReadBlobLong(image);
   image->rows=(size_t) ReadBlobLong(image);
+  if ((image->columns == 0) || (image->rows == 0))
+    ThrowReaderException(CorruptImageError,"ImproperImageHeader");
   image->alpha_trait=BlendPixelTrait;
   if (image_info->ping != MagickFalse)
     {


### PR DESCRIPTION
ReadFARBFELDImage reads width and height directly from the blob into image->columns and image->rows and then takes the image_info->ping early-return path before SetImageExtent gets a chance to reject zero dimensions, so a 16-byte file with width=0 or height=0 (or a truncated header where ReadBlobLong returns 0) succeeds and `identify` reports a 0x0 image. Same shape as the DCM fix in 84fbcef referencing GHSA-8pj9-6897-74xc.