### PR TITLE
display: Put the pan window at a user defined location

### DIFF
--- a/MagickCore/display.c
+++ b/MagickCore/display.c
@@ -9587,13 +9587,18 @@ static void XMakePanImage(Display *display,XResourceInfo *resource_info,
   */
   XSetCursorState(display,windows,MagickTrue);
   XCheckRefreshWindows(display,windows);
-  windows->pan.x=(int) windows->image.x;
-  windows->pan.y=(int) windows->image.y;
+  if (!windows->pan.x)
+    windows->pan.x=(int) windows->image.x;
+  if (!windows->pan.y)
+    windows->pan.y=(int) windows->image.y;
   status=XMakeImage(display,resource_info,&windows->pan,image,
     windows->pan.width,windows->pan.height,exception);
   if (status == MagickFalse)
     ThrowXWindowException(ResourceLimitError,"MemoryAllocationFailed",
       image->filename);
+  if (windows->pan.x || windows->pan.y)
+    (void) XMoveWindow(display,windows->pan.id,windows->pan.x,
+		       windows->pan.y);
   (void) XSetWindowBackgroundPixmap(display,windows->pan.id,
     windows->pan.pixmap);
   (void) XClearWindow(display,windows->pan.id);


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The position of the pan window is initially taken from X11 resource "display*pan.geometry" in XDisplayImage().
But that position is always overruled later in XMakePanImage(). Avoid this if the resource is set, and show the window in the user defined location.

Fixes: 25c326508ae1 ("revert")

<!-- Thanks for contributing to ImageMagick! -->
