### PR TITLE
Keep grayscale Ultra HDR base images decodable

### DIFF
--- a/coders/uhdr.c
+++ b/coders/uhdr.c
@@ -1000,6 +1000,7 @@ static StringInfo *EncodeBaseImageProfile(const ImageInfo *image_info,
   (void) CopyMagickString(base_info->filename,"JPEG:uhdr-base.jpg",
     MagickPathExtent);
   (void) CopyMagickString(base_info->magick,"JPEG",MagickPathExtent);
+  base_info->type=TrueColorType;
   if (image->quality > 0)
     base_info->quality=image->quality;
   (void) CopyMagickString(base_image->magick,"JPEG",MagickPathExtent);

--- a/tests/cli-uhdr-encoder.tap
+++ b/tests/cli-uhdr-encoder.tap
@@ -9,11 +9,13 @@ encoder_hdr=cli-uhdr-encoder-hdr.miff
 pattern_output=cli-uhdr-encoder-pattern-%d.jpg
 pattern_first=cli-uhdr-encoder-pattern-0.jpg
 pattern_wrong=cli-uhdr-encoder-pattern-1.jpg
+gray_source=cli-uhdr-encoder-gray-source.jpg
+gray_roundtrip=cli-uhdr-encoder-gray-roundtrip.jpg
 
 cleanup()
 {
   rm -f "$encoder_error" "$encoder_sdr" "$encoder_hdr" \
-    "$pattern_first" "$pattern_wrong"
+    "$pattern_first" "$pattern_wrong" "$gray_source" "$gray_roundtrip"
 }
 
 cleanup
@@ -33,7 +35,7 @@ if ! ${MAGICK} -list configure 2>/dev/null | awk '
   exit 0
 fi
 
-echo "1..6"
+echo "1..7"
 if ! ${MAGICK} "${SRCDIR}/rose.pnm" -depth 8 "$encoder_sdr" \
     >/dev/null 2>&1 ||
    ! ${MAGICK} "${SRCDIR}/rose.pnm" -depth 16 "$encoder_hdr" \
@@ -94,6 +96,27 @@ else
   echo "not ok - patterned output preserves the second scene destination"
   pattern_wrong_size=`wc -c < "$pattern_wrong" 2>/dev/null`
   echo "# destination changed or is missing (size=$pattern_wrong_size)"
+fi
+
+if ! ${MAGICK} \( "${SRCDIR}/rose.pnm" -colorspace Gray -colorspace sRGB \
+    -type TrueColor -depth 8 \) \
+  \( "${SRCDIR}/rose.pnm" -colorspace Gray -colorspace sRGB \
+    -type TrueColor -depth 16 \) \
+  -define uhdr:hdr-color-transfer=linear "UHDR:$gray_source" \
+  >/dev/null 2>&1 || \
+   ! ${MAGICK} -define uhdr:output-color-transfer=linear \
+    "UHDR:$gray_source" null: >/dev/null 2>&1; then
+  echo "Bail out! unable to create or decode grayscale UHDR source"
+  cleanup
+  exit 0
+fi
+
+if ${MAGICK} "$gray_source" "$gray_roundtrip" >/dev/null 2>&1 && \
+   ${MAGICK} -define uhdr:output-color-transfer=linear \
+    "UHDR:$gray_roundtrip" null: >/dev/null 2>&1; then
+  echo "ok - grayscale UHDR roundtrip decodes as linear HDR"
+else
+  echo "not ok - grayscale UHDR roundtrip decodes as linear HDR"
 fi
 cleanup
 :


### PR DESCRIPTION
Re-saving an Ultra HDR JPEG whose base image contains only gray pixels can produce a file that libultrahdr cannot decode as HDR. ImageMagick's JPEG writer detects the gray pixels and saves the base as a one-component JPEG, but libultrahdr requires a three-component base for HDR reconstruction.

Set `TrueColorType` when encoding the Ultra HDR base so it retains three components. The image keeps its gray appearance, and ordinary grayscale JPEG output is unchanged.

The regression generates a small valid Ultra HDR image from an existing test image, copies it through automatic JPEG routing, and checks that the result decodes to linear HDR. It fails before the fix and passes afterward. The encoder, metadata, and resize-filter tests pass with libultrahdr 1.4.0 and 2.0.2 on macOS ARM64.

### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.
