### PR TITLE
reject icon files with a negative width or height

### DIFF
--- a/coders/icon.c
+++ b/coders/icon.c
@@ -457,6 +457,8 @@ static Image *ReadICONImage(const ImageInfo *image_info,
 
         if (bits_per_pixel > 32)
           ThrowICONReaderException(CorruptImageError,"ImproperImageHeader");
+        if ((width < 0) || (height < 0))
+          ThrowICONReaderException(CorruptImageError,"ImproperImageHeader");
         (void) ReadBlobLSBLong(image); /* compression */
         (void) ReadBlobLSBLong(image); /* image_size */
         (void) ReadBlobLSBLong(image); /* x_pixels */


### PR DESCRIPTION
ReadICONImage reads the bitmap width and height as signed longs at icon.c:392 but never rejects negatives, so a file with a negative biWidth makes `identify 'ICON:file[0]'` surface an 18446744073709551616-wide image because the ping-with-scene path returns before SetImageExtent rejects it. Reject negative width and height in the bitmap branch before they are cast to size_t.