### PR TITLE
Fix incorrect Ultra HDR output after successive crops

### DIFF
--- a/coders/uhdr.c
+++ b/coders/uhdr.c
@@ -788,6 +788,7 @@ static MagickBooleanType CropGainMapImage(Image **gainmap_image,
   geometry.y=y0;
   geometry.width=(size_t) (x1-x0);
   geometry.height=(size_t) (y1-y0);
+  (void) ResetImagePage(*gainmap_image,"0x0+0+0");
   crop_image=CropImage(*gainmap_image,&geometry,exception);
   return(ReplaceGainMapImage(gainmap_image,crop_image));
 }

--- a/tests/cli-uhdr.tap
+++ b/tests/cli-uhdr.tap
@@ -30,6 +30,10 @@ invalid_output=cli-uhdr-offset-invalid.jpg
 commented_source=cli-uhdr-commented.jpg
 comment_roundtrip=cli-uhdr-comment-roundtrip.jpg
 comment_linear=cli-uhdr-comment-roundtrip-linear.miff
+crop_sequential=cli-uhdr-crop-replay-sequential.jpg
+crop_direct=cli-uhdr-crop-replay-direct.jpg
+crop_sequential_linear=cli-uhdr-crop-replay-sequential-linear.miff
+crop_direct_linear=cli-uhdr-crop-replay-direct-linear.miff
 capacity_min=1.00000012
 capacity_max=2.00000024
 expected_offsets='1.00000001e-07,1.00000001e-07,1.00000001e-07 1.00000001e-07,1.00000001e-07,1.00000001e-07'
@@ -41,7 +45,8 @@ cleanup()
   rm -f "$raw_source" "$source" "$output" "$transformed_output" \
     "$locale_output" "$jpeg_probe" "$whitespace_output" "$invalid_output"
   rm -f "$commented_source" "$comment_roundtrip" \
-    "$comment_linear"
+    "$comment_linear" "$crop_sequential" "$crop_direct" \
+    "$crop_sequential_linear" "$crop_direct_linear"
 }
 
 check_value()
@@ -81,7 +86,7 @@ if [ "X$jpeg_format" != "XJPEG" ]; then
   exit 0
 fi
 
-echo "1..13"
+echo "1..14"
 if ! ${MAGICK} \( "${SRCDIR}/rose.pnm" -depth 8 \) \
     \( "${SRCDIR}/rose.pnm" -depth 16 \) \
     -define uhdr:hdr-color-transfer=linear "UHDR:$raw_source" \
@@ -238,6 +243,30 @@ else
   roundtrip_status=$?
   echo "not ok - automatic UHDR roundtrip preserves comment and HDR decode"
   echo "# UHDR write failed (status $roundtrip_status)"
+fi
+
+if ${MAGICK} "UHDR:$source" -crop 40x30+6+4 +repage \
+    -crop 20x16+3+2 +repage -quality 85 "UHDR:$crop_sequential" \
+    >/dev/null 2>&1 &&
+   ${MAGICK} "UHDR:$source" -crop 20x16+9+6 +repage -quality 85 \
+    "UHDR:$crop_direct" >/dev/null 2>&1 &&
+   ${MAGICK} -define uhdr:output-color-transfer=linear \
+    "UHDR:$crop_sequential" "$crop_sequential_linear" >/dev/null 2>&1 &&
+   ${MAGICK} -define uhdr:output-color-transfer=linear \
+    "UHDR:$crop_direct" "$crop_direct_linear" >/dev/null 2>&1; then
+  crop_metric=`${MAGICK} compare -metric AE "$crop_sequential_linear" \
+    "$crop_direct_linear" null: 2>&1`
+  crop_status=$?
+  crop_value=`echo "$crop_metric" | awk '{print $1}'`
+  if [ "$crop_status" = "0" ] && [ "X$crop_value" = "X0" ]; then
+    echo "ok - repeated UHDR crops match direct crop"
+  else
+    echo "not ok - repeated UHDR crops match direct crop"
+    echo "# expected zero absolute error, got '$crop_metric'"
+  fi
+else
+  echo "not ok - repeated UHDR crops match direct crop"
+  echo "# unable to create or decode crop replay outputs"
 fi
 
 comma_locale=


### PR DESCRIPTION
Successive crops can produce incorrect HDR output even when the SDR image looks right. The gain map retains the canvas offset from the first crop, so a later crop can select the wrong part of the map. In a test with a full-resolution gain map, two crops produce the correct 20x16 base image but leave a 17x14 map instead of the expected 20x16 map.

Reset the gain-map canvas before applying each recorded crop. The recorded coordinates already refer to the current image's pixels, so an earlier canvas offset should not affect them.

The regression compares the decoded HDR result of two successive crops with an equivalent single crop. It checks the resulting pixels rather than only whether the output can be decoded.

All 14 focused UHDR assertions pass with libultrahdr 1.4.0 and 2.0.2 on macOS ARM64. The new crop comparison fails on the baseline and passes with this change. Additional local checks cover crop/rotation combinations and a gain map at half the base image's resolution.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.
