### PR TITLE
reject sgi files with zero columns or rows

### DIFF
--- a/coders/sgi.c
+++ b/coders/sgi.c
@@ -373,7 +373,11 @@ static Image *ReadSGIImage(const ImageInfo *image_info,ExceptionInfo *exception)
       }
     if ((image_info->ping != MagickFalse) && (image_info->number_scenes != 0))
       if (image->scene >= (image_info->scene+image_info->number_scenes-1))
-        break;
+        {
+          if ((image->columns == 0) || (image->rows == 0))
+            ThrowReaderException(CorruptImageError,"ImproperImageHeader");
+          break;
+        }
     if ((MagickSizeType) (image->columns*image->rows/255) > GetBlobSize(image))
       ThrowReaderException(CorruptImageError,"InsufficientImageDataInFile");
     status=SetImageExtent(image,image->columns,image->rows,exception);


### PR DESCRIPTION
ReadSGIImage reads columns and rows from the iris header but only rejects bad values in SetImageExtent, which the ping-with-scene path breaks out of the loop before reaching. So `identify 'SGI:file[0]'` on a header declaring zero columns reports a 0x16 image instead of failing. Adds the zero check to that early break, matching the pict.c part of 6eb7297.