### PR TITLE
reject mtv files with zero columns or rows

### DIFF
--- a/coders/mtv.c
+++ b/coders/mtv.c
@@ -159,7 +159,11 @@ static Image *ReadMTVImage(const ImageInfo *image_info,ExceptionInfo *exception)
     image->depth=8;
     if ((image_info->ping != MagickFalse) && (image_info->number_scenes != 0))
       if (image->scene >= (image_info->scene+image_info->number_scenes-1))
-        break;
+        {
+          if ((image->columns == 0) || (image->rows == 0))
+            ThrowReaderException(CorruptImageError,"ImproperImageHeader");
+          break;
+        }
     status=SetImageExtent(image,image->columns,image->rows,exception);
     if (status == MagickFalse)
       return(DestroyImageList(image));


### PR DESCRIPTION
ReadMTVImage scans columns and rows from the header but only rejects bad values in SetImageExtent, which the ping-with-scene path returns before reaching. So `identify 'MTV:file[0]'` on a header declaring `0 1` reports a 0x1 image instead of failing. Adds the zero check to that early return, matching the pict.c part of 6eb7297.