### PR TITLE
OSS-Fuzz: Fix build errors

### DIFF
--- a/oss-fuzz/build_dependencies.sh
+++ b/oss-fuzz/build_dependencies.sh
@@ -39,7 +39,7 @@ popd
 # Build libtiff
 pushd "$SRC/libtiff"
 autoreconf -fiv
-./configure --disable-shared --prefix="$WORK" CFLAGS="$CFLAGS -I$WORK/include" LIBS="-L$WORK/lib"
+./configure --disable-shared --disable-tools --prefix="$WORK" CFLAGS="$CFLAGS -I$WORK/include" LIBS="-L$WORK/lib"
 make -j$(nproc)
 make install
 popd


### PR DESCRIPTION
This PR fixes the OSS-Fuzz fuzzer build on disabling the CLI tools for libtiff build that is currently failing and does not affect fuzzing.