### PR TITLE
bound iptc record length in GetIPTCProperty

### DIFF
--- a/MagickCore/property.c
+++ b/MagickCore/property.c
@@ -464,13 +464,14 @@ static void GetIPTCProperty(const Image *image,const char *key,
   if (count != 2)
     return;
   attribute=(char *) NULL;
-  for (i=0; i < (ssize_t) GetStringInfoLength(profile); i+=(ssize_t) length)
+  for (i=0; i < (ssize_t) GetStringInfoLength(profile)-5; i+=(ssize_t) length)
   {
     length=1;
     if ((ssize_t) GetStringInfoDatum(profile)[i] != 0x1c)
       continue;
     length=(size_t) (GetStringInfoDatum(profile)[i+3] << 8);
     length|=GetStringInfoDatum(profile)[i+4];
+    length=MagickMin(length,GetStringInfoLength(profile)-(size_t) (i+5));
     if (((long) GetStringInfoDatum(profile)[i+1] == dataset) &&
         ((long) GetStringInfoDatum(profile)[i+2] == record))
       {


### PR DESCRIPTION
The IPTC property reader walks the embedded iptc/8bim profile looking for a 0x1c marker and then reads the record header that follows it, the dataset and record numbers plus a two-byte length, before copying the declared number of data bytes out of the profile. The scan loop only stops at the profile length and nothing caps the declared length, so a marker sitting in the last few bytes of the profile makes the header reads step past the end of the profile, and a record claiming a length larger than the bytes actually left makes the copy run past the record extent as well. Those values come straight from the profile, which is attacker controlled, and the reader is reachable from an ordinary request such as -format %[IPTC:2:25] on any image carrying a crafted profile. I noticed it while comparing this with the IPTC printer in identify.c, which already loops to profile_length-5 and clamps the length with MagickMin, so the two readers were treating the same data differently. The change brings GetIPTCProperty into line with that one by stopping the scan five bytes short of the end and clamping the record length to the bytes that remain, and valid IPTC still reads back as before.