### PR TITLE
reject tga files with zero columns or rows

### DIFF
--- a/coders/tga.c
+++ b/coders/tga.c
@@ -344,6 +344,8 @@ static Image *ReadTGAImage(const ImageInfo *image_info,ExceptionInfo *exception)
     image->orientation=TopLeftOrientation;
   if (image_info->ping != MagickFalse)
     {
+      if ((image->columns == 0) || (image->rows == 0))
+        ThrowReaderException(CorruptImageError,"ImproperImageHeader");
       (void) CloseBlob(image);
       return(image);
     }


### PR DESCRIPTION
ReadTGAImage takes the image_info->ping early-return before SetImageExtent rejects zero dimensions, so a TGA header declaring a zero width or height surfaces a 0x0 image to `identify`. Adds the same guard to the ping path that the other coders received in 6eb7297.