### PR TITLE
feat(8785) Downgrade ubuntu container to 18.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -440,6 +440,12 @@ jobs:
             packages: clang
 
     steps:
+
+      - name: fix package repo
+        run: |
+          sed -i 's|http://.*archive.ubuntu.com|http://old-releases.ubuntu.com|g' /etc/apt/sources.list
+          sed -i 's|http://security.ubuntu.com|http://old-releases.ubuntu.com|g' /etc/apt/sources.list
+
       - name: Install dependencies
         run: |
           set -e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,7 +423,7 @@ jobs:
   linux_app_image:
     name: Linux AppImage ${{matrix.compiler}}
     container:
-      image: ubuntu:22.04
+      image: ubuntu:18.10
     runs-on: ubuntu-24.04
     needs:
       - version


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Downgrades the container version for building precompiled binaries for better compatibility on older servers.

closes #8785 
