### PR TITLE
check profile length before reading header in GetIPTCStream

### DIFF
--- a/coders/meta.c
+++ b/coders/meta.c
@@ -1628,6 +1628,8 @@ static size_t GetIPTCStream(unsigned char **info,size_t length)
 
   p=(*info);
   extent=length;
+  if (extent < 2)
+    return(0);
   if ((*p == 0x1c) && (*(p+1) == 0x02))
     return(length);
   /*


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

GetIPTCStream in coders/meta.c reads the first two bytes of the 8bim/iptc profile (`*p` and `*(p+1)`) before it has checked that the profile actually holds two bytes, so a profile shorter than that is read past its declared length. The profile content comes from the input image, and the read is reached when writing it out through the iptc, iptctext or 8bimtext coders. Every later read in the same function is already guarded by an extent check (for instance `if (extent < 4) break` before the four-byte tag length), so this just adds the matching guard for that first read and returns zero when there is nothing to parse, which leaves valid profiles untouched.