### PR TITLE
reject dds files with zero columns or rows

### DIFF
--- a/coders/dds.c
+++ b/coders/dds.c
@@ -3091,7 +3091,11 @@ static Image *ReadDDSImage(const ImageInfo *image_info,ExceptionInfo *exception)
     image->endian=LSBEndian;
     image->depth=8;
     if (image_info->ping != MagickFalse)
-      continue;
+      {
+        if ((image->columns == 0) || (image->rows == 0))
+          ThrowReaderException(CorruptImageError,"ImproperImageHeader");
+        continue;
+      }
     status=SetImageExtent(image,image->columns,image->rows,exception);
     if (status == MagickFalse)
       return(DestroyImageList(image));


### PR DESCRIPTION
ReadDDSImage copies dds_info.width and dds_info.height into image->columns and image->rows, then the image_info->ping path does `continue` before SetImageExtent rejects the dimensions. So a DDS header declaring a zero width or height pings as a valid image:

    DDS:zero.dds DDS 0x4 0x4+0+0 8-bit sRGB 128B

A full read already fails with NegativeOrZeroImageSize. Adds the same guard to the ping path that the other coders got in 6eb7297.