### PR TITLE
reject hdr files with a negative width or height

### DIFF
--- a/coders/hdr.c
+++ b/coders/hdr.c
@@ -340,6 +340,9 @@ static Image *ReadHDRImage(const ImageInfo *image_info,ExceptionInfo *exception)
 
                   if (MagickSscanf(value,"%d +X %d",&height,&width) == 2)
                     {
+                      if ((width <= 0) || (height <= 0))
+                        ThrowReaderException(CorruptImageError,
+                          "ImproperImageHeader");
                       image->columns=(size_t) width;
                       image->rows=(size_t) height;
                     }


### PR DESCRIPTION
Noticed ReadHDRImage parses the resolution line width and height as signed int but only the zero case is rejected later. A negative value casts to a huge size_t and slips past that check, so a `-Y -1 +X 4` header makes identify -ping surface a 4x18446744073709551616 image. Reject non-positive dimensions at the parse site, like xbm.c already does.