### PR TITLE
Preserve page offsets in PCX images

### DIFF
--- a/coders/pcx.c
+++ b/coders/pcx.c
@@ -341,6 +341,8 @@ static Image *ReadPCXImage(const ImageInfo *image_info,ExceptionInfo *exception)
       ThrowPCXException(CorruptImageError,"ImproperImageHeader");
     image->columns=(size_t) (pcx_info.right-pcx_info.left)+1UL;
     image->rows=(size_t) (pcx_info.bottom-pcx_info.top)+1UL;
+    image->page.x=(ssize_t) pcx_info.left;
+    image->page.y=(ssize_t) pcx_info.top;
     image->depth=pcx_info.bits_per_pixel;
     image->units=PixelsPerInchResolution;
     image->resolution.x=(double) pcx_info.horizontal_resolution;
@@ -947,9 +949,17 @@ static MagickBooleanType WritePCXImage(const ImageInfo *image_info,Image *image,
     else if (IssRGBCompatibleColorspace(image->colorspace) == MagickFalse)
         (void) TransformImageColorspace(image,sRGBColorspace,exception);
     pcx_info.left=0;
+    if ((image->page.x > 0) && (image->page.x <= MAGICK_USHORT_MAX) &&
+        (image->columns <= (size_t) MAGICK_USHORT_MAX+1UL-
+          (size_t) image->page.x))
+      pcx_info.left=(unsigned short) image->page.x;
     pcx_info.top=0;
-    pcx_info.right=(unsigned short) (image->columns-1);
-    pcx_info.bottom=(unsigned short) (image->rows-1);
+    if ((image->page.y > 0) && (image->page.y <= MAGICK_USHORT_MAX) &&
+        (image->rows <= (size_t) MAGICK_USHORT_MAX+1UL-
+          (size_t) image->page.y))
+      pcx_info.top=(unsigned short) image->page.y;
+    pcx_info.right=(unsigned short) (pcx_info.left+image->columns-1);
+    pcx_info.bottom=(unsigned short) (pcx_info.top+image->rows-1);
     switch (image->units)
     {
       case UndefinedResolution:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ TESTS_XFAIL_TESTS =
 TESTS_TESTS = \
   tests/cli-colorspace.tap \
   tests/cli-heic.tap \
+  tests/cli-pcx.tap \
   tests/cli-pipe.tap \
   tests/cli-svg.tap \
   tests/validate-colorspace.tap \

--- a/tests/cli-pcx.tap
+++ b/tests/cli-pcx.tap
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+#  Copyright 1999 ImageMagick Studio LLC, a non-profit organization
+#  dedicated to making software imaging solutions freely available.
+#
+#  You may not use this file except in compliance with the License.  You may
+#  obtain a copy of the License at
+#
+#    https://imagemagick.org/license/
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Regression tests for PCX coder.
+#
+. ./common.shi
+. ${srcdir}/tests/common.shi
+echo "1..3"
+
+# PCX left/top coordinates should round-trip as page offsets.
+page=`${MAGICK} -size 3x2 xc:red -set page 3x2+10+29 pcx_out.pcx && \
+  ${MAGICK} pcx_out.pcx -format '%X,%Y %wx%h' info:-`
+[ "X$page" = "X+10,+29 3x2" ] && echo "ok" || echo "not ok"
+
+# The largest representable endpoint should be retained.
+page=`${MAGICK} -size 1x1 xc:red -set page 1x1+65535+65535 \
+  pcx_boundary_out.pcx && ${MAGICK} pcx_boundary_out.pcx \
+  -format '%X,%Y %wx%h' info:-`
+[ "X$page" = "X+65535,+65535 1x1" ] && echo "ok" || echo "not ok"
+
+# Origins that would overflow right/bottom fall back without corrupting size.
+page=`${MAGICK} -size 2x2 xc:red -set page 2x2+65535+65535 \
+  pcx_overflow_out.pcx && ${MAGICK} pcx_overflow_out.pcx \
+  -format '%X,%Y %wx%h' info:-`
+[ "X$page" = "X+0,+0 2x2" ] && echo "ok" || echo "not ok"
+:


### PR DESCRIPTION
PCX headers store the image origin in their `left` and `top` fields, but the
decoder currently discards those values and the encoder always writes zero.
This preserves representable page offsets in both directions and calculates
the absolute `right`/`bottom` endpoints without overflowing the 16-bit header.

The regression coverage checks a normal round trip, the maximum representable
endpoint, and the safe fallback for an origin whose endpoint would overflow.
The TGA portion of #8847 has already landed on `main`, so this completes the
remaining PCX portion.

Fixes #8847.

Tests:
- `make check TESTS=tests/cli-pcx.tap` (3 passed)
- `make check` (51 passed, 1 delegate-dependent test skipped)

AI assistance was used to investigate the coder and draft the change. I
reviewed the offset arithmetic, inspected the encoded headers, and ran the
tests and round-trip reproductions locally.
