### PR TITLE
reject rla files with an inverted active window

### DIFF
--- a/coders/rla.c
+++ b/coders/rla.c
@@ -262,6 +262,9 @@ static Image *ReadRLAImage(const ImageInfo *image_info,ExceptionInfo *exception)
   */
   image->alpha_trait=rla_info.number_matte_channels != 0 ? BlendPixelTrait : 
     UndefinedPixelTrait;
+  if ((rla_info.active_window.right < rla_info.active_window.left) ||
+      (rla_info.active_window.top < rla_info.active_window.bottom))
+    ThrowReaderException(CorruptImageError,"ImproperImageHeader");
   image->columns=(size_t) (rla_info.active_window.right-
     rla_info.active_window.left+1);
   image->rows=(size_t) (rla_info.active_window.top-


### PR DESCRIPTION
ReadRLAImage subtracts active_window.left from active_window.right and stores the result as size_t. The fields are signed shorts, so a header with right < left wraps to a huge size_t. SetImageExtent catches it on the full read but the ping path returns first, so `identify -ping 'RLA:file'` on a header declaring left=10 right=1 reports an 18446744073709551616-wide image. Reject the inverted window before the cast.