### PR TITLE
Read Cairo ARGB32 in host byte order so SVG colors are correct on big-endian

### DIFF
--- a/coders/svg.c
+++ b/coders/svg.c
@@ -374,6 +374,9 @@ static Image *RenderRSVGImage(const ImageInfo *image_info,Image *image,
   MagickBooleanType
     apply_density;
 
+  EndianType
+    endian;
+
   MemoryInfo
     *pixel_info;
 
@@ -591,6 +594,9 @@ static Image *RenderRSVGImage(const ImageInfo *image_info,Image *image,
       p=gdk_pixbuf_get_pixels(pixel_buffer);
 #endif
       GetPixelInfo(image,&fill_color);
+#if defined(MAGICKCORE_CAIRO_DELEGATE)
+      endian=GetHostEndian();
+#endif
       for (y=0; y < (ssize_t) image->rows; y++)
       {
         q=GetAuthenticPixels(image,0,y,image->columns,1,exception);
@@ -599,15 +605,26 @@ static Image *RenderRSVGImage(const ImageInfo *image_info,Image *image,
         for (x=0; x < (ssize_t) image->columns; x++)
         {
 #if defined(MAGICKCORE_CAIRO_DELEGATE)
-          fill_color.blue=ScaleCharToQuantum(*p++);
-          fill_color.green=ScaleCharToQuantum(*p++);
-          fill_color.red=ScaleCharToQuantum(*p++);
+          if (endian == LSBEndian)
+            {
+              fill_color.blue=ScaleCharToQuantum(*p++);
+              fill_color.green=ScaleCharToQuantum(*p++);
+              fill_color.red=ScaleCharToQuantum(*p++);
+              fill_color.alpha=ScaleCharToQuantum(*p++);
+            }
+          else
+            {
+              fill_color.alpha=ScaleCharToQuantum(*p++);
+              fill_color.red=ScaleCharToQuantum(*p++);
+              fill_color.green=ScaleCharToQuantum(*p++);
+              fill_color.blue=ScaleCharToQuantum(*p++);
+            }
 #else
           fill_color.red=ScaleCharToQuantum(*p++);
           fill_color.green=ScaleCharToQuantum(*p++);
           fill_color.blue=ScaleCharToQuantum(*p++);
-#endif
           fill_color.alpha=ScaleCharToQuantum(*p++);
+#endif
 #if defined(MAGICKCORE_CAIRO_DELEGATE)
           {
             double


### PR DESCRIPTION
Fixes #8596.

`RenderRSVGImage` reads the Cairo `CAIRO_FORMAT_ARGB32` surface as a fixed `B,G,R,A` byte sequence. ARGB32 is a native-endian 32-bit word (`0xAARRGGBB`), so that byte order is only correct on little-endian hosts. On big-endian the bytes are laid out `A,R,G,B`, so the channels and alpha are misread and SVG colors render incorrectly.

This detects the host byte order once per image and reads `B,G,R,A` on little-endian or `A,R,G,B` on big-endian, using the same `lsb_first` idiom already used in `constitute.c` and `xwd.c`.

### Testing

Built and tested on a native big-endian ppc64 (POWER8) host. Reading an opaque `#ff8040` rect through the rsvg coder (`magick rsvg:test.svg -depth 8 RGBA:-`):

| input | before | after | rsvg-convert reference |
|-------|--------|-------|------------------------|
| `#ff8040` | `ff ff ff ff` | `ff 80 40 ff` | `ff 80 40 ff` |
| red `#ff0000` | white | `255,0,0` | `255,0,0` |
| green `#00ff00` | white | `0,255,0` | `0,255,0` |
| `#c89664` @ 50% | white | `srgba(199,149,100,0.502)` | correct |

The `nix-snowflake-colours.svg` from the issue rendered solid white before this change and renders with the correct colors after.

Little-endian output is unchanged: the little-endian branch reads the same bytes in the same order as before, and the change is confined to the cairo delegate path inside `RenderRSVGImage`.