### PR TITLE
reject empty string when pinging a strimg image

### DIFF
--- a/coders/strimg.c
+++ b/coders/strimg.c
@@ -137,6 +137,8 @@ static Image *ReadSTRIMGImage(const ImageInfo *image_info,
   if (image_info->ping != MagickFalse)
     {
       string=DestroyString(string);
+      if (image->columns == 0)
+        ThrowReaderException(CorruptImageError,"ImproperImageHeader");
       (void) CloseBlob(image);
       return(GetFirstImageInList(image));
     }


### PR DESCRIPTION
ReadSTRIMGImage sets image->columns from strlen of the interpreted string and rows to one, then takes the image_info->ping early return before SetImageExtent runs. An empty STRIMG: string leaves columns at zero, so a full read is rejected by SetImageExtent with NegativeOrZeroImageSize while identify -ping happily reports a 0x1 image. Reject the zero-width case in the ping branch so both paths agree, matching the guards added in 6eb7297.