### PR TITLE
Fixes for PTIF writer to re-enable default creation of pyramid levels

### DIFF
--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -2925,7 +2925,7 @@ static MagickBooleanType WritePTIFImage(const ImageInfo *image_info,
       images=GetFirstImageInList(images);
       write_info=CloneImageInfo(image_info);
       write_info->adjoin=MagickTrue;
-      (void) CopyMagickString(write_info->magick,"TIFF",MagickPathExtent);
+      (void) CopyMagickString(write_info->magick,"PTIF",MagickPathExtent);
       (void) CopyMagickString(images->magick,"TIFF",MagickPathExtent);
       status=WriteTIFFImage(write_info,images,exception);
       images=DestroyImageList(images);
@@ -4141,8 +4141,10 @@ static MagickBooleanType WriteTIFFImage(const ImageInfo *image_info,
       pages=(uint16) number_scenes;
       if ((LocaleCompare(image_info->magick,"PTIF") != 0) &&
           (adjoin != MagickFalse) && (pages > 1))
-        (void) TIFFSetField(tiff,TIFFTAG_SUBFILETYPE,FILETYPE_PAGE);
-      (void) TIFFSetField(tiff,TIFFTAG_PAGENUMBER,page,pages);
+        {
+          (void) TIFFSetField(tiff,TIFFTAG_SUBFILETYPE,FILETYPE_PAGE);
+          (void) TIFFSetField(tiff,TIFFTAG_PAGENUMBER,page,pages);
+        }
     }
     (void) TIFFSetProperties(tiff,adjoin,image,exception);
     /*

--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -3442,7 +3442,7 @@ static void TIFFSetProperties(TIFF *tiff,const MagickBooleanType adjoin,
   value=GetImageProperty(image,"comment",exception);
   if (value != (const char *) NULL)
     (void) TIFFSetField(tiff,TIFFTAG_IMAGEDESCRIPTION,value);
-  value=GetImageArtifact(image,"tiff:subfiletype");
+  value=GetImageProperty(image,"tiff:subfiletype",exception);
   if (value != (const char *) NULL)
     {
       if (LocaleCompare(value,"REDUCEDIMAGE") == 0)

--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -2884,7 +2884,7 @@ static MagickBooleanType WritePTIFImage(const ImageInfo *image_info,
     Image
       *clone_image;
 
-    ssize_t
+    size_t
       i;
 
     clone_image=CloneImage(next,0,0,MagickFalse,exception);
@@ -2899,7 +2899,7 @@ static MagickBooleanType WritePTIFImage(const ImageInfo *image_info,
     resolution=next->resolution;
     for (i=0; (columns > min_base) && (rows > min_base); i++)
     {
-      if (i > (ssize_t) max_levels)
+      if (i > max_levels)
         break;
       columns/=2;
       rows/=2;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This pull request addresses 3 issues with the PTIF pyramid TIFF writer.

Firstly, https://github.com/ImageMagick/ImageMagick/commit/fed6a06dccbc87ad1159565a9c63bab93c98c855 fixes a bug in ImageMagick introduced by this commit: https://github.com/ImageMagick/ImageMagick/commit/3030b16bc61b6216e6b0901dceb296f09a37a3ac. There is a mixup between signed and unsigned (`size_t` vs `ssize_t`), which results in no pyramid layers being written unless the user specifically sets the `ptif:pyramid` option (for example `-define ptif:pyramid=128x8`). This was a breaking change with respect to previous versions of ImageMagick where pyramid layers would always be written by default. The problem has been flagged in these issues: https://github.com/ImageMagick/ImageMagick/issues/4464 and https://github.com/ruven/iipsrv/issues/291. Basically, `max_levels` is defined as `~0UL` (essentially `SIZE_MAX`) in `tiff.c` whereas the break condition uses `if (i > (ssize_t) max_levels)`, where the cast flips `max_levels` to -1. Given the initial assignment, this is not what was intended and `i` does not, in any case, need to be signed.

Secondly, the TIFF `SUBFILETYPE` was not being correctly set to `REDUCEDIMAGE` for the pyramid layers. The subfile type is set using `SetImageProperty()` within the code, whereas `GetImageArtifact()` was being used in the `TIFFSetProperties()` function at the moment of writing: `GetImageProperty()` is now used throughout.

Finally, a missing pair of brackets meant that the TIFF page number tag was being unintentionally written when writing pyramid TIFFs. This [commit](https://github.com/ImageMagick/ImageMagick/commit/21c2d29b88e58219966827393d23dac45421a9ab) adds those brackets and avoids writing the tag.

### Example

Versions of ImageMagick previous to version 7.1.2-27 create a complete 256x256 pixel tiled TIFF pyramid with resolution layers down to a minimum size of 64x64 (this size is hard-coded within ImageMagick) with the following command:

`convert input.png -define tiff:tile-geometry=256x256 ptif:output.tif`

The current ImageMagick only creates a full resolution image with no pyramid layers. This pull request re-enables full pyramid creation by default as with previous versions.