### PR TITLE
check rows*columns overflow in sct ReadSCTImage

### DIFF
--- a/coders/sct.c
+++ b/coders/sct.c
@@ -145,6 +145,7 @@ static Image *ReadSCTImage(const ImageInfo *image_info,ExceptionInfo *exception)
     *q;
 
   size_t
+    number_pixels,
     separations,
     separations_mask,
     units;
@@ -230,16 +231,19 @@ static Image *ReadSCTImage(const ImageInfo *image_info,ExceptionInfo *exception)
       (void) CloseBlob(image);
       return(GetFirstImageInList(image));
     }
-  status=SetImageExtent(image,image->columns,image->rows,exception);
-  if (status == MagickFalse)
-    return(DestroyImageList(image));
-  extent=(MagickSizeType) image->rows*image->columns*separations;
+  if (HeapOverflowSanityCheckGetSize(image->columns,image->rows,
+      &number_pixels) != MagickFalse)
+    ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
+  extent=(MagickSizeType) number_pixels*separations;
   if (extent > GetBlobSize(image))
     {
       ThrowFileException(exception,CorruptImageError,"UnexpectedEndOfFile",
         image->filename);
       return(DestroyImageList(image));
     }
+  status=SetImageExtent(image,image->columns,image->rows,exception);
+  if (status == MagickFalse)
+    return(DestroyImageList(image));
   /*
     Convert SCT raster image to pixel packets.
   */


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

ReadSCTImage works out the expected pixel size from image->rows*image->columns*separations, but the rows and columns are taken straight from the textual SCT header fields, so on a crafted file the size_t multiply can wrap and slip past the extent > GetBlobSize check, after which SetImageExtent is reached with the oversized dimensions. This is the same overflow that was recently addressed in the vicar reader. I have guarded the multiplication with HeapOverflowSanityCheckGetSize and moved the size check ahead of SetImageExtent so an over-large file is rejected before any pixel cache is allocated.