### PR TITLE
honor the disk resource limit for the TIFF EXIF temporary file

### DIFF
--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -749,6 +749,9 @@ static void TIFFSetImageProperties(TIFF *tiff,Image *image,const char *tag,
   int
     unique_file;
 
+  MagickSizeType
+    extent;
+
   /*
     Set EXIF or GPS image properties.
   */
@@ -764,6 +767,16 @@ static void TIFFSetImageProperties(TIFF *tiff,Image *image,const char *tag,
       return;
     }
   TIFFPrintDirectory(tiff,file,0);
+  (void) fseek(file,0,SEEK_END);
+  extent=(MagickSizeType) ftell(file);
+  if (AcquireMagickResource(DiskResource,extent) == MagickFalse)
+    {
+      (void) fclose(file);
+      (void) RelinquishUniqueFileResource(filename);
+      (void) ThrowMagickException(exception,GetMagickModule(),
+        ResourceLimitError,"MemoryAllocationFailed","`%s'",filename);
+      return;
+    }
   (void) fseek(file,0,SEEK_SET);
   while (fgets(buffer,(int) sizeof(buffer),file) != NULL)
   {
@@ -784,6 +797,7 @@ static void TIFFSetImageProperties(TIFF *tiff,Image *image,const char *tag,
   }
   (void) fclose(file);
   (void) RelinquishUniqueFileResource(filename);
+  RelinquishMagickResource(DiskResource,extent);
 }
 
 static void TIFFGetEXIFProperties(TIFF *tiff,Image *image,


### PR DESCRIPTION

## What

When the TIFF coder extracts EXIF/GPS metadata, `TIFFSetImageProperties()`
(`coders/tiff.c`) creates a temporary file with `AcquireUniqueFileResource()`
and calls `TIFFPrintDirectory(tiff,file,0)` to dump the whole TIFF directory to
it as text, then reads it back line by line to parse the properties.

That temporary write is not accounted against the `disk` resource limit. Every
other place that spills to disk (for example the pixel cache in
`MagickCore/cache.c`) calls `AcquireMagickResource(DiskResource,...)` first, but
this path never does, so `TIFFPrintDirectory` can write an arbitrarily large
amount of data regardless of the configured `disk` limit.

`TIFFPrintDirectory` prints tag values verbatim, so the dump size scales with
the directory contents. A TIFF whose EXIF IFD carries a single large but
individually valid ASCII tag (for example a multi-megabyte `SpectralSensitivity`,
tag 34852) produces a multi-megabyte dump, and it is written even when a much
smaller `disk` limit is in force.

## Reproduce

Build with TIFF support, then run with a small `disk` limit active:

    # policy.xml: <policy domain="resource" name="disk" value="1MiB"/>
    magick identify -verbose big-exif.tiff

where `big-exif.tiff` is a small image whose EXIF IFD holds a ~4 MB ASCII
`SpectralSensitivity` value.

Before this change: the ~4 MB directory dump is written to the temporary file
and the property is parsed, with no error and a clean exit — the 1 MiB `disk`
limit has no effect on this path.

## Fix

After `TIFFPrintDirectory` writes the dump, measure it with `ftell` and account
it against `DiskResource` via `AcquireMagickResource()`, mirroring the
acquire/relinquish pairing already used for disk-backed pixel caches in
`MagickCore/cache.c`. If the accounted size would exceed the `disk` limit, the
temporary file is released and the EXIF properties are skipped with a
`ResourceLimitError` instead of being parsed. On the normal path the resource is
released with `RelinquishMagickResource()` so repeated EXIF reads in one process
do not accumulate against the limit.

With the change, the same input under a 1 MiB `disk` limit reports a
`ResourceLimitError` at `TIFFSetImageProperties` and skips the property; a
normal-size EXIF tag (and a large tag with no `disk` limit set) is extracted
exactly as before.

The `"MemoryAllocationFailed"` message id is the existing string used for
`ResourceLimitError` resource-exhaustion throws elsewhere (for example throughout
`MagickCore/blob.c`); reusing it keeps the message consistent with the rest of
the tree.
