### PR TITLE
reject otb files that declare more pixels than the file holds

### DIFF
--- a/coders/otb.c
+++ b/coders/otb.c
@@ -163,6 +163,9 @@ static Image *ReadOTBImage(const ImageInfo *image_info,ExceptionInfo *exception)
       (void) CloseBlob(image);
       return(GetFirstImageInList(image));
     }
+  if ((image->columns > GetBlobSize(image)) ||
+      (image->rows > GetBlobSize(image)))
+    ThrowReaderException(CorruptImageError,"InsufficientImageDataInFile");
   status=SetImageExtent(image,image->columns,image->rows,exception);
   if (status == MagickFalse)
     return(DestroyImageList(image));


### PR DESCRIPTION
**Oversized dimensions accepted in the otb reader**
The width and height come straight from the header and are handed to SetImageExtent without any check that the file is large enough to hold that many pixels, so a handful of bytes can make the reader size the pixel cache and walk billions of one-bit pixels before the decode runs out of input. This mirrors the insufficient-data guard wbmp recently received, placed just before the extent is set.