### PR TITLE
fix oob read of gps rationals in GetEXIFProperty

### DIFF
--- a/MagickCore/property.c
+++ b/MagickCore/property.c
@@ -1565,6 +1565,8 @@ static void GetEXIFProperty(const Image *image,const char *property,
               if ((tag_value == GPS_LATITUDE) || (tag_value == GPS_LONGITUDE) ||
                   (tag_value == GPS_TIMESTAMP))
                 {
+                  if (number_bytes < 24)
+                    break;  /* reads three rationals */
                   components=1;
                   EXIFGPSFractions("%.20g/%.20g,%.20g/%.20g,%.20g/%.20g",
                     (double) ReadPropertyUnsignedLong(endian,p),


### PR DESCRIPTION
GetEXIFProperty reads three rationals (24 bytes) for the GPS latitude, longitude and timestamp tags but only validates the entry's declared component count first. A GPS tag declaring fewer than three rationals reads past the validated EXIF directory extent. Require the 24 bytes before reading, matching the other range checks here.