### PR TITLE
reject tim files with zero columns or rows

### DIFF
--- a/coders/tim.c
+++ b/coders/tim.c
@@ -222,7 +222,11 @@ static Image *ReadTIMImage(const ImageInfo *image_info,ExceptionInfo *exception)
       }
     if ((image_info->ping != MagickFalse) && (image_info->number_scenes != 0))
       if (image->scene >= (image_info->scene+image_info->number_scenes-1))
-        break;
+        {
+          if ((image->columns == 0) || (image->rows == 0))
+            ThrowReaderException(CorruptImageError,"ImproperImageHeader");
+          break;
+        }
     /*
       Read image data.
     */


### PR DESCRIPTION
Hit this fuzzing `identify 'TIM:file[0]'` on a no-CLUT TIM. ReadTIMImage reads the actual image columns and rows after the CLUT block, but the (image_info->ping && number_scenes) early break exits the do/while before that read, so on a no-CLUT TIM image->columns and image->rows are still zero and a 0x0 image is reported instead of failing. Adds the zero check to the early break, matching the pict.c part of 6eb7297.