### PR TITLE
guard ept length overflow before allocation

### DIFF
--- a/coders/ept.c
+++ b/coders/ept.c
@@ -211,6 +211,9 @@ static Image *ReadEPTImage(const ImageInfo *image_info,ExceptionInfo *exception)
     ThrowReaderException(CorruptImageError,"ImproperImageHeader");
   if ((MagickSizeType) ept_info.tiff_length > GetBlobSize(image))
     ThrowReaderException(CorruptImageError,"InsufficientImageDataInFile");
+  if ((ept_info.postscript_length > (UINT_MAX-1)) ||
+      (ept_info.tiff_length > (UINT_MAX-1)))
+    ThrowReaderException(ResourceLimitError,"MemoryAllocationFailed");
   (void) ReadBlobLSBShort(image);
   ept_info.postscript=(unsigned char *) AcquireQuantumMemory(
     ept_info.postscript_length+1,sizeof(*ept_info.postscript));


### PR DESCRIPTION
ReadEPTImage takes the postscript and tiff section lengths straight from the header and passes length+1 to AcquireQuantumMemory. On a build where size_t is 32-bit a length close to UINT_MAX wraps the +1 to a tiny allocation that the following read then overruns. This adds the same UINT_MAX guard that was just added to the jnx reader so an oversized length is rejected before the allocation.