### PR TITLE
fix: use registered UHDR module name in policy check

### DIFF
--- a/coders/jpeg.c
+++ b/coders/jpeg.c
@@ -405,7 +405,7 @@ static MagickBooleanType IsUltraHDRJPEGAutoRoutingEnabled(
     return(MagickFalse);
   if (IsRightsAuthorized(CoderPolicyDomain,rights,"UHDR") == MagickFalse)
     return(MagickFalse);
-  if (IsRightsAuthorized(ModulePolicyDomain,rights,"UHDr") == MagickFalse)
+  if (IsRightsAuthorized(ModulePolicyDomain,rights,"UHDR") == MagickFalse)
     return(MagickFalse);
   return(MagickTrue);
 }


### PR DESCRIPTION
### Description

The UHDR module registration was recently updated from `UHDr` to `UHDR`. This updates the corresponding JPEG auto-routing policy check to use the current module name.

Policy matching is case-sensitive, so the previous name could prevent UHDR routing under a deny-by-default module policy that explicitly permits `UHDR`.

### Validation

Using a module build with libultrahdr 1.4.0 and an ISO gain-map JPEG:

- Before this change, a policy allowing `JPEG` and `UHDR` produced `format=JPEG`.
- After this change, the same policy produced `format=UHDR`.
- Omitting `UHDR` from the allowlist continued to produce `format=JPEG`.

This change does not modify default policies, dependency discovery, JPEG detection, or AVIF behavior.
