### PR TITLE
Raise the minimum supported libultrahdr version to 1.4.0

### DIFF
--- a/configure
+++ b/configure
@@ -35805,19 +35805,19 @@ if test "$with_uhdr" != 'no'; then
 printf "%s\n" "-------------------------------------------------------------" >&6; }
 
 pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libuhdr >= 1.3.0" >&5
-printf %s "checking for libuhdr >= 1.3.0... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libuhdr >= 1.4.0" >&5
+printf %s "checking for libuhdr >= 1.4.0... " >&6; }
 
 if test -n "$UHDR_CFLAGS"; then
     pkg_cv_UHDR_CFLAGS="$UHDR_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libuhdr >= 1.3.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libuhdr >= 1.3.0") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libuhdr >= 1.4.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libuhdr >= 1.4.0") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_UHDR_CFLAGS=`$PKG_CONFIG --cflags "libuhdr >= 1.3.0" 2>/dev/null`
+  pkg_cv_UHDR_CFLAGS=`$PKG_CONFIG --cflags "libuhdr >= 1.4.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -35829,12 +35829,12 @@ if test -n "$UHDR_LIBS"; then
     pkg_cv_UHDR_LIBS="$UHDR_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libuhdr >= 1.3.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libuhdr >= 1.3.0") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libuhdr >= 1.4.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libuhdr >= 1.4.0") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_UHDR_LIBS=`$PKG_CONFIG --libs "libuhdr >= 1.3.0" 2>/dev/null`
+  pkg_cv_UHDR_LIBS=`$PKG_CONFIG --libs "libuhdr >= 1.4.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -35855,9 +35855,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        UHDR_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libuhdr >= 1.3.0" 2>&1`
+	        UHDR_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libuhdr >= 1.4.0" 2>&1`
         else
-	        UHDR_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libuhdr >= 1.3.0" 2>&1`
+	        UHDR_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libuhdr >= 1.4.0" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$UHDR_PKG_ERRORS" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -2901,7 +2901,7 @@ UHDR_LIBS=""
 UHDR_PKG=""
 if test "$with_uhdr" != 'no'; then
     AC_MSG_RESULT([-------------------------------------------------------------])
-    PKG_CHECK_MODULES([UHDR],[libuhdr >= 1.3.0],[have_uhdr=yes],[have_uhdr=no])
+    PKG_CHECK_MODULES([UHDR],[libuhdr >= 1.4.0],[have_uhdr=yes],[have_uhdr=no])
     AC_MSG_RESULT([])
 fi
 


### PR DESCRIPTION
## Summary

Raise the minimum supported libultrahdr version from 1.3.0 to 1.4.0.

## Rationale

The UHDR coder accesses the three-element `max_content_boost`, `min_content_boost`, `gamma`, `offset_sdr`, and `offset_hdr` fields in `uhdr_gainmap_metadata_t`, as well as `use_base_cg`.

Libultrahdr 1.3.0 exposes scalar metadata fields and does not provide `use_base_cg`. The compatible metadata API was introduced in libultrahdr 1.4.0. Consequently, the existing `libuhdr >= 1.3.0` check can enable a dependency against which the UHDR coder cannot compile.

This change makes the configure requirement match the API used by the source.
The generated `configure` script is updated accordingly.

## Validation

Tested with clean, exact-tag libultrahdr builds:
- 1.3.0 is rejected by the updated `pkg-config` requirement and UHDR remains
  disabled.
- 1.4.0 is accepted, and an ImageMagick module build completes.
- 2.0.2 is accepted, and an ImageMagick built-in coder build completes.
- The 1.4.0 and 2.0.2 builds list the UHDR coder, decode an existing Ultra HDR
  JPEG, and successfully encode and decode paired SDR/HDR inputs while
  preserving the `hdrgm` and ICC profiles.
