### PR TITLE
reject cineon files with zero columns or rows

### DIFF
--- a/coders/cin.c
+++ b/coders/cin.c
@@ -725,6 +725,8 @@ static Image *ReadCINImage(const ImageInfo *image_info,ExceptionInfo *exception)
   image->depth=cin.image.channel[0].bits_per_pixel;
   image->columns=cin.image.channel[0].pixels_per_line;
   image->rows=cin.image.channel[0].lines_per_image;
+  if ((image->columns == 0) || (image->rows == 0))
+    ThrowReaderException(CorruptImageError,"ImproperImageHeader");
   if (image_info->ping != MagickFalse)
     {
       (void) CloseBlob(image);


### PR DESCRIPTION
ReadCINImage copies pixels_per_line and lines_per_image from the Cineon header into image->columns and image->rows and then takes the image_info->ping early-return path before the HeapOverflowSanityCheck (which would also reject a zero) at coders/cin.c:733 gets a chance to run, so a CIN file declaring zero pixels per line or zero lines per image succeeds and `identify` reports a 0x0 image. Same shape as the DCM fix in 84fbcef (GHSA-8pj9-6897-74xc).