### PR TITLE
bound 8bim resolution resource read in GetProfilesFromResourceBlock

### DIFF
--- a/MagickCore/profile.c
+++ b/MagickCore/profile.c
@@ -1844,7 +1844,7 @@ static void GetProfilesFromResourceBlock(Image *image,
         /*
           Resolution.
         */
-        if (count < 10)
+        if (count < 16)
           break;
         p=ReadResourceLong(p,&resolution);
         image->resolution.x=((double) resolution)/65536.0;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The resolution case (0x03ED) in GetProfilesFromResourceBlock pulls two 32-bit fixed-point values and a 16-bit units field out of the resource data, so it walks the full 16-byte Photoshop ResolutionInfo structure, but it only checked that the resource declared at least 10 bytes. A Photoshop 8bim resource that declares a resolution block of 10 or 11 bytes is therefore read a little past its declared length, and when that block is the last thing in the profile the reads at offset 8..11 reach past the profile's own bytes into the trailing buffer padding.

I bounded it to the full 16 bytes the handler actually consumes, so a short resolution resource is skipped rather than read past.

Checked on a local build: a 0x03ED resource declaring 10 bytes followed by another 8BIM block left image->resolution.y holding the next block's signature bytes (0x3842, about 0.22), and a normal 16-byte resolution resource still reads back as 300x300.
