### PR TITLE
reject tim2 files with zero columns or rows

### DIFF
--- a/coders/tim2.c
+++ b/coders/tim2.c
@@ -762,6 +762,8 @@ static Image *ReadTIM2Image(const ImageInfo *image_info,
         if (status==MagickFalse)
           break;
       }
+    if ((image->columns == 0) || (image->rows == 0))
+      ThrowReaderException(CorruptImageError,"ImproperImageHeader");
     if ((image_info->ping != MagickFalse) && (image_info->number_scenes != 0))
       if (image->scene >= (image_info->scene+image_info->number_scenes-1))
         break;


### PR DESCRIPTION
ReadTIM2Image sets image->columns and image->rows from the header but only calls SetImageExtent (which rejects zero) inside ReadTIM2ImageData, which the ping path skips, so `identify -ping` on a TIM2 declaring zero width or height reports a 0x4 image instead of failing. Add the zero check to the ping branch, matching 6eb7297.