### PR TITLE
Fix inline SVG style precedence

### DIFF
--- a/coders/svg.c
+++ b/coders/svg.c
@@ -1279,6 +1279,7 @@ static void SVGStartElement(void *context,const xmlChar *name,
     background[MagickPathExtent],
     id[MagickPathExtent],
     *next_token,
+    *style,
     token[MagickPathExtent],
     **tokens,
     *units;
@@ -1325,6 +1326,7 @@ static void SVGStartElement(void *context,const xmlChar *name,
     }
   svg_info->scale[svg_info->n]=svg_info->scale[svg_info->n-1];
   color=AcquireString("none");
+  style=(char *) NULL;
   units=AcquireString("userSpaceOnUse");
   *id='\0';
   *token='\0';
@@ -2252,7 +2254,7 @@ static void SVGStartElement(void *context,const xmlChar *name,
             }
           if (LocaleCompare(keyword,"style") == 0)
             {
-              SVGProcessStyleElement(svg_info,name,value);
+              (void) CloneString(&style,value);
               break;
             }
           break;
@@ -2558,6 +2560,11 @@ static void SVGStartElement(void *context,const xmlChar *name,
           break;
       }
       value=DestroyString(value);
+    }
+  if (style != (char *) NULL)
+    {
+      SVGProcessStyleElement(svg_info,name,style);
+      style=DestroyString(style);
     }
   if (LocaleCompare((const char *) name,"svg") == 0)
     {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -62,6 +62,7 @@ TESTS_EXTRA_DIST = \
   tests/common.shi \
   tests/rose.pnm \
   tests/input_svg_gradient_transform.svg \
+  tests/input_svg_inline_style.svg \
   tests/input_256c.miff \
   tests/input_bilevel.miff \
   tests/input_gray.miff \

--- a/tests/cli-svg.tap
+++ b/tests/cli-svg.tap
@@ -24,6 +24,11 @@ echo "1..2"
 ${MAGICK} ${SRCDIR}/input_svg_gradient_transform.svg null: && echo "ok" || echo "not ok"
 
 # Inline styles override presentation attributes regardless of attribute order.
+msvg_mode=`${MAGICK} -list format | awk '$1 ~ /^MSVG/ { print $3 }'`
+case "$msvg_mode" in
+  *r*) ;;
+  *) echo "ok # SKIP MSVG coder unavailable"; exit 0 ;;
+esac
 colors=`${MAGICK} MSVG:${SRCDIR}/input_svg_inline_style.svg \
   -format '%[fx:int(255*p{5,5}.r+0.5)],%[fx:int(255*p{5,5}.g+0.5)],%[fx:int(255*p{5,5}.b+0.5)] %[fx:int(255*p{15,5}.r+0.5)],%[fx:int(255*p{15,5}.g+0.5)],%[fx:int(255*p{15,5}.b+0.5)]' info:-`
 [ "X$colors" = "X255,255,255 255,255,255" ] && echo "ok" || echo "not ok"

--- a/tests/cli-svg.tap
+++ b/tests/cli-svg.tap
@@ -24,12 +24,13 @@ echo "1..2"
 ${MAGICK} ${SRCDIR}/input_svg_gradient_transform.svg null: && echo "ok" || echo "not ok"
 
 # Inline styles override presentation attributes regardless of attribute order.
-msvg_mode=`${MAGICK} -list format | awk '$1 ~ /^MSVG/ { print $3 }'`
+msvg_mode=`${MAGICK} -list format | awk '$1 ~ /^MSVG/ { print $2 }'`
 case "$msvg_mode" in
-  *r*) ;;
-  *) echo "ok # SKIP MSVG coder unavailable"; exit 0 ;;
+  *r*)
+    colors=`${MAGICK} MSVG:${SRCDIR}/input_svg_inline_style.svg \
+      -format '%[fx:int(255*p{5,5}.r+0.5)],%[fx:int(255*p{5,5}.g+0.5)],%[fx:int(255*p{5,5}.b+0.5)] %[fx:int(255*p{15,5}.r+0.5)],%[fx:int(255*p{15,5}.g+0.5)],%[fx:int(255*p{15,5}.b+0.5)]' info:-`
+    [ "X$colors" = "X255,255,255 255,255,255" ] && echo "ok" || echo "not ok"
+    ;;
+  *) echo "ok # SKIP MSVG coder unavailable" ;;
 esac
-colors=`${MAGICK} MSVG:${SRCDIR}/input_svg_inline_style.svg \
-  -format '%[fx:int(255*p{5,5}.r+0.5)],%[fx:int(255*p{5,5}.g+0.5)],%[fx:int(255*p{5,5}.b+0.5)] %[fx:int(255*p{15,5}.r+0.5)],%[fx:int(255*p{15,5}.g+0.5)],%[fx:int(255*p{15,5}.b+0.5)]' info:-`
-[ "X$colors" = "X255,255,255 255,255,255" ] && echo "ok" || echo "not ok"
 :

--- a/tests/cli-svg.tap
+++ b/tests/cli-svg.tap
@@ -18,8 +18,13 @@
 #
 . ./common.shi
 . ${srcdir}/tests/common.shi
-echo "1..1"
+echo "1..2"
 
 # gradientTransform should not cause a double-free / SIGABRT (#8582)
 ${MAGICK} ${SRCDIR}/input_svg_gradient_transform.svg null: && echo "ok" || echo "not ok"
+
+# Inline styles override presentation attributes regardless of attribute order.
+colors=`${MAGICK} MSVG:${SRCDIR}/input_svg_inline_style.svg \
+  -format '%[fx:int(255*p{5,5}.r+0.5)],%[fx:int(255*p{5,5}.g+0.5)],%[fx:int(255*p{5,5}.b+0.5)] %[fx:int(255*p{15,5}.r+0.5)],%[fx:int(255*p{15,5}.g+0.5)],%[fx:int(255*p{15,5}.b+0.5)]' info:-`
+[ "X$colors" = "X255,255,255 255,255,255" ] && echo "ok" || echo "not ok"
 :

--- a/tests/input_svg_inline_style.svg
+++ b/tests/input_svg_inline_style.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+  <rect x="0" y="0" width="10" height="10"
+    style="fill:#ffffff" fill="#d6a312"/>
+  <rect x="10" y="0" width="10" height="10"
+    fill="#d6a312" style="fill:#ffffff"/>
+</svg>


### PR DESCRIPTION
The SVG specifications give inline style declarations higher priority than
presentation attributes. The MSVG parser currently applies both in XML
attribute order, so a presentation attribute can incorrectly override an
earlier `style` attribute.

This defers the existing inline-style processing until after presentation
attributes have been handled. The regression test covers both attribute orders
and confirms that inline CSS wins in either case.

Fixes #8799.

Tests: `make check` (52 passed, 1 delegate-dependent test skipped)

AI assistance was used to investigate the parser and draft the change. I
reviewed the diff and ran the tests and reproductions described above locally.
