### PR TITLE
reject uhdr files with zero columns or rows

### DIFF
--- a/coders/uhdr.c
+++ b/coders/uhdr.c
@@ -202,6 +202,11 @@ static Image *ReadUHDRImage(const ImageInfo *image_info,
 
   if (image_info->ping != MagickFalse)
   {
+    if ((image->columns == 0) || (image->rows == 0))
+    {
+      uhdr_release_decoder(handle);
+      ThrowReaderException(CorruptImageError,"ImproperImageHeader");
+    }
     uhdr_release_decoder(handle);
     status = CloseBlob(image);
     if (status == MagickFalse)


### PR DESCRIPTION
ReadUHDRImage in coders/uhdr.c assigns image->columns/rows from uhdr_dec_get_image_width/height and then takes the image_info->ping early return before SetImageExtent runs. If the decoder reports a zero dimension, the ping path surfaces a 0xN image to callers while the full read path is still rejected later by SetImageExtent. Adds the zero-dimension check inside the ping return block, mirroring the cin/dpx/farbfeld/pdb/pict/rgf/rla hunks of commit 6eb7297.