### PR TITLE
reject pict clip rectangles with zero width or height

### DIFF
--- a/coders/pict.c
+++ b/coders/pict.c
@@ -1020,6 +1020,8 @@ static Image *ReadPICTImage(const ImageInfo *image_info,
               break;
             image->columns=(size_t) (frame.right-frame.left);
             image->rows=(size_t) (frame.bottom-frame.top);
+            if ((image->columns == 0) || (image->rows == 0))
+              ThrowPICTException(CorruptImageError,"ImproperImageHeader");
             if (image_info->ping != MagickFalse)
               break;
             status=SetImageExtent(image,image->columns,image->rows,exception);


### PR DESCRIPTION
Found this poking at PICT clipping opcodes with identify -ping. ReadRectangle rejects right<left and bottom<top but not the equal case, so the opcode 0x01 branch in pict.c assigns 0 to image->columns/rows via the frame subtraction when right==left or bottom==top. SetImageExtent on the full-read path catches it at pict.c:1025, but the image_info->ping break at pict.c:1023 returns first, so identify reports the file as 'PICT 0x0' (confirmed: 'PICT 0x0' exit 0 before, ImproperImageHeader after; PerlMagick/t/input.pict still pings and decodes at 70x46). Same idea as the main-header guard added in 6eb7297.