### PR TITLE
fix out-of-bounds read in polynomial distort with no arguments

### DIFF
--- a/MagickCore/distort.c
+++ b/MagickCore/distort.c
@@ -423,6 +423,12 @@ static double *GenerateCoefficients(const Image *image,
       break;
     case PolynomialDistortion:
       /* number of coefficients depend on the given polynomial 'order' */
+      if ( number_arguments < 1 ) {
+        (void) ThrowMagickException(exception,GetMagickModule(),OptionError,
+                   "InvalidArgument","%s : '%s'","Polynomial",
+                   "Needs at least 1 argument");
+        return((double *) NULL);
+      }
       i = poly_number_terms(arguments[0]);
       number_coefficients = 2 + i*number_values;
       if ( i == 0 ) {


### PR DESCRIPTION
GenerateCoefficients reads arguments[0] at distort.c:426 for the Polynomial method before checking number_arguments, so DistortImage with zero arguments (`-distort Polynomial ''`) reads out of bounds. Add the count check before the read, matching the cylinder/plane fix in GHSA-p9rq-q46c-g4x6.